### PR TITLE
License notice

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -183,3 +183,8 @@ To get a team's id:
 `curl https://api.github.com/orgs/<org_name>/teams`.
 You must be authenticated with access to the org. This will show you a list of the org's teams. Find your team on the list and copy its id
 
+## Source Link for Modified Code
+
+If you have modified the Octobox code in any way, in order to comply with the AGPLv3 license, you must link to the modified source.  You
+can do this by setting the `SOURCE_REPO` environment variable to the url of a GitHub repo with the modified source.  For instance, if 
+you run this from a fork in the 'NotOctobox' org, you would set `SOURCE_REPO=https://github.com/NotOctobox/octobox`.

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -60,6 +60,10 @@ html {
   }
 }
 
+.footer {
+  text-align: center;
+}
+
 @media (max-width: $screen-sm-max) {
   .flex-container {
     .flex-main & {
@@ -539,3 +543,4 @@ td.keys {
 .spinning{
   animation: spin 1s infinite steps(90);
 }
+

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -29,4 +29,8 @@ module ApplicationHelper
   def menu_separator(custom_class=nil)
     "<li class='divider #{custom_class}'></li>".html_safe
   end
+
+  def copyright_message
+    "© 2017 Andrew Nesbitt, <a href='#{Octobox.source_repo}'>source</a> available under <a href='#{Octobox.source_repo}/blob/master/LICENSE.txt'>AGPL 3.0</a>".html_safe
+  end
 end

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,0 +1,1 @@
+<div class="footer"><%= copyright_message %></div>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -83,6 +83,8 @@
       <div class="text-center visible-sm-block visible-md-block visible-lg-block visible-xl-block">
         <%= paginate @notifications %>
       </div>
+
+      <%= render 'layouts/footer' %>
     </div>
   </div>
 </div>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -16,4 +16,5 @@
     </div>
   </div>
 </div>
+<%= render 'layouts/footer'%>
 <script async defer src="https://buttons.github.io/buttons.js"></script>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -50,4 +50,5 @@
       <%= link_to 'Delete my Octobox account', current_user, method: :delete, class: 'btn btn-danger', data: { confirm: 'Are you sure you want to do this?' } %>
     </div>
   </div>
+  <%= render 'layouts/footer' %>
 </div>

--- a/config/initializers/octobox_config.rb
+++ b/config/initializers/octobox_config.rb
@@ -37,5 +37,11 @@ module Octobox
     def restricted_access_enabled?
       restricted_access_enabled
     end
+
+    def source_repo
+      @source_repo || ENV['SOURCE_REPO'] || 'https://github.com/octobox/octobox'
+    end
+    attr_writer :source_repo
+
   end
 end


### PR DESCRIPTION
closes #278

This adds the license notice "© 2017 Andrew Nesbitt, [source](https://github.com/octobox/octobox) available under [AGPL 3.0](https://github.com/octobox/octobox/blob/master/LICENSE.txt)"  to the bottom of each page.  It also adds a `SOURCE_REPO` configuration option that can be used to link to an alternate repo in case it is run with modified source code.

My first choice for the layout was to render the footer at the [bottom of application.html.erb](https://github.com/WillAbides/octobox/blob/fa42c985c68ecd787d0f5fe08ffb9cf9bbfed3ed/app/views/layouts/application.html.erb#L42), but I couldn't find a good way to do that without it stealing real estate from notifications.  That would get quite annoying on mobile.  Instead I rendered it at the bottom of `notifications/index.html.erb` as well as `pages/home.html.erb` and `users/edit.html.erb`.

Logged Out:
![2017-01-21 at 12 43 pm](https://cloud.githubusercontent.com/assets/233500/22176784/31707ba2-dfd7-11e6-8403-a580c083ac91.png)

Notifications:
![2017-01-21 at 12 40 pm](https://cloud.githubusercontent.com/assets/233500/22176773/efe391a6-dfd6-11e6-854a-139829d1623f.png)

User Settings:
![2017-01-21 at 12 57 pm](https://cloud.githubusercontent.com/assets/233500/22176887/2ad52cdc-dfd9-11e6-8fc4-b7c7eb0547ae.png)

