### PR TITLE
Fix scrollbars showing all the time

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -42,13 +42,13 @@ html {
 }
 .flex-sidebar {
   flex: 0 0 250px;
-  overflow: scroll;
+  overflow: auto;
   padding-bottom: 60px;
 }
 .flex-main {
   flex: 1;
   min-width: 0;
-  overflow: scroll;
+  overflow: auto;
 }
 .flex-container {
   padding: 15px;


### PR DESCRIPTION
With this commit, scrollbars will no longer show even if there is no content overflow. The scrollbar will now show when necessary.