### PR TITLE
Open contributer link in new tab

### DIFF
--- a/app/views/layouts/_et-al.html.erb
+++ b/app/views/layouts/_et-al.html.erb
@@ -7,7 +7,7 @@
       </div>
       <div class="modal-body">
          <% Octobox.contributors.each do |contributor| %>
-            <div><a href="<%= contributor.html_url%>"><%= contributor.login %></a></div>
+            <div><a href="<%= contributor.html_url%>" target="_blank"><%= contributor.login %></a></div>
           <% end %>
       </div>
     </div>


### PR DESCRIPTION
I added `target="_blank"` to open the contributer link in a new tab. 😄 