### PR TITLE
Click a row to move the cursor

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -199,3 +199,11 @@ function recoverPreviousCursorPosition() {
 function loadTurbolinksArchiveURL(link, route) {
   Turbolinks.visit('/notifications/'+$(link).val()+'/'+route+location.search)
 }
+
+// Clicking a row marks it current
+$(document).ready(function() {
+  $("tr.notification").click(function() {
+    $(".current.js-current").removeClass("current js-current");
+    $( this ).find("td").first().addClass("current js-current");
+  })
+});


### PR DESCRIPTION
I like the keyboard navigation, but I don't like having to start out by hitting `j` repeatedly to get to the first notification I want to mark.

This will let me click a row to set the cursor there.