### PR TITLE
Add support for updating beyond page size

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -15,7 +15,8 @@ function getMarkedRows(unmarked) {
 }
 
 function getIdsFromRows(rows) {
-  return $.map(rows, function(row) {return $(row).find("input").val()})
+  return $('button.select_all').hasClass('all_selected') ?
+    'all' : $.map(rows, function(row) {return $(row).find("input").val()})
 }
 
 // returns true if there are any marked rows (or unmarked rows if unmarked is true)
@@ -39,7 +40,7 @@ function updateFavicon() {
       if ( old_link ) {
         $(old_link).remove();
       }
-      
+
       var canvas = document.createElement('canvas'),
         ctx,
         img = document.createElement('img'),
@@ -47,21 +48,21 @@ function updateFavicon() {
         txt = unread_count + '';
 
       link.id = "favicon-count";
-      
+
       if (canvas.getContext) {
         canvas.height = canvas.width = 16;
         ctx = canvas.getContext('2d');
         img.onload = function () {
           ctx.drawImage(this, 0, 0);
-          
+
           ctx.fillStyle = '#f93e00';
           var width = ctx.measureText(txt).width;
           ctx.fillRect(0, 0, width+2, 12);
-          
+
           ctx.font = 'bold 10px "helvetica", sans-serif';
           ctx.fillStyle = '#fff';
           ctx.fillText(txt, 1, 10);
-          
+
           link.href = canvas.toDataURL('image/png');
           document.body.appendChild(link);
         };
@@ -73,6 +74,7 @@ function updateFavicon() {
 
 document.addEventListener("turbolinks:load", function() {
   $('button.archive_selected, button.unarchive_selected').click(toggleArchive);
+  $('button.select_all').click(toggleSelectAll);
   $('button.mute_selected').click(mute);
   $('button.mark_read_selected').click(markReadSelected);
 
@@ -81,9 +83,14 @@ document.addEventListener("turbolinks:load", function() {
       var prop = hasMarkedRows(true) ? 'indeterminate' : 'checked';
       $(".js-select_all").prop(prop, true);
       $('button.archive_selected, button.unarchive_selected, button.mute_selected').removeClass('hidden');
+      if ( prop === 'checked' ) {
+        $('button.select_all').removeClass('hidden');
+      } else {
+        $('button.select_all').addClass('hidden');
+      }
     } else {
       $(".js-select_all").prop('checked', false);
-      $('button.archive_selected, button.unarchive_selected, button.mute_selected').addClass('hidden');
+      $('button.archive_selected, button.unarchive_selected, button.mute_selected, button.select_all').addClass('hidden');
     }
     var marked_unread_length = getMarkedRows().filter('.active').length;
     if ( marked_unread_length > 0 ) {
@@ -209,7 +216,14 @@ function toggleArchive() {
 
   var ids = getIdsFromRows(getMarkedOrCurrentRows());
 
-  $.post( "/notifications/archive_selected", { 'id[]': ids, 'value': value } ).done(function() {resetCursorAfterRowsRemoved(ids)});
+  $.post( "/notifications/archive_selected" + location.search, { 'id[]': ids, 'value': value } ).done(function() {resetCursorAfterRowsRemoved(ids)});
+}
+
+function toggleSelectAll() {
+  $.map($('button.select_all > span'), function( val, i ) {
+    $(val).toggleClass('bold')
+  });
+  $('button.select_all').toggleClass('all_selected')
 }
 
 function resetCursorAfterRowsRemoved(ids) {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -534,6 +534,10 @@ td.keys {
   .panel-footer {
     padding: 6px 8px;
   }
+
+  .bold {
+    font-weight: bold;
+  }
 }
 
 .select-all {
@@ -562,4 +566,3 @@ td.keys {
 .spinning{
   animation: spin 1s infinite steps(90);
 }
-

--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -65,7 +65,7 @@ module NotificationsHelper
   end
 
   def select_all_button(cur_selected, total)
-    button_tag(type: 'button', class: "select_all btn btn-default hidden") do
+    button_tag(type: 'button', class: "select_all btn btn-default hidden", 'data-toggle': "tooltip", 'data-placement': "top", 'title': "Number of items selected") do
       octicon('check', height: 16) +
         content_tag(:span, " #{cur_selected}", class: 'bold hidden-xs') +
         " |" +

--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -64,6 +64,15 @@ module NotificationsHelper
     function_button("#{action.capitalize} selected", 'checklist', "archive_toggle #{action}_selected")
   end
 
+  def select_all_button(cur_selected, total)
+    button_tag(type: 'button', class: "select_all btn btn-default hidden") do
+      octicon('check', height: 16) +
+        content_tag(:span, " #{cur_selected}", class: 'bold hidden-xs') +
+        " |" +
+        content_tag(:span, " #{total}", class: 'hidden-xs')
+    end if cur_selected < total
+  end
+
   def function_button(title, octicon, css_class)
     button_tag(type: 'button', class: "#{css_class} btn btn-default hidden") do
       octicon(octicon, height: 16) + content_tag(:span, " #{title}", class: 'hidden-xs')
@@ -84,7 +93,7 @@ module NotificationsHelper
 
   def filter_option(param, &block)
     if filters[param].present?
-      link_to root_path(filters.except(param)), class: 'btn btn-default' do
+      link_to root_path(filters.except(param)), class: "btn btn-default" do
         concat octicon('x', :height => 16)
         concat ' '
         concat block.call

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -35,6 +35,7 @@
           <label class="btn btn-default select-all" for="select_all">
             <input id="select_all" type="checkbox" class='js-select_all'>
           </label>
+          <%= select_all_button(@cur_selected, @total) %>
           <% end %>
           <%= link_to sync_notifications_path(filters), class: 'btn btn-default sync', 'data-toggle' => 'tooltip', 'data-placement' => 'bottom', 'data-turbolinks' => false, 'data-animation' => 'false', 'data-position' => 'bottom', 'title' => 'Refresh list', method: :post do %>
             <%= octicon 'sync', :height => 16 %>

--- a/test/controllers/notifications_controller_test.rb
+++ b/test/controllers/notifications_controller_test.rb
@@ -69,6 +69,37 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
     refute notification3.reload.archived?
   end
 
+  test 'archives all notifications' do
+    sign_in_as(@user)
+    notification1 = create(:notification, user: @user, archived: false)
+    notification2 = create(:notification, user: @user, archived: false)
+    notification3 = create(:notification, user: @user, archived: false)
+
+    post '/notifications/archive_selected', params: { id: ['all'], value: true }
+
+    assert_response :ok
+
+    assert notification1.reload.archived?
+    assert notification2.reload.archived?
+    assert notification3.reload.archived?
+  end
+
+  test 'archives respects current filters' do
+    sign_in_as(@user)
+    notification1 = create(:notification, user: @user, archived: false, unread: false)
+    notification2 = create(:notification, user: @user, archived: false)
+    notification3 = create(:notification, user: @user, archived: false)
+
+    post '/notifications/archive_selected', params: { status: true, id: ['all'], value: true }
+
+    assert_response :ok
+
+    refute notification1.reload.archived?
+    assert notification2.reload.archived?
+    assert notification3.reload.archived?
+  end
+
+
   test 'mutes multiple notifications' do
     sign_in_as(@user)
     notification1 = create(:notification, user: @user, archived: false)
@@ -88,6 +119,28 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
     refute notification3.reload.archived?
   end
 
+  test 'mutes all notifications in current scope' do
+    sign_in_as(@user)
+    Notification.destroy_all
+    notification1 = create(:notification, user: @user, archived: false)
+    notification2 = create(:notification, user: @user, archived: false)
+    notification3 = create(:notification, user: @user, archived: false)
+    User.any_instance.stubs(:github_client).returns(mock {
+      expects(:update_thread_subscription).with(notification1.github_id, ignored: true).returns true
+      expects(:update_thread_subscription).with(notification2.github_id, ignored: true).returns true
+      expects(:update_thread_subscription).with(notification3.github_id, ignored: true).returns true
+      expects(:mark_thread_as_read).with(notification1.github_id, read: true).returns true
+      expects(:mark_thread_as_read).with(notification2.github_id, read: true).returns true
+      expects(:mark_thread_as_read).with(notification3.github_id, read: true).returns true
+    })
+    post '/notifications/mute_selected', params: { id: ['all'] }
+    assert_response :ok
+
+    assert notification1.reload.archived?
+    assert notification2.reload.archived?
+    assert notification3.reload.archived?
+  end
+
   test 'marks read multiple notifications' do
     sign_in_as(@user)
     notification1 = create(:notification, user: @user, archived: false)
@@ -103,6 +156,25 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
     refute notification1.reload.unread?
     refute notification2.reload.unread?
     assert notification3.reload.unread?
+  end
+
+  test 'marks read all notifications' do
+    sign_in_as(@user)
+    Notification.destroy_all
+    notification1 = create(:notification, user: @user, archived: false)
+    notification2 = create(:notification, user: @user, archived: false)
+    notification3 = create(:notification, user: @user, archived: false)
+    User.any_instance.stubs(:github_client).returns(mock {
+      expects(:mark_thread_as_read).with(notification1.github_id, read: true).returns true
+      expects(:mark_thread_as_read).with(notification2.github_id, read: true).returns true
+      expects(:mark_thread_as_read).with(notification3.github_id, read: true).returns true
+    })
+    post '/notifications/mark_read_selected', params: { id: ['all'] }
+    assert_response :ok
+
+    refute notification1.reload.unread?
+    refute notification2.reload.unread?
+    refute notification3.reload.unread?
   end
 
   test 'toggles starred on a notification' do


### PR DESCRIPTION
<img width="943" alt="screen shot 2017-02-04 at 6 36 12 pm" src="https://cloud.githubusercontent.com/assets/4482399/22625023/d772fa02-eb3f-11e6-81a1-65eb35b2edd6.png">

Before this change you could select all visible items and update them
together, but if you wanted to update more than your current page
size, you had to select each page one at a time until you had finished
removing items from your current query.

Now you have the option to select beyond the set of currently visible
items on the page.