### PR TITLE
Let users set blank refresh_interval to not have any auto refresh

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -30,7 +30,7 @@ class UsersController < ApplicationController
   end
 
   def update_user_params
-    if params[:user][:refresh_interval_minutes].present?
+    if params[:user].has_key? :refresh_interval_minutes
       params[:user][:refresh_interval] = params[:user][:refresh_interval_minutes].to_i * 60_000
     end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,12 +14,23 @@ class User < ApplicationRecord
   validates :github_login, presence: true
   validates :refresh_interval, numericality: {
     only_integer: true,
-    allow_blank: false,
+    allow_blank: true,
     greater_than_or_equal_to: 0,
     less_than_or_equal_to: 86_400_000,
     message: ERRORS[:refresh_interval_size][1]
   }
   validate :personal_access_token_validator
+
+  def refresh_interval=(val)
+    val = nil if 0 == val
+    super(val)
+  end
+
+  # For users who had zero values set before 20170111185505_allow_null_for_last_synced_at_in_users.rb
+  # We want their zeros treated like nils
+  def refresh_interval
+    0 == super ? nil : super
+  end
 
   def self.find_by_auth_hash(auth_hash)
     User.find_by(github_id: auth_hash['uid'])
@@ -53,8 +64,9 @@ class User < ApplicationRecord
 
   # Use the greater of the system minimum or the user's setting
   def effective_refresh_interval
-    return 0 if [Octobox.minimum_refresh_interval, refresh_interval].include?(0)
-    [Octobox.minimum_refresh_interval * 60_000, refresh_interval].max
+    if Octobox.refresh_interval_enabled? && refresh_interval
+      [Octobox.minimum_refresh_interval * 60_000, refresh_interval].max
+    end
   end
 
   def effective_access_token

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -7,10 +7,10 @@
       <% if Octobox.refresh_interval_enabled? %>
         <div class="form-group">
           <%= f.label :refresh_interval_minutes, 'Notification Refresh Interval' %>
-          <%= f.number_field :refresh_interval_minutes, max: 1440, min: Octobox.minimum_refresh_interval, value: current_user.effective_refresh_interval / 60_000, class: 'form-control' %>
+          <%= f.number_field :refresh_interval_minutes, max: 1440, min: Octobox.minimum_refresh_interval, value: current_user.effective_refresh_interval.nil? ? '' : current_user.effective_refresh_interval / 60_000, class: 'form-control' %>
           <p>
             <em>
-              Auto refresh every N minutes when you are viewing notifications. If set to 0, no auto refreshes will occur.
+              Auto refresh every N minutes when you are viewing notifications. If blank, no auto refreshes will occur.
             </em>
           </p>
         </div>

--- a/db/migrate/20170111185505_allow_null_for_last_synced_at_in_users.rb
+++ b/db/migrate/20170111185505_allow_null_for_last_synced_at_in_users.rb
@@ -1,0 +1,5 @@
+class AllowNullForLastSyncedAtInUsers < ActiveRecord::Migration[5.0]
+  def change
+    change_column_null :users, :refresh_interval, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170102152008) do
+ActiveRecord::Schema.define(version: 20170111185505) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -37,14 +37,15 @@ ActiveRecord::Schema.define(version: 20170102152008) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.integer  "github_id",                         null: false
-    t.string   "access_token",                      null: false
-    t.string   "github_login",                      null: false
-    t.datetime "created_at",                        null: false
-    t.datetime "updated_at",                        null: false
+    t.integer  "github_id",                             null: false
+    t.string   "access_token",                          null: false
+    t.string   "github_login",                          null: false
+    t.datetime "created_at",                            null: false
+    t.datetime "updated_at",                            null: false
     t.datetime "last_synced_at"
     t.string   "personal_access_token"
-    t.integer  "refresh_interval",      default: 0, null: false
+    t.boolean  "sync_on_load",          default: false, null: false
+    t.integer  "refresh_interval",      default: 0
     t.index ["access_token"], name: "index_users_on_access_token", unique: true, using: :btree
     t.index ["github_id"], name: "index_users_on_github_id", unique: true, using: :btree
   end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -147,17 +147,21 @@ class UserTest < ActiveSupport::TestCase
     assert_equal 60_000, users(:andrew).refresh_interval
   end
 
-  [{refresh_interval: 90_000, minimum_refresh_interval: 0, expected_result: 0},
+  [{refresh_interval: 90_000, minimum_refresh_interval: 0, expected_result: nil},
    {refresh_interval: 90_000, minimum_refresh_interval: 60, expected_result: 60 * 60_000},
-   {refresh_interval: 0, minimum_refresh_interval: 60, expected_result: 0},
-   {refresh_interval: 0, minimum_refresh_interval: 0, expected_result: 0}
+   {refresh_interval: 0, minimum_refresh_interval: 60, expected_result: nil},
+   {refresh_interval: 0, minimum_refresh_interval: 0, expected_result: nil}
   ].each do |t|
     test "effective_refresh_interval returns #{t[:expected_result]} when minimum_refresh_interval is #{t[:minimum_refresh_interval]} and refresh_interval is #{t[:refresh_interval]}" do
       stub_minimum_refresh_interval(t[:minimum_refresh_interval])
       user = users(:andrew)
       user.refresh_interval = t[:refresh_interval]
       user.save
-      assert_equal t[:expected_result], user.effective_refresh_interval
+      if t[:expected_result].nil?
+        assert_nil user.effective_refresh_interval
+      else
+        assert_equal t[:expected_result], user.effective_refresh_interval
+      end
     end
   end
 


### PR DESCRIPTION
fixes #213 [/settings won't let you set Notification Refresh Interval to 0](https://github.com/octobox/octobox/issues/213)

This was a little bigger fix than I intended.  I ended up changing the value for no auto-refresh to be nil instead of 0.  That meant updating the schema.  There will still be users who have 0 values, so I overrode `user.refresh_interval` so that 0 maps to nil.