### PR TITLE
Use icons on function buttons, hide text on mobile

### DIFF
--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -52,7 +52,7 @@ module NotificationsHelper
   def mute_selected_button(custom_class=nil)
     unless params[:archive]
       button_tag(type: 'button', class: "mute_selected #{custom_class}") do
-        'Mute selected'
+        octicon('mute', height: 16) + content_tag(:span, ' Mute selected', class: 'hidden-xs')
       end
     end
   end
@@ -61,7 +61,7 @@ module NotificationsHelper
     action = params[:archive] ? 'unarchive' : 'archive'
     button_tag(type: "button",
                class: "archive_toggle #{action}_selected #{custom_class}") do
-      "#{action} selected".capitalize
+      octicon('checklist', height: 16) + content_tag(:span, " #{action.capitalize} selected", class: 'hidden-xs')
     end
   end
 


### PR DESCRIPTION
With the addition of `Mute Selected` the mobile interface was feeling a little cramped, this adds icons to the function buttons and hides the text on mobile.

Desktop:
![screen shot 2017-01-09 at 12 44 35 pm](https://cloud.githubusercontent.com/assets/1060/21767124/14605328-d66a-11e6-8cd4-678f13cf417a.png)

Mobile:
![screen shot 2017-01-09 at 12 47 16 pm](https://cloud.githubusercontent.com/assets/1060/21767120/1155b02e-d66a-11e6-8890-13d9eae38ec1.png)
