### PR TITLE
Hide select all button if there's nothing to select

### DIFF
--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -29,9 +29,11 @@
           <button type="button" class="hidden-md hidden-lg btn btn-default" data-toggle="offcanvas">
             <%= octicon 'three-bars', :height => 16 %>
           </button>
+          <% if @notifications.any? %>
           <label class="btn btn-default select-all" for="select_all">
             <input id="select_all" type="checkbox" class='js-select_all'>
-        </label>
+          </label>
+          <% end %>
           <%= link_to sync_notifications_path(filters), class: 'btn btn-default sync', 'data-toggle' => 'tooltip', 'data-placement' => 'bottom', 'data-turbolinks' => false, 'data-animation' => 'false', 'data-position' => 'bottom', 'title' => 'Refresh list', method: :post do %>
             <%= octicon 'sync', :height => 16 %>
           <% end %>


### PR DESCRIPTION
No reason for a select all checkbox if there's nothing to select!