### PR TITLE
Manual mark read

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ You can use keyboard shortcuts to navigate and perform certain actions:
  - `x` - mark/unmark current notification
  - `y` - archive current/marked notification(s)
  - `m` - mute current/marked notification(s)
+ - `d` - mark current/marked notification(s) as read here and on GitHub
  - `o` or `Enter` - open current notification in a new window
 
 Press `?` for the help menu.

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -75,19 +75,20 @@ function enableKeyboardShortcuts() {
 }
 
 var shortcuts = {
-  65:  checkSelectAll, // a
-  74:  cursorDown,      // j
-  75:  cursorUp,        // k
-  83:  toggleStar,      // s
-  88:  markCurrent,     // x
-  89:  toggleArchive,   // y
-  77:  mute,            // m
-  13:  openCurrentLink, // Enter
-  79:  openCurrentLink, // o
-  191: openModal,       // ?
-  190: sync,            // .
-  82:  sync             // r
-}
+  65:  checkSelectAll,    // a
+  68:  markReadSelected,  // d
+  74:  cursorDown,        // j
+  75:  cursorUp,          // k
+  83:  toggleStar,        // s
+  88:  markCurrent,       // x
+  89:  toggleArchive,     // y
+  77:  mute,              // m
+  13:  openCurrentLink,   // Enter
+  79:  openCurrentLink,   // o
+  191: openModal,         // ?
+  190: sync,              // .
+  82:  sync               // r
+};
 
 function cursorDown() {
   moveCursor('up')
@@ -145,7 +146,7 @@ function markReadSelected() {
     ids = [ $('td.js-current input').val() ];
   }
   $.post( "/notifications/mark_read_selected", {'id[]': ids}).done(function() {
-    marked.parents('tr').removeClass('active');
+    ids.forEach(function(id){$('.js-table-notifications #notification-'+id).removeClass('active')});
     $('button.mark_read_selected').addClass('hidden');
   })
 }

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,10 +16,16 @@ document.addEventListener("turbolinks:load", function() {
       } else {
         $(".js-select_all").prop("indeterminate", true);
       }
-      $('button.archive_selected, button.unarchive_selected, button.mute_selected, button.mark_read_selected').removeClass('hidden');
+      $('button.archive_selected, button.unarchive_selected, button.mute_selected').removeClass('hidden');
     } else {
       $(".js-select_all").prop('checked', false)
-      $('button.archive_selected, button.unarchive_selected, button.mute_selected, button.mark_read_selected').addClass('hidden');
+      $('button.archive_selected, button.unarchive_selected, button.mute_selected').addClass('hidden');
+    }
+    var marked_unread_length = marked.parents('tr.active').length;
+    if ( marked_unread_length > 0 ) {
+      $('button.mark_read_selected').removeClass('hidden');
+    } else {
+      $('button.mark_read_selected').addClass('hidden');
     }
   });
   $('.toggle-star').click(function() {

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -150,8 +150,8 @@ function markReadSelected() {
   })
 }
 
-function markAsRead(id) {
-  $.get( "/notifications/"+id+"/mark_as_read");
+function markRead(id) {
+  $.get( "/notifications/"+id+"/mark_read");
   $('#notification-'+id).removeClass('active');
 }
 

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,10 +16,10 @@ document.addEventListener("turbolinks:load", function() {
       } else {
         $(".js-select_all").prop("indeterminate", true);
       }
-      $('button.archive_selected, button.unarchive_selected, button.mute_selected').removeClass('hidden');
+      $('button.archive_selected, button.unarchive_selected, button.mute_selected, button.mark_read_selected').removeClass('hidden');
     } else {
       $(".js-select_all").prop('checked', false)
-      $('button.archive_selected, button.unarchive_selected, button.mute_selected').addClass('hidden');
+      $('button.archive_selected, button.unarchive_selected, button.mute_selected, button.mark_read_selected').addClass('hidden');
     }
   });
   $('.toggle-star').click(function() {

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -8,6 +8,7 @@
 document.addEventListener("turbolinks:load", function() {
   $('button.archive_selected, button.unarchive_selected').click(function () { toggleArchive(); });
   $('button.mute_selected').click(function () { mute(); });
+  $('button.mark_read_selected').click(function() {markReadSelected()});
   $('input.archive, input.unarchive').change(function() {
     var marked = $(".js-table-notifications input:checked");
     if ( marked.length > 0 ) {
@@ -133,6 +134,20 @@ function mute() {
     }
     Turbolinks.visit("/"+location.search);
   });
+}
+
+function markReadSelected() {
+  if ( $(".js-table-notifications tr").length === 0 ) return;
+  marked = $(".js-table-notifications tr.active input:checked");
+  if ( marked.length > 0 ) {
+    ids = marked.map(function() { return this.value; }).get();
+  } else {
+    ids = [ $('td.js-current input').val() ];
+  }
+  $.post( "/notifications/mark_read_selected", {'id[]': ids}).done(function() {
+    marked.parents('tr').removeClass('active');
+    $('button.mark_read_selected').addClass('hidden');
+  })
 }
 
 function markAsRead(id) {

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -2,7 +2,7 @@
 class NotificationsController < ApplicationController
   skip_before_action :authenticate_user!, only: [:index]
   before_action :render_home_page_unless_authenticated, only: [:index]
-  before_action :find_notification, only: [:archive, :unarchive, :star, :mark_as_read]
+  before_action :find_notification, only: [:archive, :unarchive, :star, :mark_read]
 
   def index
     scope    = current_user.notifications
@@ -53,7 +53,7 @@ class NotificationsController < ApplicationController
     head :ok
   end
 
-  def mark_as_read
+  def mark_read
     @notification.update_columns unread: false
     head :ok
   end

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -48,7 +48,7 @@ class NotificationsController < ApplicationController
   def mark_read_selected
     notifications = current_user.notifications.where(id: params[:id])
     notifications.each do |notification|
-      notification.mark_as_read(update_github: true)
+      notification.mark_read(update_github: true)
     end
     head :ok
   end

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -45,6 +45,14 @@ class NotificationsController < ApplicationController
     head :ok
   end
 
+  def mark_read_selected
+    notifications = current_user.notifications.where(id: params[:id])
+    notifications.each do |notification|
+      notification.mark_as_read(update_github: true)
+    end
+    head :ok
+  end
+
   def mark_as_read
     @notification.update_columns unread: false
     head :ok

--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -59,6 +59,12 @@ module NotificationsHelper
     end
   end
 
+  def mark_read_selected_button(custom_class=nil)
+    button_tag(type: 'button', class: "mark_read_selected #{custom_class}") do
+      octicon('eye', height: 16) + content_tag(:span, ' Mark as read', class: 'hidden-xs')
+    end
+  end
+
   def archive_selected_button(custom_class=nil)
     action = params[:archive] ? 'unarchive' : 'archive'
     button_tag(type: "button",

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -38,7 +38,7 @@ class Notification < ApplicationRecord
     end
   end
 
-  def mark_as_read(update_github: false)
+  def mark_read(update_github: false)
     self[:unread] = false
     save(touch: false) if changed?
 
@@ -52,7 +52,7 @@ class Notification < ApplicationRecord
   end
 
   def mute
-    mark_as_read(update_github: true)
+    mark_read(update_github: true)
     ignore_thread
   end
 

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -38,8 +38,13 @@ class Notification < ApplicationRecord
     end
   end
 
-  def mark_as_read
-    user.github_client.mark_thread_as_read(github_id, read: true)
+  def mark_as_read(update_github: false)
+    self[:unread] = false
+    save(touch: false) if changed?
+
+    if update_github
+      user.github_client.mark_thread_as_read(github_id, read: true)
+    end
   end
 
   def ignore_thread
@@ -47,7 +52,7 @@ class Notification < ApplicationRecord
   end
 
   def mute
-    mark_as_read
+    mark_as_read(update_github: true)
     ignore_thread
   end
 

--- a/app/views/notifications/_help-box.html.erb
+++ b/app/views/notifications/_help-box.html.erb
@@ -75,6 +75,14 @@
             </tr>
             <tr>
               <td class="keys">
+                <div class="key">d</div>
+              </td>
+              <td>
+                Mark current/marked notification(s) as read here and on GitHub
+              </td>
+            </tr>
+            <tr>
+              <td class="keys">
                 <div class="key">o</div> or <div class="key">Enter</div>
               </td>
               <td>

--- a/app/views/notifications/_notification.html.erb
+++ b/app/views/notifications/_notification.html.erb
@@ -16,7 +16,7 @@
     <%= octicon notification_icon(notification.subject_type), :height => 16 %>
   </td>
   <td class='notification-subject'>
-    <%= link_to notification.subject_title, notification.web_url, target: '_blank', class: 'link', onclick: "markAsRead(#{notification.id})" %>
+    <%= link_to notification.subject_title, notification.web_url, target: '_blank', class: 'link', onclick: "markRead(#{notification.id})" %>
   </td>
   <% unless params[:repo].present? %>
   <td class='notification-repo'>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -39,6 +39,7 @@
           <% end %>
           <%= archive_selected_button("btn btn-default hidden") %>
           <%= mute_selected_button("btn btn-default hidden") %>
+          <%= mark_read_selected_button("btn btn-default hidden") %>
           <%= render 'filter-list' %>
         </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
       post :archive_selected
       post :sync
       post :mute_selected
+      post :mark_read_selected
     end
 
     member do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,7 +20,7 @@ Rails.application.routes.draw do
 
     member do
       get :star
-      get :mark_as_read
+      get :mark_read
     end
   end
 

--- a/test/controllers/notifications_controller_test.rb
+++ b/test/controllers/notifications_controller_test.rb
@@ -120,7 +120,7 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
 
     sign_in_as(@user)
 
-    get "/notifications/#{notification.id}/mark_as_read"
+    get "/notifications/#{notification.id}/mark_read"
     assert_response :ok
 
     refute notification.reload.unread?

--- a/test/models/notification_test.rb
+++ b/test/models/notification_test.rb
@@ -13,31 +13,31 @@ class NotificationTest < ActiveSupport::TestCase
     assert notification.ignore_thread
   end
 
-  test 'mark_as_read updates the github thread' do
+  test 'mark_read updates the github thread' do
     notification = notifications(:unreadone)
     notification.user.stubs(:github_client).returns(mock {
       expects(:mark_thread_as_read).with(notification.github_id, read: true).returns true
     })
-    notification.mark_as_read(update_github: true)
+    notification.mark_read(update_github: true)
     refute notification.reload.unread?
   end
 
-  test 'mark_as_read does not change updated_at' do
+  test 'mark_read does not change updated_at' do
     notification = notifications(:unreadone)
     expected_updated_at = notification.updated_at
-    notification.mark_as_read
+    notification.mark_read
     assert_equal expected_updated_at, notification.reload.updated_at
   end
 
-  test 'mark_as_read turns unread to false' do
+  test 'mark_read turns unread to false' do
     notification = notifications(:unreadone)
-    notification.mark_as_read
+    notification.mark_read
     refute notification.reload.unread?
   end
 
-  test 'mark_as_read does not update github when update_github:false' do
+  test 'mark_read does not update github when update_github:false' do
     # the real assertion here is that no http request is made
-    notifications(:unreadone).mark_as_read
+    notifications(:unreadone).mark_read
   end
 
   test 'mute ignores the thread and marks it as read' do


### PR DESCRIPTION
This adds the ability to manually update notifications marking them as read on both Octobox and  GitHub.  

My motivation for this is for times when a bunch of automated PRs are generated and I know I don't need to actually look at them.  However, I don't want to mute them because I still want to see future activity.

I also suspect that this will be more useful for others now that we are limiting syncs to 500 notifications.  This relates to #230

![mark_read_bigger](https://cloud.githubusercontent.com/assets/233500/21995193/21eb3c2c-dbe9-11e6-8a0d-94a56e1e18b3.gif)
