### PR TITLE
added apple icon support

### DIFF
--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,3 +1,15 @@
+<head>
+  <link rel="apple-touch-icon" sizes="57x57" href="/public/apple-icon-57x57.png">
+  <link rel="apple-touch-icon" sizes="60x60" href="/public/apple-icon-60x60.png">
+  <link rel="apple-touch-icon" sizes="72x72" href="/public/apple-icon-72x72.png">
+  <link rel="apple-touch-icon" sizes="76x76" href="/public/apple-icon-76x76.png">
+  <link rel="apple-touch-icon" sizes="114x114" href="/public/apple-icon-114x114.png">
+  <link rel="apple-touch-icon" sizes="120x120" href="/public/apple-icon-120x120.png">
+  <link rel="apple-touch-icon" sizes="144x144" href="/public/apple-icon-144x144.png">
+  <link rel="apple-touch-icon" sizes="152x152" href="/public/apple-icon-152x152.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="/public/apple-icon-180x180.png">
+</head>
+<body>
 <div class="jumbotron">
   <div class="container">
     <h1 class="text-center"><%= octobox_icon(80) %> Octobox</h1>
@@ -18,3 +30,4 @@
 </div>
 <%= render 'layouts/footer'%>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
+</body>


### PR DESCRIPTION
I'm not sure this is the correct way to do it, but I found that adding Octobox didn't add the icon to the little app picture. I've fixed that by adding a head to the file:

```
<head>
  <link rel="apple-touch-icon" sizes="57x57" href="/public/apple-icon-57x57.png">
  <link rel="apple-touch-icon" sizes="60x60" href="/public/apple-icon-60x60.png">
  <link rel="apple-touch-icon" sizes="72x72" href="/public/apple-icon-72x72.png">
  <link rel="apple-touch-icon" sizes="76x76" href="/public/apple-icon-76x76.png">
  <link rel="apple-touch-icon" sizes="114x114" href="/public/apple-icon-114x114.png">
  <link rel="apple-touch-icon" sizes="120x120" href="/public/apple-icon-120x120.png">
  <link rel="apple-touch-icon" sizes="144x144" href="/public/apple-icon-144x144.png">
  <link rel="apple-touch-icon" sizes="152x152" href="/public/apple-icon-152x152.png">
  <link rel="apple-touch-icon" sizes="180x180" href="/public/apple-icon-180x180.png">
</head>
```

Thanks.