### PR TITLE
Adds a mobile search button

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -58,7 +58,7 @@ html {
   }
 }
 
-@media (max-width: $screen-xs-max) {
+@media (max-width: $screen-sm-max) {
   .flex-container {
     .flex-main & {
       padding-left: 15px;
@@ -107,7 +107,11 @@ html {
   padding: 0;
   margin-top: 12px;
 }
-
+.navbar-search-toggle {
+  margin-top: 9px;
+  padding: 6px 10px 7px;
+  margin-right: 8px;
+}
 .navbar-avatar {
   margin-bottom: -3px;
   position: relative;
@@ -121,7 +125,11 @@ html {
     width: 16px;
   }
 }
-
+@media (min-width: $screen-sm-min) {
+  #search {
+    float: left;
+  }
+}
 @media (max-width: $screen-xs-max) {
   .navbar-nav .dropdown .dropdown-menu {
     display: block;
@@ -149,6 +157,12 @@ html {
     .divider {
       background-color: #e5e5e5;
     }
+  }
+  .navbar-form {
+    border-top: none;
+    border-bottom: none;
+    padding-top: 0;
+    padding-bottom: 0;
   }
 }
 

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -7,14 +7,17 @@
           <span class="sr-only">Toggle navigation</span>
           <%= image_tag current_user.github_avatar_url + "?size=64", width: 32, class: 'img-rounded navbar-avatar' %>
         </button>
+        <button type="button" class="navbar-toggle navbar-search-toggle collapsed" data-toggle="collapse" data-target="#search" aria-expanded="false">
+          <span class="sr-only">Toggle search</span>
+          <%= octicon 'search', height: 16, class: 'text-muted' %>
+        </button>
       <% end %>
       <a class="navbar-brand" href="/">
         <%= octobox_icon(28) %>
-        Octobox
+        <span class="hidden-xs">Octobox</span>
       </a>
     </div>
-
-    <div class="collapse navbar-collapse js-octobox-menu" id="octobox-menu">
+    <div class="collapse navbar-collapse" id="search">
       <%= form_tag root_path, method: :get, class: 'navbar-form navbar-left', enforce_utf8: false do |f| %>
         <div class="form-group">
           <% filters.except(:q).select{|n,v| v.present? }.each do |name, value| %>
@@ -23,6 +26,8 @@
           <%= text_field_tag 'q', params[:q], placeholder: 'Search...', class: 'form-control', size: 40, id: 'search-box' %>
         </div>
       <% end %>
+    </div>
+    <div class="collapse navbar-collapse js-octobox-menu" id="octobox-menu">
       <ul class="nav navbar-nav navbar-right">
         <% if current_user %>
           <li class="dropdown">


### PR DESCRIPTION
Makes search a bit easier to get to by adding a search-specific button to the mobile navbar

<img width="1105" alt="octobox" src="https://cloud.githubusercontent.com/assets/29120/21691069/ab8ae0c8-d33c-11e6-9c06-338f236ce951.png">

<img width="395" alt="octobox" src="https://cloud.githubusercontent.com/assets/29120/21691111/dabc4710-d33c-11e6-8e29-a00dd056007c.png">

<img width="397" alt="octobox" src="https://cloud.githubusercontent.com/assets/29120/21691120/e40adcf0-d33c-11e6-9321-4e134aba2204.png">
