### PR TITLE
Improve Docker development environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,16 @@
-FROM ruby:2.3-onbuild
-
+FROM ruby:2.3
 RUN \
     apt-get update \
-    && apt-get install -y --no-install-recommends nodejs \
+    && apt-get install -y --no-install-recommends netcat nodejs \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+# throw errors if Gemfile has been modified since Gemfile.lock
+RUN bundle config --global frozen 1
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+COPY Gemfile /usr/src/app/
+COPY Gemfile.lock /usr/src/app/
+RUN bundle install
+
+COPY . /usr/src/app

--- a/README.md
+++ b/README.md
@@ -108,21 +108,19 @@ Finally you can boot the rails app:
 ```bash
 rails s
 ```
-#### Docker Compose
+#### Docker
 
-If you're familiar with [Docker](https://docs.docker.com/engine/) and [Docker Compose](https://docs.docker.com/compose/), the included `docker-compose.yml` configuration allows you to spin up the application locally.
+You can use Docker to run Octobox in development.
 
-First, launch an instance of PostgreSQL and wait for it to fully initialize:
+First, [install Docker](https://docs.docker.com/engine/installation/). If you've got run macOS or Windows, Docker for Mac/Windows makes this really easy.
 
-```bash
-docker-compose up database
-```
-
-Once the PostgreSQL initialization process is complete, launch the application using another terminal session:
+Then, run:
 
 ```bash
-GITHUB_CLIENT_ID=yourclientid GITHUB_CLIENT_SECRET=yourclientsecret docker-compose up app
+GITHUB_CLIENT_ID=yourclientid GITHUB_CLIENT_SECRET=yourclientsecret docker-compose up --build
 ```
+
+Octobox will be running on [http://localhost:3000](http://localhost:3000).
 
 **Note**: You can add `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET` to a `.env` file instead of supplying them directly on the command-line.
 

--- a/bin/docker-start
+++ b/bin/docker-start
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+
+while ! nc -z database.service.octobox.internal 5432; do
+  echo "Waiting for database to be available..."
+  sleep 1
+done
+
+bundle exec rake db:migrate
+rm -rf tmp/pids
+
+exec rails s -b 0.0.0.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - POSTGRES_PASSWORD=development
 
   app:
-    image: github-inbox
+    image: octobox
     build:
       context: ./
       dockerfile: Dockerfile
@@ -23,4 +23,4 @@ services:
       - OCTOBOX_DATABASE_USER=postgres
       - OCTOBOX_DATABASE_PASSWORD=development
       - OCTOBOX_DATABASE_HOST=database.service.octobox.internal
-    command: sh -c 'bundle exec rake db:migrate && rm -rf tmp/pids && rails s -b 0.0.0.0'
+    command: bin/docker-start


### PR DESCRIPTION
A follow-up from #35.

- Wait for database to start on boot so only a single command is needed.
- Tidied up readme.
- Explicitly specify build steps instead of using onbuild so the apt package cache isn't busted by new code.
- Rename built image to be "octobox"

This is ridiculously simpler than installing manually. Perhaps it makes sense to be the recommended way to get started, with the manual steps as the alternative if you don't want to use Docker? 😄 