### PR TITLE
Replace reference to unused variable GITHUB_TOKEN

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Once the PostgreSQL initialization process is complete, launch the application u
 GITHUB_CLIENT_ID=yourclientid GITHUB_CLIENT_SECRET=yourclientsecret docker-compose up app
 ```
 
-**Note**: You can add `GITHUB_TOKEN` to `.env` instead of supplying it directly on the command-line.
+**Note**: You can add `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET` to a `.env` file instead of supplying them directly on the command-line.
 
 ### Keyboard shortcuts
 


### PR DESCRIPTION
In the past, a Personal Access Token was supplied to Octobox via the `GITHUB_TOKEN` variable. However, since Octobox is now implemented as an OAuth Application, we use a pair of `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET` variables instead. The README still contains a reference to supplying `GITHUB_TOKEN` in a `.env` file, so let's fix it up to reference the real variables we use.

Signed-off-by: David Celis <me@davidcel.is>