### PR TITLE
Made source and licence open in tab

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -31,8 +31,8 @@ module ApplicationHelper
   end
 
   def license_message
-    source_link = "<a href='#{Octobox.config.source_repo}'>Source</a>"
-    license_link = "<a href='#{Octobox.config.source_repo}/blob/master/LICENSE.txt'>AGPL 3.0</a>"
+    source_link = "<a href='#{Octobox.config.source_repo}' target='_blank'>Source</a>"
+    license_link = "<a href='#{Octobox.config.source_repo}/blob/master/LICENSE.txt' target='_blank'>AGPL 3.0</a>"
     "#{source_link} available under #{license_link}".html_safe
   end
 

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -21,13 +21,13 @@ class ApplicationHelperTest < ActionView::TestCase
 
   test 'license_message has correct link when SOURCE_REPO is not set' do
     ENV.stubs(:[]).with('SOURCE_REPO').returns(nil)
-    expected_message = "<a href='https://github.com/octobox/octobox'>Source</a> available under <a href='https://github.com/octobox/octobox/blob/master/LICENSE.txt' target='_blank'>AGPL 3.0</a>"
+    expected_message = "<a href='https://github.com/octobox/octobox' target='_blank'>Source</a> available under <a href='https://github.com/octobox/octobox/blob/master/LICENSE.txt' target='_blank'>AGPL 3.0</a>"
     assert_equal expected_message, license_message
   end
 
   test 'license_message has correct link when SOURCE_REPO is set' do
     ENV.stubs(:[]).with('SOURCE_REPO').returns('https://github.com/foo/bar')
-    expected_message = "<a href='https://github.com/foo/bar'>Source</a> available under <a href='https://github.com/foo/bar/blob/master/LICENSE.txt' target='_blank'>AGPL 3.0</a>"
+    expected_message = "<a href='https://github.com/foo/bar' target='_blank'>Source</a> available under <a href='https://github.com/foo/bar/blob/master/LICENSE.txt' target='_blank'>AGPL 3.0</a>"
     assert_equal expected_message, license_message
   end
 end

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -21,13 +21,13 @@ class ApplicationHelperTest < ActionView::TestCase
 
   test 'license_message has correct link when SOURCE_REPO is not set' do
     ENV.stubs(:[]).with('SOURCE_REPO').returns(nil)
-    expected_message = "<a href='https://github.com/octobox/octobox'>Source</a> available under <a href='https://github.com/octobox/octobox/blob/master/LICENSE.txt'>AGPL 3.0</a>"
+    expected_message = "<a href='https://github.com/octobox/octobox'>Source</a> available under <a href='https://github.com/octobox/octobox/blob/master/LICENSE.txt' target='_blank'>AGPL 3.0</a>"
     assert_equal expected_message, license_message
   end
 
   test 'license_message has correct link when SOURCE_REPO is set' do
     ENV.stubs(:[]).with('SOURCE_REPO').returns('https://github.com/foo/bar')
-    expected_message = "<a href='https://github.com/foo/bar'>Source</a> available under <a href='https://github.com/foo/bar/blob/master/LICENSE.txt'>AGPL 3.0</a>"
+    expected_message = "<a href='https://github.com/foo/bar'>Source</a> available under <a href='https://github.com/foo/bar/blob/master/LICENSE.txt' target='_blank'>AGPL 3.0</a>"
     assert_equal expected_message, license_message
   end
 end


### PR DESCRIPTION
```
source_link = "<a href='#{Octobox.config.source_repo}' target='_blank'>Source</a>"
    license_link = "<a href='#{Octobox.config.source_repo}/blob/master/LICENSE.txt' target='_blank'>AGPL 3.0</a>"
```

I added`target='_blank'` to the source and license link. I believe this is the way to do it, but note the standard way is `target="_blank"`. I did it with `'` as that is how the links are added, and using `"` would cause a conflict.

Thanks, hope this helps!