### PR TITLE
Use label for select_all button

### DIFF
--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -29,9 +29,9 @@
           <button type="button" class="hidden-md hidden-lg btn btn-default" data-toggle="offcanvas">
             <%= octicon 'three-bars', :height => 16 %>
           </button>
-          <div class="btn btn-default select-all">
-            <input type="checkbox" class='js-select_all'>
-          </div>
+          <label class="btn btn-default select-all" for="select_all">
+            <input id="select_all" type="checkbox" class='js-select_all'>
+        </label>
           <%= link_to sync_notifications_path, class: 'btn btn-default sync', 'data-toggle' => 'tooltip', 'data-placement' => 'bottom', 'data-turbolinks' => false, 'data-animation' => 'false', 'data-position' => 'bottom', 'title' => 'Refresh list', method: :post do %>
             <%= octicon 'sync', :height => 16 %>
           <% end %>


### PR DESCRIPTION
This replaces the select_all button `div` with a `label` that has its `for` attribute set. This allows us to make the whole button clickable, rather than just the select box inside it.