### PR TITLE
Click on row to select it

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -32,6 +32,14 @@ function getMarkedOrCurrentRows() {
   return hasMarkedRows() ? getMarkedRows() : getCurrentRow()
 }
 
+function moveCursorToClickedRow(event) {
+  // Don't event.preventDefault(), since we want the normal clicking behavior for links, starring, etc
+  oldCurrent = getCurrentRow();
+  target = $(this);
+  setRowCurrent(oldCurrent, false);
+  setRowCurrent(target, true);
+}
+
 function updateFavicon() {
   $.get( "/notifications/unread_count", function(data) {
     var unread_count = data["count"];
@@ -77,6 +85,7 @@ document.addEventListener("turbolinks:load", function() {
   $('button.select_all').click(toggleSelectAll);
   $('button.mute_selected').click(mute);
   $('button.mark_read_selected').click(markReadSelected);
+  $('tr.notification').click(moveCursorToClickedRow);
 
   $('input.archive, input.unarchive').change(function() {
     if ( hasMarkedRows() ) {


### PR DESCRIPTION
I find myself often doing this:

- visually skimming a list of notifications
- click an issue to browse
- come back to octobox and use x to select the row, and e to archive

When I do that though, the row I just clicked on isn't the current one, so I end up reading some unrelated (and possible unread) notification.

By adding a click handler for notification rows, this means that
clicking anywhere in the row, be it on a td or a link to an issue,
starring, the clicked row will be set as the new current.

Also worth mentioning this is consistent with how navigation works in gmail, when you click into something and come back, the message you just viewed is made the current.

I did not see any tests for javascript stuff, or I would have added one.