### PR TITLE
Fix configuration for rubucop to be compliant with new version

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -716,7 +716,7 @@ Style/LineEndConcatenation:
                  line end.
   Enabled: false
 
-Style/MethodCallParentheses:
+Style/MethodCallWithoutArgsParentheses:
   Description: 'Do not use parentheses for method calls with no arguments.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-args-no-parens'
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ end
 group :development do
   gem 'web-console'
   gem 'listen', '~> 3.0.5'
+  gem 'rubocop', require: false
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,6 +49,7 @@ GEM
     addressable (2.5.0)
       public_suffix (~> 2.0, >= 2.0.2)
     arel (7.1.4)
+    ast (2.3.0)
     autoprefixer-rails (6.6.1)
       execjs
     bootstrap-sass (3.3.7)
@@ -156,11 +157,14 @@ GEM
     omniauth-oauth2 (1.4.0)
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
+    parser (2.3.3.1)
+      ast (~> 2.2)
     pg (0.19.0)
     pg_search (2.0.1)
       activerecord (>= 4.2)
       activesupport (>= 4.2)
       arel (>= 6)
+    powerpack (0.1.1)
     public_suffix (2.0.5)
     puma (3.6.2)
     rack (2.0.1)
@@ -194,10 +198,18 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
+    rainbow (2.2.1)
     rake (12.0.0)
     rb-fsevent (0.9.8)
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
+    rubocop (0.47.0)
+      parser (>= 2.3.3.1, < 3.0)
+      powerpack (~> 0.1)
+      rainbow (>= 1.99.1, < 3.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-progressbar (1.8.1)
     safe_yaml (1.0.4)
     sass (3.4.23)
     sassc (1.11.1)
@@ -243,6 +255,7 @@ GEM
       thread_safe (~> 0.1)
     uglifier (3.0.4)
       execjs (>= 0.3.0, < 3)
+    unicode-display_width (1.1.3)
     web-console (3.4.0)
       actionview (>= 5.0)
       activemodel (>= 5.0)
@@ -283,6 +296,7 @@ DEPENDENCIES
   rails-controller-testing
   rails_safe_tasks
   rake (~> 12.0)
+  rubocop
   sassc-rails
   simplecov
   spring


### PR DESCRIPTION
I noticed that running rubocop was producing an exception related to a change in supported methods in the rubocop.yml. This updates that out so that it will run without exception. 

```shell
Error: The `Style/MethodCallParentheses` cop has been renamed to `Style/MethodCallWithoutArgsParentheses`.
(obsolete configuration found in /Users/michaelrauh/Dev/octobox/.rubocop.yml, please update it)
```