### PR TITLE
Cache notification partial fragements

### DIFF
--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -42,7 +42,7 @@
 
         <% if @notifications.any? %>
           <table class='table table-hover table-notifications js-table-notifications' data-refresh-interval=<%= current_user.effective_refresh_interval %>>
-            <%= render partial: 'notification', collection: @notifications %>
+            <%= render partial: 'notification', collection: @notifications, cached: true %>
           </table>
         <% elsif no_url_filter_parameters_present %>
           <div class="blankslate blankslate-spacious blankslate-clean-background">


### PR DESCRIPTION
I was looking at [Rails fragment caching](http://guides.rubyonrails.org/caching_with_rails.html#fragment-caching) and thought it might be nice to cache the views for Notifications since they don't change that often.

I noticed a bit of a speed up on my machine, but if it's an over optimization or has unintended side effects I'm 🆒 with this not being merged.