### PR TITLE
Add ? to keyboard help menu

### DIFF
--- a/app/views/notifications/_help-box.html.erb
+++ b/app/views/notifications/_help-box.html.erb
@@ -72,6 +72,14 @@
                 Open current notification in a new window
               </td>
             </tr>
+            <tr>
+              <td class="keys">
+                <div class="key">?</div>
+              </td>
+              <td>
+                Show this help menu
+              </td>
+            </tr>
           </tbody>
         </table>
       </div>


### PR DESCRIPTION
As the title says, this adds `?` to the keys on the keyboard shortcuts list.