### PR TITLE
Fix race condition causing mute to not update

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -182,7 +182,7 @@ function mute() {
   if (getDisplayedRows().length === 0) return;
   if ( $(".js-table-notifications tr").length === 0 ) return;
   var ids = getIdsFromRows(getMarkedOrCurrentRows());
-  $.post( "/notifications/mute_selected", { 'id[]': ids}).done(resetCursorAfterRowsRemoved(ids));
+  $.post( "/notifications/mute_selected", { 'id[]': ids}).done(function() {resetCursorAfterRowsRemoved(ids)});
 }
 
 function markReadSelected() {
@@ -209,7 +209,7 @@ function toggleArchive() {
 
   var ids = getIdsFromRows(getMarkedOrCurrentRows());
 
-  $.post( "/notifications/archive_selected", { 'id[]': ids, 'value': value } ).done(resetCursorAfterRowsRemoved(ids));
+  $.post( "/notifications/archive_selected", { 'id[]': ids, 'value': value } ).done(function() {resetCursorAfterRowsRemoved(ids)});
 }
 
 function resetCursorAfterRowsRemoved(ids) {


### PR DESCRIPTION
Fixes #288

After muting or toggling archive, we weren't waiting for the call to complete before refreshing the page.  This caused a race condition.