### PR TITLE
Pin Controls on Mobile

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -97,7 +97,7 @@ html {
     display: flex;
     position: relative;
     margin-left: 120px;
-    margin-top: -34px;
+    margin-top: -33.5px;
     > .btn-group {
       display: flex;
       overflow-x: scroll;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -93,6 +93,16 @@ html {
       padding-right: 0;
     }
   }
+  .filter-options {
+    display: flex;
+    position: relative;
+    margin-left: 120px;
+    margin-top: -34px;
+    > .btn-group {
+      display: flex;
+      overflow-x: scroll;
+    }
+  }
 }
 
 .turbolinks-progress-bar {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -73,6 +73,21 @@ html {
   .flex-container {
     .flex-main & {
       padding-left: 15px;
+      overflow-y: hidden;
+      height: 100%;
+      > .panel {
+        height: 100%;
+        overflow-y: scroll;
+        > .panel-heading {
+          position: absolute;
+          z-index: 1;
+          right: 16px;
+          left: 16px;
+        }
+        > .table {
+          margin-top: 46px;
+        }
+      }
     }
     .flex-sidebar & {
       padding-right: 0;


### PR DESCRIPTION
This approach seems to work pretty nicely for #243, until you start adding a bunch of filters. How should we best handle that case? We could adjust the styling dynamically using js to account for the height of the control bar, or maybe there is a flex-based solution we can try?

![c5nwxbtco3](https://cloud.githubusercontent.com/assets/816517/22092183/c8b88028-ddc9-11e6-872f-5399d51d047b.gif)
