### PR TITLE
Fix type in environment variable interpolation for GITHUB_ env

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -54,7 +54,7 @@ class SessionsController < ApplicationController
   end
 
   def member?(client, nickname, type:)
-    id = ENV["GITHUB_#{type.to_s.upcase}_ID"]
+    id = ENV["GITHUB_#{type.to_s.upcase}]_ID"]
     return false unless id.present?
 
     begin

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -54,7 +54,7 @@ class SessionsController < ApplicationController
   end
 
   def member?(client, nickname, type:)
-    id = ENV["GITHUB_#{type.to_s.upcase}]_ID"]
+    id = ENV["GITHUB_#{type.to_s.upcase}_ID"]
     return false unless id.present?
 
     begin

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -69,6 +69,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
 
     post '/auth/github/callback'
     assert_redirected_to root_path
+    assert_nil flash[:error]
   end
 
   test 'POST #create is successful if the user is a team member' do
@@ -82,6 +83,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
 
     post '/auth/github/callback'
     assert_redirected_to root_path
+    assert_nil flash[:error]
   end
 
   test 'GET #destroy redirects to /' do


### PR DESCRIPTION
For some reason the tests didn't pick up on this. Will need to investigate.

**Update:** turns out no matter if we failed our not we redirect to root. I've added tests to make sure there isn't a `flash[:error]` on redirect.