### PR TITLE
Allow filtering by owner

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -24,6 +24,7 @@ class NotificationsController < ApplicationController
     scope = scope.reason(params[:reason]) if params[:reason].present?
     scope = scope.type(params[:type])     if params[:type].present?
     scope = scope.status(params[:status]) if params[:status].present?
+    scope = scope.owner(params[:owner])   if params[:owner].present?
 
     @notifications = scope.newest.page(page).per(per_page)
   end

--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -10,12 +10,13 @@ module NotificationsHelper
       repo:    params[:repo],
       type:    params[:type],
       archive: params[:archive],
-      starred: params[:starred]
+      starred: params[:starred],
+      owner: params[:owner]
     }
   end
 
   def any_active_filters?
-    [:status, :reason, :type, :repo].any?{|param| filters[param].present? }
+    [:status, :reason, :type, :repo, :owner].any?{|param| filters[param].present? }
   end
 
   def filtered_params(override = {})

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -11,6 +11,7 @@ class Notification < ApplicationRecord
   scope :type,     ->(subject_type) { where(subject_type: subject_type) }
   scope :reason,   ->(reason)       { where(reason: reason) }
   scope :status,   ->(status)       { where(unread: status) }
+  scope :owner,    ->(owner_name)   { where(repository_owner_name: owner_name) }
 
   paginates_per 20
 

--- a/app/views/notifications/_filter-list.html.erb
+++ b/app/views/notifications/_filter-list.html.erb
@@ -31,6 +31,12 @@
         <% end %>
       <% end %>
 
+      <% if filters[:owner].present? %>
+        <%= link_to root_path(filters.except(:owner)), class: 'btn btn-default' do %>
+          <%= octicon 'x', :height => 16 %>
+          <%= params[:owner] %>
+        <% end %>
+      <% end %>
     </span>
   </span>
 <% end %>


### PR DESCRIPTION
For: https://github.com/octobox/octobox/issues/144 cc @knolleary 

Enables the `owner` url parameter to filter in the same way as the others, this works because we store the owner in a separate field since #74, denormalization ftw!

![screen shot 2016-12-23 at 2 07 15 pm](https://cloud.githubusercontent.com/assets/1060/21455573/393ce9da-c919-11e6-98bc-bd6c26a4e7e1.png)
