### PR TITLE
Add ability to mute notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ You can use keyboard shortcuts to navigate and perform certain actions:
  - `s` - star current notification
  - `x` - mark/unmark current notification
  - `y` - archive current/marked notification(s)
+ - `m` - mute current/marked notification(s)
  - `o` or `Enter` - open current notification in a new window
 
 Press `?` for the help menu.

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -7,6 +7,7 @@
 
 document.addEventListener("turbolinks:load", function() {
   $('button.archive_selected, button.unarchive_selected').click(function () { toggleArchive(); });
+  $('button.mute_selected').click(function () { mute(); });
   $('input.archive, input.unarchive').change(function() {
     var marked = $(".js-table-notifications input:checked");
     if ( marked.length > 0 ) {
@@ -15,10 +16,10 @@ document.addEventListener("turbolinks:load", function() {
       } else {
         $(".js-select_all").prop("indeterminate", true);
       }
-      $('button.archive_selected, button.unarchive_selected').removeClass('hidden');
+      $('button.archive_selected, button.unarchive_selected, button.mute_selected').removeClass('hidden');
     } else {
       $(".js-select_all").prop('checked', false)
-      $('button.archive_selected, button.unarchive_selected').addClass('hidden');
+      $('button.archive_selected, button.unarchive_selected, button.mute_selected').addClass('hidden');
     }
   });
   $('.toggle-star').click(function() {
@@ -73,6 +74,7 @@ var shortcuts = {
   83:  toggleStar,      // s
   88:  markCurrent,     // x
   89:  toggleArchive,   // y
+  77:  mute,            // m
   13:  openCurrentLink, // Enter
   79:  openCurrentLink, // o
   191: openModal,       // ?
@@ -103,6 +105,28 @@ function checkAll(checked) {
 function checkSelectAll() {
   var allSelected = $(".js-select_all").prop('checked')
   $(".js-select_all").prop('checked', !allSelected).trigger('change')
+}
+
+function mute() {
+  if ( $(".js-table-notifications tr").length === 0 ) return;
+  marked = $(".js-table-notifications input:checked");
+  if ( marked.length > 0 ) {
+    ids = marked.map(function() { return this.value; }).get();
+  } else {
+    ids = [ $('td.js-current input').val() ];
+  }
+  $.post( "/notifications/mute_selected", { 'id[]': ids}).done(function() {
+    // calculating new position of the cursor
+    current = $('td.js-current').parent();
+    while ( $.inArray(current.find('input').val(), ids) > -1 && current.next().length > 0) {
+      current = current.next();
+    }
+    window.current_id = current.find('input').val();
+    if ( $.inArray(window.current_id, ids ) > -1 ) {
+      window.current_id = $(".js-table-notifications input:not(:checked)").last().val();
+    }
+    Turbolinks.visit("/"+location.search);
+  });
 }
 
 function toggleArchive() {

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -31,6 +31,15 @@ class NotificationsController < ApplicationController
     @notifications = scope.newest.page(page).per(per_page)
   end
 
+  def mute_selected
+    notifications = current_user.notifications.where(id: params[:id])
+    notifications.each do |notification|
+      notification.mute
+      notification.update archived: true
+    end
+    head :ok
+  end
+
   def archive_selected
     current_user.notifications.where(id: params[:id]).update_all archived: params[:value]
     head :ok

--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -49,6 +49,14 @@ module NotificationsHelper
     filters.merge(override)
   end
 
+  def mute_selected_button(custom_class=nil)
+    unless params[:archive]
+      button_tag(type: 'button', class: "mute_selected #{custom_class}") do
+        'Mute Selected'
+      end
+    end
+  end
+
   def archive_selected_button(custom_class=nil)
     action = params[:archive] ? 'unarchive' : 'archive'
     button_tag(type: "button",

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -82,6 +82,19 @@ class Notification < ApplicationRecord
     end
   end
 
+  def mark_as_read
+    user.github_client.mark_thread_as_read(github_id, read: true)
+  end
+
+  def ignore_thread
+    user.github_client.update_thread_subscription(github_id, ignored: true)
+  end
+
+  def mute
+    mark_as_read
+    ignore_thread
+  end
+
   def web_url
     subject_url.gsub("#{Octobox.github_api_prefix}/repos", Octobox.github_domain)
                .gsub('/pulls/', '/pull/')

--- a/app/views/notifications/_help-box.html.erb
+++ b/app/views/notifications/_help-box.html.erb
@@ -65,6 +65,15 @@
               </td>
             </tr>
             <tr>
+            <tr>
+              <td class="keys">
+                <div class="key">m</div>
+              </td>
+              <td>
+                Mute current/marked notification(s)
+              </td>
+            </tr>
+            <tr>
               <td class="keys">
                 <div class="key">o</div> or <div class="key">Enter</div>
               </td>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -36,6 +36,7 @@
             <%= octicon 'sync', :height => 16 %>
           <% end %>
           <%= archive_selected_button("btn btn-default hidden") %>
+          <%= mute_selected_button("btn btn-default hidden") %>
           <%= render 'filter-list' %>
         </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
     collection do
       post :archive_selected
       post :sync
+      post :mute_selected
     end
 
     member do

--- a/test/models/notification_test.rb
+++ b/test/models/notification_test.rb
@@ -36,4 +36,32 @@ class NotificationTest < ActiveSupport::TestCase
     assert_equal 'RepositoryInvitation', notification.subject_type
     assert_match %r{https://github.com/.+/invitations$}, notification.subject_url
   end
+
+  test 'ignore_thread sends ignore request to github' do
+    user = users(:andrew)
+    notification = create(:notification, user: user, archived: false)
+    user.stubs(:github_client).returns(mock {
+      expects(:update_thread_subscription).with(notification.github_id, ignored: true).returns true
+    })
+    assert notification.ignore_thread
+  end
+
+  test 'mark_as_read updates the github thread' do
+    user = users(:andrew)
+    notification = create(:notification, user: user, archived: false)
+    user.stubs(:github_client).returns(mock {
+      expects(:mark_thread_as_read).with(notification.github_id, read: true).returns true
+    })
+    assert notification.mark_as_read
+  end
+
+  test 'mute ignores the thread and marks it as read' do
+    user = users(:andrew)
+    notification = create(:notification, user: user, archived: false)
+    user.stubs(:github_client).returns(mock {
+      expects(:update_thread_subscription).with(notification.github_id, ignored: true).returns true
+      expects(:mark_thread_as_read).with(notification.github_id, read: true).returns true
+    })
+    assert notification.mute
+  end
 end


### PR DESCRIPTION
closes #7 

This adds an action next to archive that will send api requests marking the thread as read and ignored.  It also archives the marked notifications.