### PR TITLE
Implement refresh on refresh

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -5,6 +5,8 @@ class NotificationsController < ApplicationController
   before_action :find_notification, only: [:archive, :unarchive, :star]
 
   def index
+    current_user.sync_notifications if current_user.sync_on_load
+
     scope    = current_user.notifications
 
     scope = if params[:starred].present?
@@ -40,7 +42,8 @@ class NotificationsController < ApplicationController
   end
 
   def sync
-    current_user.sync_notifications
+    # When a user has sync_on_load enabled, doing a sync here would cause a double sync when index is reloaded
+    current_user.sync_notifications unless current_user.sync_on_load
     redirect_back fallback_location: root_path
   end
 

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -5,7 +5,7 @@ class NotificationsController < ApplicationController
   before_action :find_notification, only: [:archive, :unarchive, :star]
 
   def index
-    current_user.sync_notifications if current_user.sync_on_load
+    current_user.sync_notifications(quick_sync: true) if current_user.sync_on_load
 
     scope    = current_user.notifications
 
@@ -42,8 +42,9 @@ class NotificationsController < ApplicationController
   end
 
   def sync
+    quick_sync = params[:quick]
     # When a user has sync_on_load enabled, doing a sync here would cause a double sync when index is reloaded
-    current_user.sync_notifications unless current_user.sync_on_load
+    current_user.sync_notifications(quick_sync: quick_sync) unless current_user.sync_on_load
     redirect_back fallback_location: root_path
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -41,6 +41,6 @@ class UsersController < ApplicationController
       params[:user][:personal_access_token] = nil
     end
 
-    params.require(:user).permit(:personal_access_token)
+    params.require(:user).permit(:personal_access_token, :sync_on_load)
   end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -16,10 +16,10 @@ class Notification < ApplicationRecord
   paginates_per 20
 
   class << self
-    def download(user)
+    def download(user, options = {})
       timestamp = Time.current
 
-      fetch_notifications(user) do |notification|
+      fetch_notifications(user, options) do |notification|
         begin
           n = user.notifications.find_or_initialize_by(github_id: notification.id)
 
@@ -58,15 +58,19 @@ class Notification < ApplicationRecord
 
     private
 
-    def fetch_notifications(user)
-      user.github_client.notifications(fetch_params(user)).each { |n| yield n }
+    def fetch_notifications(user, options = {})
+      params = fetch_params(user, options)
+      user.github_client.notifications(params).each { |n| yield n }
     end
 
-    def fetch_params(user)
-      if user.last_synced_at?
-        { all: true, since: 1.week.ago.iso8601 }
-      else
-        { all: true, since: 1.month.ago.iso8601 }
+    def fetch_params(user, quick_sync: false)
+      case
+        when !user.last_synced_at
+          {all: true, since: 1.month.ago.iso8601}
+        when quick_sync
+          {all: true, since: user.last_synced_at.iso8601}
+        else
+          {all: true, since: 1.week.ago.iso8601}
       end
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,8 +27,8 @@ class User < ApplicationRecord
     update_attributes(github_attributes)
   end
 
-  def sync_notifications
-    Notification.download(self)
+  def sync_notifications(options = {})
+    Notification.download(self, options)
   end
 
   def github_client

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,8 +1,12 @@
 <div class="container">
   <h1>Settings</h1>
-  <% if Octobox.personal_access_tokens_enabled? %>
-    <hr>
-    <%= form_for current_user do |f| %>
+  <hr>
+  <%= form_for current_user do |f| %>
+    <div class="form-group">
+      <%= f.label :sync_on_load, "Sync notifications with every page load" %>
+      <%= f.check_box :sync_on_load, class: 'form-control' %>
+    </div>
+    <% if Octobox.personal_access_tokens_enabled? %>
       <div class="form-group">
         <%= f.label :personal_access_token, "Personal Access Token" %>
         <%= f.text_field :personal_access_token, value: nil, placeholder: current_user.masked_personal_access_token, class: 'form-control' %>
@@ -17,10 +21,9 @@
           </label>
         </div>
       </div>
-
-      <%= submit_tag 'Save', class: 'btn btn-primary' %>
-      <%= link_to 'Cancel', root_path, class: 'btn btn-default' %>
     <% end %>
+    <%= submit_tag 'Save', class: 'btn btn-primary' %>
+    <%= link_to 'Cancel', root_path, class: 'btn btn-default' %>
   <% end %>
 
   <hr>

--- a/db/migrate/20170102174718_add_sync_on_load_to_users.rb
+++ b/db/migrate/20170102174718_add_sync_on_load_to_users.rb
@@ -1,0 +1,5 @@
+class AddSyncOnLoadToUsers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :sync_on_load, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161228162823) do
+ActiveRecord::Schema.define(version: 20170102174718) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -37,13 +37,14 @@ ActiveRecord::Schema.define(version: 20161228162823) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.integer  "github_id",             null: false
-    t.string   "access_token",          null: false
-    t.string   "github_login",          null: false
-    t.datetime "created_at",            null: false
-    t.datetime "updated_at",            null: false
+    t.integer  "github_id",                             null: false
+    t.string   "access_token",                          null: false
+    t.string   "github_login",                          null: false
+    t.datetime "created_at",                            null: false
+    t.datetime "updated_at",                            null: false
     t.datetime "last_synced_at"
     t.string   "personal_access_token"
+    t.boolean  "sync_on_load",          default: false, null: false
     t.index ["access_token"], name: "index_users_on_access_token", unique: true, using: :btree
     t.index ["github_id"], name: "index_users_on_github_id", unique: true, using: :btree
   end

--- a/test/controllers/notifications_controller_test.rb
+++ b/test/controllers/notifications_controller_test.rb
@@ -90,7 +90,7 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
     @user.sync_on_load = true
     @user.save
     sign_in_as(@user)
-    User.any_instance.expects(:sync_notifications).once
+    User.any_instance.expects(:sync_notifications).with({quick_sync: true}).once
     get '/'
     assert_response :success
     assert_template 'notifications/index'

--- a/test/controllers/notifications_controller_test.rb
+++ b/test/controllers/notifications_controller_test.rb
@@ -85,4 +85,24 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
     post "/notifications/sync"
     assert_response :redirect
   end
+
+  test 'syncs when loading the index if sync_on_load is enabled' do
+    @user.sync_on_load = true
+    @user.save
+    sign_in_as(@user)
+    User.any_instance.expects(:sync_notifications).once
+    get '/'
+    assert_response :success
+    assert_template 'notifications/index'
+  end
+
+  test 'does not sync when loading the index if sync_on_load is disabled' do
+    @user.sync_on_load = false
+    @user.save
+    sign_in_as(@user)
+    User.any_instance.expects(:sync_notifications).never
+    get '/'
+    assert_response :success
+    assert_template 'notifications/index'
+  end
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -91,4 +91,15 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to root_path
     assert User.exists?(users(:andrew).id)
   end
+
+  test 'updates sync_on_load' do
+    refute @user.sync_on_load
+    sign_in_as(@user)
+    patch user_url(@user), params: {user: { sync_on_load: 'true'}}
+    @user.reload
+    assert @user.sync_on_load
+    patch user_url(@user), params: {user: { sync_on_load: 'false'}}
+    @user.reload
+    refute @user.sync_on_load
+  end
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -95,10 +95,10 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   test 'updates sync_on_load' do
     refute @user.sync_on_load
     sign_in_as(@user)
-    patch user_url(@user), params: {user: { sync_on_load: 'true'}}
+    patch user_url(@user), params: {user: { sync_on_load: '1'}}
     @user.reload
     assert @user.sync_on_load
-    patch user_url(@user), params: {user: { sync_on_load: 'false'}}
+    patch user_url(@user), params: {user: { sync_on_load: '0'}}
     @user.reload
     refute @user.sync_on_load
   end

--- a/test/models/notification_test.rb
+++ b/test/models/notification_test.rb
@@ -26,6 +26,17 @@ class NotificationTest < ActiveSupport::TestCase
     end
   end
 
+  test '#download fetches notifications since last sync when quick_sync is set' do
+    travel_to "2016-12-19T20:00:00Z" do
+      user = users(:andrew)
+      user.last_synced_at = "2016-12-19T19:00:00Z"
+
+      Notification.download(user, quick_sync: true)
+
+      assert_requested :get, "https://api.github.com/notifications?all=true&per_page=100&since=2016-12-19T19:00:00Z"
+    end
+  end
+
   test "#download will set the url for a Repository invitation correctly" do
     stub_notifications_request(body: file_fixture('repository_invitation_notification.json'))
     user = users(:andrew)

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -121,4 +121,15 @@ class UserTest < ActiveSupport::TestCase
     user.personal_access_token = 'abcdefghijklmnopqrstuvwxyz'
     assert_equal user.masked_personal_access_token, '********************************stuvwxyz'
   end
+
+  test 'sync_on_load attribute' do
+    user = users(:andrew)
+    refute user.sync_on_load
+    user.sync_on_load = true
+    user.save
+    assert user.valid?
+    assert user.sync_on_load
+  end
+
+
 end


### PR DESCRIPTION
This gives the user an option to sync notifications every time the notifications page loads.

![2017-01-02 at 1 41 pm](https://cloud.githubusercontent.com/assets/233500/21595236/4eabef16-d0f1-11e6-86e7-2d4f24c1602f.png)

closes #205