### PR TITLE
Add user id to notifications unique index

### DIFF
--- a/db/migrate/20161227173809_drop_unique_index_on_github_id.rb
+++ b/db/migrate/20161227173809_drop_unique_index_on_github_id.rb
@@ -1,0 +1,6 @@
+class DropUniqueIndexOnGithubId < ActiveRecord::Migration[5.0]
+  def change
+    remove_index :notifications, :github_id
+    add_index :notifications, [:user_id, :github_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161220150731) do
+ActiveRecord::Schema.define(version: 20161227173809) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -32,8 +32,8 @@ ActiveRecord::Schema.define(version: 20161220150731) do
     t.datetime "created_at",                            null: false
     t.boolean  "starred",               default: false
     t.string   "repository_owner_name", default: ""
-    t.index ["github_id"], name: "index_notifications_on_github_id", unique: true, using: :btree
     t.index ["user_id", "archived", "updated_at"], name: "index_notifications_on_user_id_and_archived_and_updated_at", using: :btree
+    t.index ["user_id", "github_id"], name: "index_notifications_on_user_id_and_github_id", unique: true, using: :btree
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
Turns out that the `id` in the [notifications api](https://developer.github.com/v3/activity/notifications/) is not unique for users, so multiple users actually get the same notification record for a single pull request sent to all the users watching the repo.

We assumed it was unique and so added a unique database index to make sure we don't get any duplicates but this turns out to cause problems!

Anyone running their own instance wouldn't run into this but the hosted version has multiple people signed up and watching the same repos, so who ever gets the notification first will block everyone else from seeing it.

This pr changes the index to be unique by user id and notification id 😅