### PR TITLE
Allow users to self-delete

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -14,6 +14,14 @@ class UsersController < ApplicationController
     end
   end
 
+  def destroy
+    user = User.find(current_user.id)
+    github_login = user.github_login
+    user.destroy
+    flash[:success] = "User deleted: #{github_login}"
+    redirect_to root_path
+  end
+
   private
 
   def ensure_correct_user

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -33,14 +33,12 @@
                 Octobox Support
               <% end %>
             </li>
-            <% if Octobox.personal_access_tokens_enabled? %>
-              <li>
-                <%= link_to "settings" do %>
-                  <%= octicon 'settings', height: 16, class: 'text-muted' %>
-                  Settings
-                <% end %>
-              </li>
-            <% end %>
+            <li>
+              <%= link_to "settings" do %>
+                <%= octicon 'settings', height: 16, class: 'text-muted' %>
+                Settings
+              <% end %>
+            </li>
             <li role="separator" class="divider"></li>
             <li>
               <%= link_to logout_path do %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -22,11 +22,11 @@
       </div>
       <%= submit_tag 'Save', class: 'btn btn-primary' %>
       <%= link_to 'Cancel', root_path, class: 'btn btn-default' %>
-    <% else %>
-      <div>
-        There are no currently configurable user options. Check back later.
-      </div>
     <% end %>
-
   <% end %>
+  <hr>
+  <div class="form-group" >
+    <%= link_to 'Delete my Octobox account', current_user, method: :delete, class: 'btn btn-danger', data: {confirm: 'Are you sure you want to do this?'}%>
+  </div>
+
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,5 +22,5 @@ Rails.application.routes.draw do
   end
 
   get '/settings', to: 'users#edit'
-  resources :users, only: [:update]
+  resources :users, only: [:update, :destroy]
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -70,4 +70,25 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_nil users(:andrew).personal_access_token
   end
 
+  test 'deletes a user' do
+    sign_in_as(users(:andrew))
+    delete user_url(users(:andrew))
+    assert_redirected_to root_path
+    assert_equal "User deleted: #{users(:andrew).github_login}", flash[:success]
+    refute User.exists?(users(:andrew).id)
+  end
+
+  test 'cannot delete another user' do
+    sign_in_as(users(:tokenuser))
+    delete user_url(users(:andrew))
+    assert_response :unauthorized
+    assert User.exists?(users(:andrew).id)
+    assert User.exists?(users(:tokenuser).id)
+  end
+
+  test 'cannot delete user without logging in' do
+    delete user_url(users(:andrew))
+    assert_redirected_to root_path
+    assert User.exists?(users(:andrew).id)
+  end
 end

--- a/test/support/omniauth.rb
+++ b/test/support/omniauth.rb
@@ -12,6 +12,7 @@ OmniAuth.config.mock_auth[:github] = OmniAuth::AuthHash.new(
 module SignInHelper
   def sign_in_as(user)
     OmniAuth.config.mock_auth[:github].uid = user.github_id
+    OmniAuth.config.mock_auth[:github].info = { 'nickname' => user.github_login }
     OmniAuth.config.mock_auth[:github].credentials.token = user.access_token
     post '/auth/github/callback'
   end


### PR DESCRIPTION
closes #175 

This adds a button to /settings that will delete a user's account.

![2016-12-30 at 1 57 pm](https://cloud.githubusercontent.com/assets/233500/21571782/32913c2e-ce98-11e6-88ac-2d27aac54187.png)
