### PR TITLE
Rescue notification syncs so they dont interrupt other user syncs

### DIFF
--- a/lib/tasks/tasks.rake
+++ b/lib/tasks/tasks.rake
@@ -2,7 +2,11 @@ namespace :tasks do
   desc "Sync Notifications"
   task sync_notifications: :environment do
     User.find_each do |user|
-      user.sync_notifications
+      begin
+        user.sync_notifications
+      rescue Octokit::BadGateway, Octokit::ServiceUnavailable => e
+        STDERR.puts "Failed to sync notifications for #{user.github_login}\n#{e.class}\n#{e.message}"
+      end
     end
   end
 end


### PR DESCRIPTION
While syncing notifications, I noticed that if Github returns a 502/503 (which happens more often than you'd think), the entire sync tasks exits. This means that subsequent users don't sync, despite this being a transient thing.

<details>
<pre>
D, [2017-02-22T15:16:00.554654 #4] DEBUG -- :   Notification Load (1.2ms)  SELECT  "notifications".* FROM "notifications" WHERE "notifications"."user_id" = $1 AND "notifications"."unread" = $2 ORDER BY updated_at ASC LIMIT $3  [["user_id", 42], ["unread", true], ["LIMIT", 1]]
I, [2017-02-22T15:16:10.828925 #4]  INFO -- : ** [Bugsnag] Notifying https://notify.bugsnag.com of Octokit::BadGateway
rake aborted!
Octokit::BadGateway: GET https://api.github.com/notifications?all=true&per_page=100&since=2017-02-21T17%3A26%3A49Z: 502 - Server Error
/app/vendor/bundle/ruby/2.4.0/gems/octokit-4.6.2/lib/octokit/response/raise_error.rb:16:in `on_complete'
/app/vendor/bundle/ruby/2.4.0/gems/faraday-0.10.1/lib/faraday/response.rb:9:in `block in call'
/app/vendor/bundle/ruby/2.4.0/gems/faraday-0.10.1/lib/faraday/response.rb:61:in `on_complete'
/app/vendor/bundle/ruby/2.4.0/gems/faraday-0.10.1/lib/faraday/response.rb:8:in `call'
/app/vendor/bundle/ruby/2.4.0/gems/octokit-4.6.2/lib/octokit/middleware/follow_redirects.rb:73:in `perform_with_redirection'
/app/vendor/bundle/ruby/2.4.0/gems/octokit-4.6.2/lib/octokit/middleware/follow_redirects.rb:61:in `call'
/app/vendor/bundle/ruby/2.4.0/gems/faraday-0.10.1/lib/faraday/rack_builder.rb:139:in `build_response'
/app/vendor/bundle/ruby/2.4.0/gems/faraday-0.10.1/lib/faraday/connection.rb:377:in `run_request'
/app/vendor/bundle/ruby/2.4.0/gems/faraday-0.10.1/lib/faraday/connection.rb:140:in `get'
/app/vendor/bundle/ruby/2.4.0/gems/sawyer-0.8.1/lib/sawyer/agent.rb:94:in `call'
/app/vendor/bundle/ruby/2.4.0/gems/octokit-4.6.2/lib/octokit/connection.rb:154:in `request'
/app/app/services/download_service.rb:106:in `paginate'
/app/vendor/bundle/ruby/2.4.0/gems/octokit-4.6.2/lib/octokit/client/notifications.rb:27:in `notifications'
/app/app/services/download_service.rb:54:in `fetch_notifications'
/app/app/services/download_service.rb:69:in `fetch_read_notifications'
/app/app/services/download_service.rb:84:in `download'
/app/app/models/user.rb:51:in `sync_notifications'
/app/lib/tasks/tasks.rake:5:in `block (3 levels) in <top (required)>'
</pre>
</details>


cc @tarebyte 