### PR TITLE
Add log to show when a user has synced their notifications

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -48,6 +48,7 @@ class User < ApplicationRecord
 
   def sync_notifications
     download_service.download
+    Rails.logger.info("\n\n\033[32m[#{Time.now}] INFO -- #{github_login} synced their notifications\033[0m\n\n")
   end
 
   def download_service


### PR DESCRIPTION
@WillAbides and I were chatting that it would be nice to be able to see when users sync their notifications in the server log for debugging purposes.

This adds a line to the logs that looks like this:

```
[2017-02-03 10:53:44 -0500] INFO -- tarebyte synced their notifications
```

Thoughts?