### PR TITLE
Allow optional access restriction to Octobox

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,17 @@ PERSONAL_ACCESS_TOKENS_ENABLED=1
 
 Once that is set, users can set a personal access token on the Settings page (found on the user drop-down menu).
 
+## Limiting Access
+You can restrict access to your Octobox instance, and only allow members or a GitHub organization or team.  To limit access set the environment variable
+`RESTRICTED_ACCESS_ENABLED=1` then set either `GITHUB_ORGANIZATION_ID=<org_id_number>` `GITHUB_TEAM_ID=<team_id_number>`.
+
+You can get an organization's id with this curl command:
+`curl https://api.github.com/orgs/<org_name>`
+
+To get a team's id:
+`curl https://api.github.com/orgs/<org_name>/teams`.
+You must be authenticated with access to the org. This will show you a list of the org's teams. Find your team on the list and copy its id
+
 ## Development
 
 The source code is hosted at [GitHub](https://github.com/octobox/octobox).

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 class SessionsController < ApplicationController
   skip_before_action :authenticate_user!
+  before_action :authorize_access!, only: :create
 
   def new
     redirect_to '/auth/github'
   end
 
   def create
-    auth_hash = request.env['omniauth.auth']
-    user      = User.find_by_auth_hash(auth_hash) || User.new
+    user = User.find_by_auth_hash(auth_hash) || User.new
 
     user.assign_from_auth_hash(auth_hash)
     user.sync_notifications
@@ -25,5 +25,51 @@ class SessionsController < ApplicationController
   def failure
     flash[:error] = 'There was a problem authenticating with GitHub, please try again.'
     redirect_to root_path
+  end
+
+  private
+
+  def auth_hash
+    @auth_hash ||= request.env['omniauth.auth']
+  end
+
+  def authorize_access!
+    return true unless Octobox.restricted_access_enabled?
+
+    client = Octokit::Client.new(access_token: auth_hash.credentials.token)
+    nickname = auth_hash.info.nickname
+
+    return true if organization_member?(client, nickname) || team_member?(client, nickname)
+
+    flash[:error] = 'Access denied.'
+    redirect_to root_path
+  end
+
+  def organization_member?(client, nickname)
+    return false unless ENV['GITHUB_ORGANIZATION_ID'].present?
+
+    begin
+      client.organization_member?(
+        ENV['GITHUB_ORGANIZATION_ID'].to_i,
+        nickname,
+        headers: { 'Cache-Control' => 'no-cache, no-store' }
+      )
+    rescue Octokit::Error
+      false
+    end
+  end
+
+  def team_member?(client, nickname)
+    return false unless ENV['GITHUB_TEAM_ID'].present?
+
+    begin
+      client.team_member?(
+        ENV['GITHUB_TEAM_ID'].to_i,
+        nickname,
+        headers: { 'Cache-Control' => 'no-cache, no-store' }
+      )
+    rescue Octokit::Error
+      false
+    end
   end
 end

--- a/config/initializers/octobox_config.rb
+++ b/config/initializers/octobox_config.rb
@@ -1,5 +1,5 @@
 module Octobox
-  class <<self
+  class << self
     def personal_access_tokens_enabled
       @personal_access_tokens_enabled || ENV['PERSONAL_ACCESS_TOKENS_ENABLED'].present?
     end
@@ -28,5 +28,14 @@ module Octobox
       end
     end
     attr_writer :max_notifications_to_sync
+
+    def restricted_access_enabled
+      @restricted_access_enabled || ENV['RESTRICTED_ACCESS_ENABLED'].present?
+    end
+    attr_writer :restricted_access_enabled
+
+    def restricted_access_enabled?
+      restricted_access_enabled
+    end
   end
 end

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -27,7 +27,61 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     OmniAuth.config.mock_auth[:github].uid = users(:andrew).github_id
 
     post '/auth/github/callback'
-    assert_requested  @notifications_request, times: 2
+    assert_requested @notifications_request, times: 2
+  end
+
+  test 'POST #create redirects to the root_path with an error message if they are not an org member' do
+    user = users(:andrew)
+    OmniAuth.config.mock_auth[:github].uid           = user.github_id
+    OmniAuth.config.mock_auth[:github].info.nickname = user.github_login
+
+    stub_restricted_access_enabled
+    stub_env('GITHUB_ORGANIZATION_ID', value: 1)
+    stub_organization_membership_request(organization_id: 1, login: user.github_login, successful: false)
+
+    post '/auth/github/callback'
+    assert_redirected_to root_path
+    assert_equal 'Access denied.', flash[:error]
+  end
+
+  test 'POST #create redirects to the root_path with an error message if they are not an team member' do
+    user = users(:andrew)
+    OmniAuth.config.mock_auth[:github].uid           = user.github_id
+    OmniAuth.config.mock_auth[:github].info.nickname = user.github_login
+
+    stub_restricted_access_enabled
+    stub_env('GITHUB_TEAM_ID', value: 1)
+    stub_team_membership_request(team_id: 1, login: user.github_login, successful: false)
+
+    post '/auth/github/callback'
+    assert_redirected_to root_path
+    assert_equal 'Access denied.', flash[:error]
+  end
+
+  test 'POST #create is successful if the user is an org member' do
+    user = users(:andrew)
+    OmniAuth.config.mock_auth[:github].uid           = user.github_id
+    OmniAuth.config.mock_auth[:github].info.nickname = user.github_login
+
+    stub_restricted_access_enabled
+    stub_env('GITHUB_ORGANIZATION_ID', value: 1)
+    stub_organization_membership_request(organization_id: 1, login: user.github_login, successful: true)
+
+    post '/auth/github/callback'
+    assert_redirected_to root_path
+  end
+
+  test 'POST #create is successful if the user is a team member' do
+    user = users(:andrew)
+    OmniAuth.config.mock_auth[:github].uid           = user.github_id
+    OmniAuth.config.mock_auth[:github].info.nickname = user.github_login
+
+    stub_restricted_access_enabled
+    stub_env('GITHUB_TEAM_ID', value: 1)
+    stub_team_membership_request(team_id: 1, login: user.github_login, successful: true)
+
+    post '/auth/github/callback'
+    assert_redirected_to root_path
   end
 
   test 'GET #destroy redirects to /' do

--- a/test/support/stub_helper.rb
+++ b/test/support/stub_helper.rb
@@ -1,4 +1,31 @@
 module StubHelper
+  def stub_env(variable, value:)
+    ENV.stubs(:[])
+    ENV.stubs(:[]).with(variable).returns(value.to_s)
+  end
+
+  def stub_organization_membership_request(organization_id:, login:, successful:)
+    membership_url = %r{https://api.github.com/organizations/#{organization_id}/members/#{login}}
+
+    headers          = { 'Content-Type' => 'application/json', 'Cache-Control' => 'no-cach, no-store' }
+    default_response = { body: nil, headers: headers }
+
+    response = successful ? default_response.merge(status: 204) : default_response.merge(status: 404)
+
+    stub_request(:get, membership_url).to_return(response)
+  end
+
+  def stub_team_membership_request(team_id:, login:, successful:)
+    membership_url = %r{https://api.github.com/teams/#{team_id}/members/#{login}}
+
+    headers          = { 'Content-Type' => 'application/json', 'Cache-Control' => 'no-cach, no-store' }
+    default_response = { body: nil, headers: headers }
+
+    response = successful ? default_response.merge(status: 204) : default_response.merge(status: 404)
+
+    stub_request(:get, membership_url).to_return(response)
+  end
+
   def stub_notifications_request(url: nil, body: nil, extra_headers: {})
     url ||= %r{https://api.github.com/notifications}
     body     ||= file_fixture('notifications.json')
@@ -27,5 +54,9 @@ module StubHelper
 
   def stub_minimum_refresh_interval(value = 0)
     Octobox.stubs(:minimum_refresh_interval).returns(value)
+  end
+
+  def stub_restricted_access_enabled(value: true)
+    Octobox.stubs(:restricted_access_enabled).returns(value)
   end
 end


### PR DESCRIPTION
If you are running a private Octobox instance for your company, you may want to limit it to a GitHub organization or team.

This PR allows you to turn on restricted access via environment variables so that if you don't want someone to have access to your Octobox instance they can't.

This requires the use of the `read:org` scope to check for org and team membership.

Let me know what you think!