### PR TITLE
Bugfix Select All Button Slightly Too Large on Mobile

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -430,6 +430,18 @@ td.keys {
   padding: 6px 10px;
 }
 
+.select-all input {
+  margin-top: 0;
+  position: relative;
+  top: -1px;
+}
+
+@media (max-width: $screen-xs-max) {
+  .select-all input {
+    top: 2px;
+  }
+}
+
 @keyframes spin {
   to { transform: rotate(1turn); }
 }


### PR DESCRIPTION
The select all button on mobile was slightly too big due to a top margin
on the input element which caused the element to extend in height
slightly.

Positioning has also been added to fix some vertical alignment of the
input element within the label element as the alignment was slightly off
on both larger and smaller screen sizes.

Desktop Screenshot:
![desktop](https://cloud.githubusercontent.com/assets/1390569/21541394/f6c91010-ce09-11e6-82b7-deadb290bdcb.jpg)

Mobile Screenshot:
![mobile](https://cloud.githubusercontent.com/assets/1390569/21541397/fb5ebe40-ce09-11e6-91d1-63229a0b3abf.jpg)

Fixes issue #183