### PR TITLE
Mark As Read on notification click

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -129,6 +129,11 @@ function mute() {
   });
 }
 
+function markAsRead(id) {
+  $.get( "/notifications/"+id+"/mark_as_read");
+  $('#notification-'+id).removeClass('active');
+}
+
 function toggleArchive() {
   if ( $(".js-table-notifications tr").length === 0 ) return;
 

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -2,7 +2,7 @@
 class NotificationsController < ApplicationController
   skip_before_action :authenticate_user!, only: [:index]
   before_action :render_home_page_unless_authenticated, only: [:index]
-  before_action :find_notification, only: [:archive, :unarchive, :star]
+  before_action :find_notification, only: [:archive, :unarchive, :star, :mark_as_read]
 
   def index
     scope    = current_user.notifications
@@ -42,6 +42,11 @@ class NotificationsController < ApplicationController
 
   def archive_selected
     current_user.notifications.where(id: params[:id]).update_all archived: params[:value]
+    head :ok
+  end
+
+  def mark_as_read
+    @notification.update_columns unread: false
     head :ok
   end
 

--- a/app/views/notifications/_notification.html.erb
+++ b/app/views/notifications/_notification.html.erb
@@ -1,4 +1,4 @@
-<tr class='notification <%= notification.unread ? 'active' : '' %>'>
+<tr id='notification-<%= notification.id %>' class='notification <%= notification.unread ? 'active' : '' %>'>
   <td class='notification-checkbox'>
     <%= check_box_tag(
         '',
@@ -16,7 +16,7 @@
     <%= octicon notification_icon(notification.subject_type), :height => 16 %>
   </td>
   <td class='notification-subject'>
-    <%= link_to notification.subject_title, notification.web_url, target: '_blank', class: 'link' %>
+    <%= link_to notification.subject_title, notification.web_url, target: '_blank', class: 'link', onclick: "markAsRead(#{notification.id})" %>
   </td>
   <% unless params[:repo].present? %>
   <td class='notification-repo'>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
 
     member do
       get :star
+      get :mark_as_read
     end
   end
 

--- a/test/controllers/notifications_controller_test.rb
+++ b/test/controllers/notifications_controller_test.rb
@@ -98,6 +98,17 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
     assert notification.reload.starred?
   end
 
+  test 'toggles unread on a notification' do
+    notification = create(:notification, user: @user, unread: true)
+
+    sign_in_as(@user)
+
+    get "/notifications/#{notification.id}/mark_as_read"
+    assert_response :ok
+
+    refute notification.reload.unread?
+  end
+
   test 'syncs users notifications' do
     sign_in_as(@user)
 


### PR DESCRIPTION
Closes #239

When a notification is clicked, instead of waiting to mark the notification as read on the next sync action, immediately mark the notification as having been read.

![](http://screenshots.chrisarcand.com/permpxtwi.gif)

I dislike that this feature utilizes GET instead of PATCH for updating a notification but I know little to nothing about JQuery and see that this is how the toggling of 'starred' works, so... ¯\\\_(ツ)_/¯