### PR TITLE
Hide Save and cancel button in settings when not available

### DIFF
--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,38 +1,42 @@
 <div class="container">
   <h1>Settings</h1>
-  <hr>
-  <%= form_for current_user do |f| %>
-    <% if Octobox.refresh_interval_enabled? %>
-      <div class="form-group">
-        <%= f.label :refresh_interval_minutes, 'Notification Refresh Interval' %>
-        <%= f.number_field :refresh_interval_minutes, max: 1440, min: Octobox.minimum_refresh_interval, value: current_user.effective_refresh_interval / 60_000, class: 'form-control' %>
-        <p>
-          <em>
-            Auto refresh every N minutes when you are viewing notifications. If set to 0, no auto refreshes will occur.
-          </em>
-        </p>
-      </div>
-    <% end %>
+  <% if Octobox.refresh_interval_enabled? || Octobox.personal_access_tokens_enabled? %>
+    <hr>
 
-    <% if Octobox.personal_access_tokens_enabled? %>
-      <div class="form-group">
-        <%= f.label :personal_access_token, "Personal Access Token" %>
-        <%= f.text_field :personal_access_token, value: nil, placeholder: current_user.masked_personal_access_token, class: 'form-control' %>
-        <span class="help-block">Setting a personal access token will cause Octobox to authenticate with this token instead of the OAuth token that was generated when you logged in.  There is no need to set this unless you have a specific reason.
-        </span>
-      </div>
-      <div class="form-group">
-        <div class="checkbox">
-          <label>
-            <input type="checkbox" name="clear_personal_access_token" id="clear_personal_access_token"/>
-            Clear personal access token
-          </label>
+    <%= form_for current_user do |f| %>
+      <% if Octobox.refresh_interval_enabled? %>
+        <div class="form-group">
+          <%= f.label :refresh_interval_minutes, 'Notification Refresh Interval' %>
+          <%= f.number_field :refresh_interval_minutes, max: 1440, min: Octobox.minimum_refresh_interval, value: current_user.effective_refresh_interval / 60_000, class: 'form-control' %>
+          <p>
+            <em>
+              Auto refresh every N minutes when you are viewing notifications. If set to 0, no auto refreshes will occur.
+            </em>
+          </p>
         </div>
-      </div>
+      <% end %>
 
+      <% if Octobox.personal_access_tokens_enabled? %>
+        <div class="form-group">
+          <%= f.label :personal_access_token, "Personal Access Token" %>
+          <%= f.text_field :personal_access_token, value: nil, placeholder: current_user.masked_personal_access_token, class: 'form-control' %>
+          <span class="help-block">Setting a personal access token will cause Octobox to authenticate with this token instead of the OAuth token that was generated when you logged in.  There is no need to set this unless you have a specific reason.
+          </span>
+        </div>
+        <div class="form-group">
+          <div class="checkbox">
+            <label>
+              <input type="checkbox" name="clear_personal_access_token" id="clear_personal_access_token"/>
+              Clear personal access token
+            </label>
+          </div>
+        </div>
+
+      <% end %>
+
+      <%= submit_tag 'Save', class: 'btn btn-primary' %>
+      <%= link_to 'Cancel', root_path, class: 'btn btn-default' %>
     <% end %>
-    <%= submit_tag 'Save', class: 'btn btn-primary' %>
-    <%= link_to 'Cancel', root_path, class: 'btn btn-default' %>
   <% end %>
 
   <hr>


### PR DESCRIPTION
Closes #223 

This hides the save and cancel button for the users form when it's not needed.

## Example screenshots

![screen shot 2017-01-05 at 23 31 53](https://cloud.githubusercontent.com/assets/564113/21707705/86f9bc9e-d39f-11e6-8cd5-19b087f976ea.png)
![screen shot 2017-01-05 at 23 32 06](https://cloud.githubusercontent.com/assets/564113/21707706/86faec36-d39f-11e6-8888-480005261380.png)
![screen shot 2017-01-05 at 23 32 16](https://cloud.githubusercontent.com/assets/564113/21707707/86fe9f0c-d39f-11e6-8ada-c76ebf7cafa0.png)

/cc @WillAbides @johnthepink