### PR TITLE
Make separate requests for read and unread notifications

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -26,58 +26,79 @@ class Notification < ApplicationRecord
 
   paginates_per 20
 
+  API_ATTRIBUTE_MAP = {
+    repository_id: [:repository, :id],
+    repository_full_name: [:repository, :full_name],
+    repository_owner_name: [:repository, :owner, :login],
+    subject_title: [:subject, :title],
+    subject_type: [:subject, :type],
+    subject_url: [:subject, :url],
+    reason: [:reason],
+    unread: [:unread],
+    updated_at: [:updated_at],
+    last_read_at: [:last_read_at],
+    url: [:url],
+    github_id: [:id]
+  }.freeze
+
   class << self
     def download(user)
       timestamp = Time.current
 
-      fetch_notifications(user) do |notification|
-        begin
-          n = user.notifications.find_or_initialize_by(github_id: notification.id)
-
-          if n.archived && n.updated_at < notification.updated_at
-            n.archived = false
-          end
-
-          attrs = {}.tap do |attr|
-            attr[:repository_id]         = notification.repository.id
-            attr[:repository_full_name]  = notification.repository.full_name
-            attr[:repository_owner_name] = notification.repository.owner.login
-            attr[:subject_title]         = notification.subject.title
-            attr[:subject_type]          = notification.subject.type
-            attr[:reason]                = notification.reason
-            attr[:unread]                = notification.unread
-            attr[:updated_at]            = notification.updated_at
-            attr[:last_read_at]          = notification.last_read_at
-            attr[:url]                   = notification.url
-
-            attr[:subject_url] = if notification.subject.type == "RepositoryInvitation"
-                                   "#{notification.repository.html_url}/invitations"
-                                 else
-                                   notification.subject.url
-                                 end
-          end
-
-          n.attributes = attrs
-          n.save(touch: false) if n.changed?
-        rescue ActiveRecord::RecordNotUnique
-          nil
-        end
-      end
+      fetch_unread_notifications(user)
+      fetch_read_notifications(user)
 
       user.update_column(:last_synced_at, timestamp)
     end
 
-    private
-
-    def fetch_notifications(user)
-      user.github_client.notifications(fetch_params(user)).each { |n| yield n }
+    def attributes_from_api_response(api_response)
+      attrs = API_ATTRIBUTE_MAP.map{|attr, path|
+        [attr, api_response.to_h.dig(*path)]
+      }.to_h
+      if "RepositoryInvitation" == api_response.subject.type
+        attrs[:subject_url] = "#{api_response.repository.html_url}/invitations"
+      end
+      attrs
     end
 
-    def fetch_params(user)
-      if user.last_synced_at?
-        { all: true, since: 1.week.ago.iso8601 }
-      else
-        { all: true, since: 1.month.ago.iso8601 }
+    private
+
+    def process_unread_notifications(notifications, user)
+      return if notifications.blank?
+      notifications.each do |notification|
+        begin
+          n =  user.notifications.find_or_initialize_by(github_id: notification[:id])
+          n.update_from_api_response(notification, unarchive: true)
+        rescue ActiveRecord::RecordNotUnique
+          nil
+        end
+      end
+    end
+
+    def process_read_notifications(notifications, user)
+      return if notifications.blank?
+      notifications.each do |notification|
+        next if notification.unread
+        n = user.notifications.find_by(github_id: notification.id)
+        next unless n
+        n.update_from_api_response(notification)
+      end
+    end
+
+    def fetch_unread_notifications(user)
+      headers = {cache_control: %w(no-store no-cache)}
+      headers[:if_modified_since] = user.last_synced_at.iso8601 if user.last_synced_at.respond_to?(:iso8601)
+      notifications = user.github_client.notifications(headers: headers)
+      process_unread_notifications(notifications, user)
+    end
+
+    def fetch_read_notifications(user)
+      oldest_unread = user.notifications.status(true).newest.last
+      if oldest_unread && oldest_unread.updated_at.respond_to?(:iso8601)
+        headers = {cache_control: %w(no-store no-cache)}
+        since = oldest_unread.updated_at - 1
+        notifications = user.github_client.notifications(all: true, since: since.iso8601, headers: headers)
+        process_read_notifications(notifications, user)
       end
     end
   end
@@ -104,5 +125,21 @@ class Notification < ApplicationRecord
 
   def repo_url
     "#{Octobox.github_domain}/#{repository_full_name}"
+  end
+
+  def unarchive_if_updated
+    return unless self.archived?
+    change = changes['updated_at']
+    return unless change
+    if self.archived && change[1] > change[0]
+      self.archived = false
+    end
+  end
+
+  def update_from_api_response(api_response, unarchive: false)
+    attrs = Notification.attributes_from_api_response(api_response)
+    self.attributes = attrs
+    unarchive_if_updated if unarchive
+    save(touch: false) if changed?
   end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -52,9 +52,9 @@ class Notification < ApplicationRecord
     end
 
     def attributes_from_api_response(api_response)
-      attrs = API_ATTRIBUTE_MAP.map{|attr, path|
+      attrs = API_ATTRIBUTE_MAP.map do |attr, path|
         [attr, api_response.to_h.dig(*path)]
-      }.to_h
+      end.to_h
       if "RepositoryInvitation" == api_response.subject.type
         attrs[:subject_url] = "#{api_response.repository.html_url}/invitations"
       end

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -25,9 +25,8 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
 
   test 'POST #create forces the user to sync their notifications' do
     OmniAuth.config.mock_auth[:github].uid = users(:andrew).github_id
-
     post '/auth/github/callback'
-    assert_requested @notifications_request
+    assert_requested :get, %r{https://api\.github\.com/notifications}
   end
 
   test 'GET #destroy redirects to /' do

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -25,8 +25,9 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
 
   test 'POST #create forces the user to sync their notifications' do
     OmniAuth.config.mock_auth[:github].uid = users(:andrew).github_id
+
     post '/auth/github/callback'
-    assert_requested :get, %r{https://api\.github\.com/notifications}
+    assert_requested  @notifications_request, times: 2
   end
 
   test 'GET #destroy redirects to /' do

--- a/test/fixtures/files/morty_notifications.json
+++ b/test/fixtures/files/morty_notifications.json
@@ -1,0 +1,88 @@
+[
+  {
+    "id": "420",
+    "repository": {
+      "id": 930405,
+      "owner": {
+        "login": "andrew",
+        "id": 1,
+        "avatar_url": "https://avatars3.githubusercontent.com/u/1060",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/andrew",
+        "html_url": "https://github.com/andrew",
+        "followers_url": "https://api.github.com/users/andrew/followers",
+        "following_url": "https://api.github.com/users/andrew/following{/other_user}",
+        "gists_url": "https://api.github.com/users/andrew/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/andrew/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/andrew/subscriptions",
+        "organizations_url": "https://api.github.com/users/andrew/orgs",
+        "repos_url": "https://api.github.com/users/andrew/repos",
+        "events_url": "https://api.github.com/users/andrew/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/andrew/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "name": "octobox",
+      "full_name": "octobox/octobox",
+      "description": "Take back control of your GitHub Notifications",
+      "private": false,
+      "fork": false,
+      "url": "https://api.github.com/repos/octobox/octobox",
+      "html_url": "https://github.com/octobox/octobox"
+    },
+    "subject": {
+      "title": "UI Updates",
+      "url": "https://api.github.com/repos/octobox/octobox/issues/56",
+      "latest_comment_url": "https://api.github.com/repos/octobox/octobox/issues/comments/123",
+      "type": "Issue"
+    },
+    "reason": "subscribed",
+    "unread": true,
+    "updated_at": "2016-12-19T22:01:45Z",
+    "last_read_at": "2016-12-19T22:01:45Z",
+    "url": "https://api.github.com/notifications/threads/420"
+  },
+  {
+    "id": "421",
+    "repository": {
+      "id": 930405,
+      "owner": {
+        "login": "andrew",
+        "id": 1,
+        "avatar_url": "https://avatars3.githubusercontent.com/u/1060",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/andrew",
+        "html_url": "https://github.com/andrew",
+        "followers_url": "https://api.github.com/users/andrew/followers",
+        "following_url": "https://api.github.com/users/andrew/following{/other_user}",
+        "gists_url": "https://api.github.com/users/andrew/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/andrew/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/andrew/subscriptions",
+        "organizations_url": "https://api.github.com/users/andrew/orgs",
+        "repos_url": "https://api.github.com/users/andrew/repos",
+        "events_url": "https://api.github.com/users/andrew/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/andrew/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "name": "octobox",
+      "full_name": "octobox/octobox",
+      "description": "Take back control of your GitHub Notifications",
+      "private": false,
+      "fork": false,
+      "url": "https://api.github.com/repos/octobox/octobox",
+      "html_url": "https://github.com/octobox/octobox"
+    },
+    "subject": {
+      "title": "More stuff",
+      "url": "https://api.github.com/repos/octobox/octobox/issues/560",
+      "latest_comment_url": "https://api.github.com/repos/octobox/octobox/issues/comments/123",
+      "type": "Issue"
+    },
+    "reason": "subscribed",
+    "unread": true,
+    "updated_at": "2016-12-19T22:00:00Z",
+    "last_read_at": null,
+    "url": "https://api.github.com/notifications/threads/421"
+  }
+]

--- a/test/fixtures/files/newuser_all_notifications.json
+++ b/test/fixtures/files/newuser_all_notifications.json
@@ -1,0 +1,131 @@
+[
+  {
+    "id": "420",
+    "repository": {
+      "id": 930405,
+      "owner": {
+        "login": "andrew",
+        "id": 1,
+        "avatar_url": "https://avatars3.githubusercontent.com/u/1060",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/andrew",
+        "html_url": "https://github.com/andrew",
+        "followers_url": "https://api.github.com/users/andrew/followers",
+        "following_url": "https://api.github.com/users/andrew/following{/other_user}",
+        "gists_url": "https://api.github.com/users/andrew/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/andrew/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/andrew/subscriptions",
+        "organizations_url": "https://api.github.com/users/andrew/orgs",
+        "repos_url": "https://api.github.com/users/andrew/repos",
+        "events_url": "https://api.github.com/users/andrew/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/andrew/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "name": "octobox",
+      "full_name": "octobox/octobox",
+      "description": "Take back control of your GitHub Notifications",
+      "private": false,
+      "fork": false,
+      "url": "https://api.github.com/repos/octobox/octobox",
+      "html_url": "https://github.com/octobox/octobox"
+    },
+    "subject": {
+      "title": "UI Updates",
+      "url": "https://api.github.com/repos/octobox/octobox/issues/56",
+      "latest_comment_url": "https://api.github.com/repos/octobox/octobox/issues/comments/123",
+      "type": "Issue"
+    },
+    "reason": "subscribed",
+    "unread": true,
+    "updated_at": "2016-12-19T22:01:45Z",
+    "last_read_at": "2016-12-19T22:01:45Z",
+    "url": "https://api.github.com/notifications/threads/420"
+  },
+  {
+    "id": "421",
+    "repository": {
+      "id": 930405,
+      "owner": {
+        "login": "andrew",
+        "id": 1,
+        "avatar_url": "https://avatars3.githubusercontent.com/u/1060",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/andrew",
+        "html_url": "https://github.com/andrew",
+        "followers_url": "https://api.github.com/users/andrew/followers",
+        "following_url": "https://api.github.com/users/andrew/following{/other_user}",
+        "gists_url": "https://api.github.com/users/andrew/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/andrew/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/andrew/subscriptions",
+        "organizations_url": "https://api.github.com/users/andrew/orgs",
+        "repos_url": "https://api.github.com/users/andrew/repos",
+        "events_url": "https://api.github.com/users/andrew/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/andrew/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "name": "octobox",
+      "full_name": "octobox/octobox",
+      "description": "Take back control of your GitHub Notifications",
+      "private": false,
+      "fork": false,
+      "url": "https://api.github.com/repos/octobox/octobox",
+      "html_url": "https://github.com/octobox/octobox"
+    },
+    "subject": {
+      "title": "More stuff",
+      "url": "https://api.github.com/repos/octobox/octobox/issues/560",
+      "latest_comment_url": "https://api.github.com/repos/octobox/octobox/issues/comments/123",
+      "type": "Issue"
+    },
+    "reason": "subscribed",
+    "unread": true,
+    "updated_at": "2016-12-19T22:00:00Z",
+    "last_read_at": null,
+    "url": "https://api.github.com/notifications/threads/421"
+  },
+  {
+    "id": "419",
+    "repository": {
+      "id": 930405,
+      "owner": {
+        "login": "andrew",
+        "id": 1,
+        "avatar_url": "https://avatars3.githubusercontent.com/u/1060",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/andrew",
+        "html_url": "https://github.com/andrew",
+        "followers_url": "https://api.github.com/users/andrew/followers",
+        "following_url": "https://api.github.com/users/andrew/following{/other_user}",
+        "gists_url": "https://api.github.com/users/andrew/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/andrew/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/andrew/subscriptions",
+        "organizations_url": "https://api.github.com/users/andrew/orgs",
+        "repos_url": "https://api.github.com/users/andrew/repos",
+        "events_url": "https://api.github.com/users/andrew/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/andrew/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "name": "octobox",
+      "full_name": "octobox/octobox",
+      "description": "Take back control of your GitHub Notifications",
+      "private": false,
+      "fork": false,
+      "url": "https://api.github.com/repos/octobox/octobox",
+      "html_url": "https://github.com/octobox/octobox"
+    },
+    "subject": {
+      "title": "Even more stuff",
+      "url": "https://api.github.com/repos/octobox/octobox/issues/52",
+      "latest_comment_url": "https://api.github.com/repos/octobox/octobox/issues/comments/123",
+      "type": "Issue"
+    },
+    "reason": "subscribed",
+    "unread": false,
+    "updated_at": "2016-12-19T22:00:00Z",
+    "last_read_at": "2016-12-19T22:01:45Z",
+    "url": "https://api.github.com/notifications/threads/419"
+  }
+]

--- a/test/fixtures/files/newuser_notifications.json
+++ b/test/fixtures/files/newuser_notifications.json
@@ -1,0 +1,88 @@
+[
+  {
+    "id": "420",
+    "repository": {
+      "id": 930405,
+      "owner": {
+        "login": "andrew",
+        "id": 1,
+        "avatar_url": "https://avatars3.githubusercontent.com/u/1060",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/andrew",
+        "html_url": "https://github.com/andrew",
+        "followers_url": "https://api.github.com/users/andrew/followers",
+        "following_url": "https://api.github.com/users/andrew/following{/other_user}",
+        "gists_url": "https://api.github.com/users/andrew/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/andrew/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/andrew/subscriptions",
+        "organizations_url": "https://api.github.com/users/andrew/orgs",
+        "repos_url": "https://api.github.com/users/andrew/repos",
+        "events_url": "https://api.github.com/users/andrew/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/andrew/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "name": "octobox",
+      "full_name": "octobox/octobox",
+      "description": "Take back control of your GitHub Notifications",
+      "private": false,
+      "fork": false,
+      "url": "https://api.github.com/repos/octobox/octobox",
+      "html_url": "https://github.com/octobox/octobox"
+    },
+    "subject": {
+      "title": "UI Updates",
+      "url": "https://api.github.com/repos/octobox/octobox/issues/56",
+      "latest_comment_url": "https://api.github.com/repos/octobox/octobox/issues/comments/123",
+      "type": "Issue"
+    },
+    "reason": "subscribed",
+    "unread": true,
+    "updated_at": "2016-12-19T22:01:45Z",
+    "last_read_at": "2016-12-19T22:01:45Z",
+    "url": "https://api.github.com/notifications/threads/420"
+  },
+  {
+    "id": "421",
+    "repository": {
+      "id": 930405,
+      "owner": {
+        "login": "andrew",
+        "id": 1,
+        "avatar_url": "https://avatars3.githubusercontent.com/u/1060",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/andrew",
+        "html_url": "https://github.com/andrew",
+        "followers_url": "https://api.github.com/users/andrew/followers",
+        "following_url": "https://api.github.com/users/andrew/following{/other_user}",
+        "gists_url": "https://api.github.com/users/andrew/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/andrew/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/andrew/subscriptions",
+        "organizations_url": "https://api.github.com/users/andrew/orgs",
+        "repos_url": "https://api.github.com/users/andrew/repos",
+        "events_url": "https://api.github.com/users/andrew/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/andrew/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "name": "octobox",
+      "full_name": "octobox/octobox",
+      "description": "Take back control of your GitHub Notifications",
+      "private": false,
+      "fork": false,
+      "url": "https://api.github.com/repos/octobox/octobox",
+      "html_url": "https://github.com/octobox/octobox"
+    },
+    "subject": {
+      "title": "More stuff",
+      "url": "https://api.github.com/repos/octobox/octobox/issues/560",
+      "latest_comment_url": "https://api.github.com/repos/octobox/octobox/issues/comments/123",
+      "type": "Issue"
+    },
+    "reason": "subscribed",
+    "unread": true,
+    "updated_at": "2016-12-19T22:00:00Z",
+    "last_read_at": null,
+    "url": "https://api.github.com/notifications/threads/421"
+  }
+]

--- a/test/fixtures/notifications.yml
+++ b/test/fixtures/notifications.yml
@@ -12,3 +12,62 @@ one:
   unread: false
   url: MyString
   archived: false
+
+unreadone:
+  user: userwithunread
+  github_id: 2
+  repository_id: 2
+  repository_full_name: MyString
+  subject_title: MyString
+  subject_url: MyString
+  subject_type: MyString
+  reason: MyString
+  unread: true
+  url: MyString
+  archived: false
+  last_read_at: <%= 5.day.ago %>
+  updated_at: <%= 30.minutes.ago %>
+
+unreadtwo:
+  user: userwithunread
+  github_id: 3
+  repository_id: 2
+  repository_full_name: MyString
+  subject_title: MyString
+  subject_url: MyString
+  subject_type: MyString
+  reason: MyString
+  unread: false
+  url: MyString
+  archived: false
+
+archived:
+  user: morty
+  github_id: 2
+  repository_id: 2
+  repository_full_name: MyString
+  subject_title: MyString
+  subject_url: MyString
+  subject_type: MyString
+  reason: MyString
+  unread: true
+  url: MyString
+  archived: true
+  last_read_at: <%= 5.day.ago %>
+  updated_at: <%= 30.minutes.ago %>
+
+morty_updated:
+  user: morty
+  github_id: 420
+  repository_id: 930405
+  repository_full_name: octobox/octobox
+  repository_owner_name: andrew
+  subject_title: UI Updates
+  subject_url: https://api.github.com/repos/octobox/octobox/issues/56
+  subject_type: Issue
+  reason: subscribed
+  unread: false
+  url: https://api.github.com/notifications/threads/420
+  archived: true
+  updated_at: 2016-12-17T22:00:00Z
+  last_read_at: 2016-12-18T22:00:00Z

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -15,8 +15,15 @@ userwithunread:
   github_id: 92873
   access_token: <%= SecureRandom.hex(20) %>
   github_login: 'userwithunread'
+  last_synced_at: <%= Time.parse('2016-12-19T12:00:00Z') %>
 
 morty:
   github_id: 947168
   access_token: <%= SecureRandom.hex(20) %>
   github_login: 'morty'
+  last_synced_at: <%= Time.parse('2016-12-19T12:00:00Z') %>
+
+newuser:
+  github_id: 297580
+  access_token: <%= SecureRandom.hex(20) %>
+  github_login: 'newuser'

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -10,3 +10,13 @@ tokenuser:
   access_token: <%= SecureRandom.hex(20) %>
   github_login: 'tokenuser'
   personal_access_token: 'deadbeef'
+
+userwithunread:
+  github_id: 92873
+  access_token: <%= SecureRandom.hex(20) %>
+  github_login: 'userwithunread'
+
+morty:
+  github_id: 947168
+  access_token: <%= SecureRandom.hex(20) %>
+  github_login: 'morty'

--- a/test/models/notification_test.rb
+++ b/test/models/notification_test.rb
@@ -2,28 +2,54 @@
 require 'test_helper'
 
 class NotificationTest < ActiveSupport::TestCase
-  setup { stub_notifications_request }
 
-  test '#download fetches one months notification when a user has not been synched before' do
-    travel_to "2016-12-19T19:00:00Z" do
-      user = users(:andrew)
-      user.last_synced_at = nil
+  test '#download only fetches unread notifications when a user has no unread notifications' do
+    user = users(:tokenuser)
+    User.any_instance.stubs(:github_client).returns(mock {
+      expects(:notifications).returns([])
+    })
+    Notification.download(user)
+  end
 
-      Notification.download(user)
+  test '#download fetches notifications newer than the oldest unread' do
+    # one second before oldest unread notification
+    user = users(:userwithunread)
+    expected_since =( user.notifications.status(true).first.updated_at - 1).iso8601
+    User.any_instance.stubs(:github_client).returns(mock {
+      expects(:notifications).returns([])
+      expects(:notifications).with(all: true, since: expected_since, headers: {cache_control: ['no-store', 'no-cache']}).returns([])
+    })
 
-      assert_requested :get, "https://api.github.com/notifications?all=true&per_page=100&since=2016-11-19T19:00:00Z"
+    Notification.download(user)
+  end
+
+  test '#download will create new notification' do
+    expected_attributes = build_expected_attributes(notifications_from_fixture('morty_notifications.json'))
+    stub_notifications_request(body: file_fixture('morty_notifications.json'))
+    user = users(:morty)
+    user.notifications.destroy_all
+    Notification.download(user)
+    notifications = user.notifications.map(&:attributes)
+    expected_attributes.each do |expected|
+      assert attrs = notifications.select{|n| n['github_id'] == expected['github_id']}.first
+      assert_equal attrs, attrs.merge(expected)
     end
   end
 
-  test '#download fetches one weeks notification when a user has synched before' do
-    travel_to "2016-12-19T19:00:00Z" do
-      user = users(:andrew)
-      user.last_synced_at = "2016-12-19T19:00:00Z"
-
-      Notification.download(user)
-
-      assert_requested :get, "https://api.github.com/notifications?all=true&per_page=100&since=2016-12-12T19:00:00Z"
-    end
+  test "#download will update and unarchive a notification" do
+    expected_attributes =  build_expected_attributes(notifications_from_fixture('morty_notifications.json'))
+                            .find{|n| n['github_id'] == 420}
+    stub_notifications_request(body: file_fixture('morty_notifications.json'))
+    user = users(:morty)
+    notification = notifications(:morty_updated)
+    assert notification.archived?
+    refute notification.unread?
+    Notification.download(user)
+    notification.reload
+    assert notification.unread?
+    refute notification.archived?
+    attrs = notification.attributes
+    assert_equal attrs, attrs.merge(expected_attributes)
   end
 
   test "#download will set the url for a Repository invitation correctly" do
@@ -35,6 +61,12 @@ class NotificationTest < ActiveSupport::TestCase
     assert notification = Notification.last
     assert_equal 'RepositoryInvitation', notification.subject_type
     assert_match %r{https://github.com/.+/invitations$}, notification.subject_url
+  end
+
+  test '#download handles no new notifications' do
+    Octokit::Client.any_instance.stubs(:notifications).returns('')
+    user = users(:morty)
+    Notification.download(user)
   end
 
   test 'ignore_thread sends ignore request to github' do
@@ -63,5 +95,89 @@ class NotificationTest < ActiveSupport::TestCase
       expects(:mark_thread_as_read).with(notification.github_id, read: true).returns true
     })
     assert notification.mute
+  end
+
+  test 'unarchive_if_updated unarchives when updated_at is newer' do
+    notification = notifications(:archived)
+    notification.updated_at += 1
+    notification.unarchive_if_updated
+    refute notification.archived?
+  end
+
+  test 'unarchive_if_updated does nothing when updated_at is older' do
+    notification = notifications(:archived)
+    notification.updated_at -= 1
+    notification.unarchive_if_updated
+    assert notification.archived?
+  end
+
+  test 'unarchive_if_updated does nothing unless updated_at is changed' do
+    notification = notifications(:archived)
+    notification.subject_title = "whatever"
+    notification.unarchive_if_updated
+    assert notification.archived?
+  end
+
+  test 'unarchive_if_updated does nothing if nothing is changed' do
+    notification = notifications(:archived)
+    notification.unarchive_if_updated
+    assert notification.archived?
+  end
+
+  test 'update_from_api_response updates attributes' do
+    api_response = notifications_from_fixture('morty_notifications.json').first
+    notification = notifications(:morty_updated)
+    expected_attributes = notification.attributes.merge(
+      {last_read_at: '2016-12-19 22:01:45 UTC',
+       updated_at: Time.zone.parse('2016-12-19T22:01:45Z'),
+       unread: true,
+       archived: false}.stringify_keys)
+    notification.update_from_api_response(api_response, unarchive: true)
+    assert notification.unread?
+    refute notification.archived?
+    assert_equal expected_attributes, notification.attributes
+  end
+
+  test 'update_from_api_response updates attributes on a new notification' do
+    user = users(:morty)
+    expected_attributes = {
+      user_id: user.id,
+      github_id: 421,
+      repository_id: 930405,
+      repository_full_name: 'octobox/octobox',
+      subject_title: 'More stuff',
+      subject_url: 'https://api.github.com/repos/octobox/octobox/issues/560',
+      subject_type: 'Issue',
+      reason: 'subscribed',
+      unread: true,
+      last_read_at: nil,
+      url: 'https://api.github.com/notifications/threads/421',
+      archived: false,
+      starred: false,
+      repository_owner_name: 'andrew',
+      updated_at: Time.zone.parse('2016-12-19T22:00:00Z')
+    }.stringify_keys
+    api_response = notifications_from_fixture('morty_notifications.json').second
+    n = user.notifications.find_or_initialize_by(github_id: api_response[:id])
+    n.update_from_api_response(api_response, unarchive: true)
+    attributes = n.attributes
+    assert_equal attributes, attributes.merge(expected_attributes)
+  end
+
+  def build_expected_attributes(expected_notifications, keys: nil)
+    keys ||= Notification::API_ATTRIBUTE_MAP.keys
+    expected_notifications.map{|n|
+      notification = Notification.new
+      notification.attributes = Notification.attributes_from_api_response(n)
+      attrs = notification.attributes
+      notification.destroy
+      attrs.slice(*(keys.map(&:to_s)))
+    }
+  end
+
+  def notifications_from_fixture(fixture_file)
+    JSON.parse(file_fixture(fixture_file).read, object_class: OpenStruct).tap do |notifications|
+      notifications.map { |n| n.last_read_at = Time.parse(n.last_read_at).to_s if n.last_read_at }
+    end
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -47,6 +47,7 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test '#effective_access_token returns access_token if personal_access_tokens_enabled? is false' do
+    stub_personal_access_tokens_enabled(value: false)
     user = users(:tokenuser)
     assert_equal user.access_token, user.effective_access_token
   end
@@ -92,6 +93,7 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test 'does not allow setting personal_access_token without being enabled' do
+    stub_personal_access_tokens_enabled(value: false)
     user = users(:andrew)
     user.personal_access_token = '1234'
     assert_error_present(user, User::ERRORS[:disallowed_tokens])

--- a/test/support/stub_helper.rb
+++ b/test/support/stub_helper.rb
@@ -22,8 +22,8 @@ module StubHelper
     stub_request(:get, user_url).to_return(response)
   end
 
-  def stub_personal_access_tokens_enabled(value: 'true')
-    Octobox.stubs(:personal_access_tokens_enabled).returns(true)
+  def stub_personal_access_tokens_enabled(value: true)
+    Octobox.stubs(:personal_access_tokens_enabled).returns(value)
   end
 
   def stub_minimum_refresh_interval(value = 0)


### PR DESCRIPTION
This decreases complexity by separating out api requests for read and unread notifications.

The request for unread notifications goes back to using the If-Modified-Since header because it will cause an `HTTP 304` response if there is nothing new and the rate limit won't be decremented.  

The request for read notifications now sets the since value to your oldest unread notification.  This will prevent loading more pages of notifications than is necessary to mark a notification as read.

closes #221