### PR TITLE
Recognize contributors in the copyright notice

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -64,6 +64,25 @@ html {
   text-align: center;
 }
 
+.footer-expendable {
+  display: inline-block;
+}
+
+.footer-data {
+  width: 30%;
+  display:inline-block;
+}
+
+@media (max-width: $screen-xs-max) {
+  .footer-data {
+    width: unset;
+    display: block;
+  }
+  .footer-expendable {
+    display: none;
+  }
+}
+
 @media (max-width: $screen-sm-max) {
   .flex-container {
     .flex-main & {

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -30,7 +30,15 @@ module ApplicationHelper
     "<li class='divider #{custom_class}'></li>".html_safe
   end
 
+  def license_message
+    source_link = "<a href='#{Octobox.source_repo}'>Source</a>"
+    license_link = "<a href='#{Octobox.source_repo}/blob/master/LICENSE.txt'>AGPL 3.0</a>"
+    "#{source_link} available under #{license_link}".html_safe
+  end
+
   def copyright_message
-    "© 2017 Andrew Nesbitt, <a href='#{Octobox.source_repo}'>source</a> available under <a href='#{Octobox.source_repo}/blob/master/LICENSE.txt'>AGPL 3.0</a>".html_safe
+    et_al = Octobox.contributors ?
+      "<a href='#' data-toggle='modal' data-target='#et-al'>et al</a>" : 'et al'
+    "© 2017 Andrew Nesbitt, #{et_al}".html_safe
   end
 end

--- a/app/views/layouts/_et-al.html.erb
+++ b/app/views/layouts/_et-al.html.erb
@@ -1,0 +1,15 @@
+<div id="et-al" class="modal" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-sm" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+        <h4 class="modal-title">Octobox Contributors</h4>
+      </div>
+      <div class="modal-body">
+         <% Octobox.contributors.each do |contributor| %>
+            <div><a href="<%= contributor.html_url%>"><%= contributor.login %></a></div>
+          <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,1 +1,5 @@
-<div class="footer"><%= copyright_message %></div>
+<div class="footer text-muted">
+  <div class="footer-data"><p><%= copyright_message %></p></div>
+  <div class="footer-expendable"><%= octobox_icon %></div>
+  <div class="footer-data"><p><%= license_message %></p></div>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -41,3 +41,4 @@
     <%= yield %>
   </body>
 </html>
+<%= render 'layouts/et-al' %>

--- a/config/initializers/octobox_config.rb
+++ b/config/initializers/octobox_config.rb
@@ -43,5 +43,11 @@ module Octobox
     end
     attr_writer :source_repo
 
+    def contributors
+      @contributors ||= Octokit::Client.new(auto_paginate: true).contributors(Octokit::Repository.from_url(source_repo))
+    rescue
+      nil
+    end
+    attr_writer :contributors
   end
 end

--- a/test/controllers/notifications_controller_test.rb
+++ b/test/controllers/notifications_controller_test.rb
@@ -4,6 +4,7 @@ require 'test_helper'
 class NotificationsControllerTest < ActionDispatch::IntegrationTest
   setup do
     stub_notifications_request
+    stub_contributors
     @user = users(:andrew)
   end
 

--- a/test/fixtures/files/contributors.json
+++ b/test/fixtures/files/contributors.json
@@ -1,0 +1,42 @@
+[
+  {
+    "login": "andrew",
+    "id": 1060,
+    "avatar_url": "https://avatars.githubusercontent.com/u/1060?v=3",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/andrew",
+    "html_url": "https://github.com/andrew",
+    "followers_url": "https://api.github.com/users/andrew/followers",
+    "following_url": "https://api.github.com/users/andrew/following{/other_user}",
+    "gists_url": "https://api.github.com/users/andrew/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/andrew/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/andrew/subscriptions",
+    "organizations_url": "https://api.github.com/users/andrew/orgs",
+    "repos_url": "https://api.github.com/users/andrew/repos",
+    "events_url": "https://api.github.com/users/andrew/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/andrew/received_events",
+    "type": "User",
+    "site_admin": false,
+    "contributions": 262
+  },
+  {
+    "login": "tarebyte",
+    "id": 564113,
+    "avatar_url": "https://avatars.githubusercontent.com/u/564113?v=3",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/tarebyte",
+    "html_url": "https://github.com/tarebyte",
+    "followers_url": "https://api.github.com/users/tarebyte/followers",
+    "following_url": "https://api.github.com/users/tarebyte/following{/other_user}",
+    "gists_url": "https://api.github.com/users/tarebyte/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/tarebyte/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/tarebyte/subscriptions",
+    "organizations_url": "https://api.github.com/users/tarebyte/orgs",
+    "repos_url": "https://api.github.com/users/tarebyte/repos",
+    "events_url": "https://api.github.com/users/tarebyte/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/tarebyte/received_events",
+    "type": "User",
+    "site_admin": true,
+    "contributions": 151
+  }
+]

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -1,3 +1,5 @@
+require 'test_helper'
+
 class ApplicationHelperTest < ActionView::TestCase
   test "should return the correct bootstrap class for each type of flash" do
     assert_equal bootstrap_class_for(:success), 'alert-success'
@@ -5,5 +7,27 @@ class ApplicationHelperTest < ActionView::TestCase
     assert_equal bootstrap_class_for(:alert), 'alert-warning'
     assert_equal bootstrap_class_for(:notice), 'alert-info'
     assert_equal bootstrap_class_for(:foobar), 'foobar'
+  end
+
+  test 'copyright_message has no et al link when no contributors are found' do
+    Octobox.stubs(:contributors).returns(nil)
+    assert_equal '© 2017 Andrew Nesbitt, et al', copyright_message
+  end
+
+  test 'copyright_message has et al link' do
+    stub_contributors
+    assert_equal "© 2017 Andrew Nesbitt, <a href='#' data-toggle='modal' data-target='#et-al'>et al</a>", copyright_message
+  end
+
+  test 'license_message has correct link when SOURCE_REPO is not set' do
+    ENV.stubs(:[]).with('SOURCE_REPO').returns(nil)
+    expected_message = "<a href='https://github.com/octobox/octobox'>Source</a> available under <a href='https://github.com/octobox/octobox/blob/master/LICENSE.txt'>AGPL 3.0</a>"
+    assert_equal expected_message, license_message
+  end
+
+  test 'license_message has correct link when SOURCE_REPO is set' do
+    ENV.stubs(:[]).with('SOURCE_REPO').returns('https://github.com/foo/bar')
+    expected_message = "<a href='https://github.com/foo/bar'>Source</a> available under <a href='https://github.com/foo/bar/blob/master/LICENSE.txt'>AGPL 3.0</a>"
+    assert_equal expected_message, license_message
   end
 end

--- a/test/support/stub_helper.rb
+++ b/test/support/stub_helper.rb
@@ -59,4 +59,11 @@ module StubHelper
   def stub_restricted_access_enabled(value: true)
     Octobox.stubs(:restricted_access_enabled).returns(value)
   end
+
+  def stub_contributors(body: nil)
+    url = %r{https://api.github.com/repos/.+/.+/contributors.*}
+    body ||= file_fixture('contributors.json')
+    headers = { 'Content-Type' => 'application/json' }
+    stub_request(:get, url).to_return( status: 200, body: body, headers: headers)
+  end
 end


### PR DESCRIPTION
Following up on #284 based on [an article I was sent today](http://www.ebb.org/bkuhn/blog/2011/06/28/gilligans-island.html) about recognizing contributors in copyright notices.  This ads an 'et al' to the copyright notice which links to a modal with a list of contributors.  This also ads an octobox logo as a separator between the copyright notice and the license notice.  On very narrow screens, the octobox logo is removed and the copyright and license notices are on separate lines.

Contributors modal:

![2017-01-21 at 5 53 pm](https://cloud.githubusercontent.com/assets/233500/22178648/9a2d3876-e002-11e6-882d-8bb2b628c5b2.png)

Footer on a wide screen:

![2017-01-21 at 5 59 pm](https://cloud.githubusercontent.com/assets/233500/22178670/7b91712e-e003-11e6-8ccc-3060e5ff1f0e.png)

Footer on a narrow screen:

![2017-01-21 at 6 00 pm](https://cloud.githubusercontent.com/assets/233500/22178677/9e914406-e003-11e6-97d2-a50937bf1707.png)

