### PR TITLE
Enable web concurrency for Octobox in production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,4 +45,5 @@ group :production do
   gem 'lograge'
   gem 'rails_safe_tasks'
   gem 'bugsnag'
+  gem 'puma_worker_killer'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,7 @@ GEM
     faraday (0.10.1)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.17)
+    get_process_mem (0.2.1)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     hashdiff (0.3.2)
@@ -167,6 +168,9 @@ GEM
     powerpack (0.1.1)
     public_suffix (2.0.5)
     puma (3.6.2)
+    puma_worker_killer (0.0.7)
+      get_process_mem (~> 0.2)
+      puma (>= 2.7, < 4)
     rack (2.0.1)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -292,6 +296,7 @@ DEPENDENCIES
   pg
   pg_search
   puma
+  puma_worker_killer
   rails (= 5.0.1)
   rails-controller-testing
   rails_safe_tasks

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: rails server
+web: bundle exec puma -C config/puma.rb

--- a/app.json
+++ b/app.json
@@ -18,6 +18,10 @@
       "description": "Minimum value allowed for a user to set auto-refresh.  Setting to 0 means this is disabled.",
       "value": "10"
     }
+    "WEB_CONCURRENCY": {
+      "description": "Specifies the number of `workers` to boot in clustered mode.",
+      "value": "2"
+    }
   },
   "addons": [
     "heroku-postgresql",

--- a/config/initializers/puma_worker_killer.rb
+++ b/config/initializers/puma_worker_killer.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+if Rails.env.production?
+  PumaWorkerKiller.config do |config|
+    config.ram           = Integer(ENV['DYNO_RAM'] || 512) # mb
+    config.frequency     = 5    # seconds
+    config.percent_usage = 0.98
+    config.rolling_restart_frequency = 6 * 3600 # 6 hours in seconds
+  end
+  PumaWorkerKiller.start
+end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -21,7 +21,7 @@ environment ENV.fetch("RAILS_ENV") { "development" }
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
 #
-# workers ENV.fetch("WEB_CONCURRENCY") { 2 }
+workers ENV.fetch("WEB_CONCURRENCY") { 1 }
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code
@@ -30,7 +30,7 @@ environment ENV.fetch("RAILS_ENV") { "development" }
 # you need to make sure to reconnect any threads in the `on_worker_boot`
 # block.
 #
-# preload_app!
+preload_app!
 
 # The code in the `on_worker_boot` will be called if you are using
 # clustered mode by specifying a number of `workers`. After each worker
@@ -39,9 +39,9 @@ environment ENV.fetch("RAILS_ENV") { "development" }
 # or connections that may have been created at application boot, Ruby
 # cannot share connections between processes.
 #
-# on_worker_boot do
-#   ActiveRecord::Base.establish_connection if defined?(ActiveRecord)
-# end
+on_worker_boot do
+  ActiveRecord::Base.establish_connection if defined?(ActiveRecord)
+end
 
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart


### PR DESCRIPTION
This enables concurrency in the application for production, and allows us to kill puma workers on a rolling restart if they start taking up too much memory.

Thoughts?