### PR TITLE
Rename status to unread

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -6,10 +6,10 @@ class NotificationsController < ApplicationController
 
   def index
     scope = notifications_for_presentation
-    @types               = scope.distinct.group(:subject_type).count
-    @statuses            = scope.distinct.group(:unread).count
-    @reasons             = scope.distinct.group(:reason).count
-    @unread_repositories = scope.distinct.group(:repository_full_name).count
+    @types                 = scope.distinct.group(:subject_type).count
+    @unread_notifications  = scope.distinct.group(:unread).count
+    @reasons               = scope.distinct.group(:reason).count
+    @unread_repositories   = scope.distinct.group(:repository_full_name).count
     scope = current_notifications(scope)
     check_out_of_bounds(scope)
 
@@ -70,7 +70,7 @@ class NotificationsController < ApplicationController
   end
 
   def current_notifications(scope = notifications_for_presentation)
-    sub_scopes = [:repo, :reason, :type, :status, :owner]
+    sub_scopes = [:repo, :reason, :type, :unread, :owner]
     sub_scopes.each do |sub_scope|
       scope = scope.send(sub_scope, params[sub_scope]) if params[sub_scope].present?
     end

--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -20,7 +20,7 @@ module NotificationsHelper
   def filters
     {
       reason:   params[:reason],
-      status:   params[:status],
+      unread:   params[:unread],
       repo:     params[:repo],
       type:     params[:type],
       archive:  params[:archive],

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -21,7 +21,7 @@ class Notification < ApplicationRecord
   scope :repo,     ->(repo_name)    { where(repository_full_name: repo_name) }
   scope :type,     ->(subject_type) { where(subject_type: subject_type) }
   scope :reason,   ->(reason)       { where(reason: reason) }
-  scope :status,   ->(status)       { where(unread: status) }
+  scope :unread,   ->(unread)       { where(unread: unread) }
   scope :owner,    ->(owner_name)   { where(repository_owner_name: owner_name) }
 
   paginates_per 20

--- a/app/services/download_service.rb
+++ b/app/services/download_service.rb
@@ -62,7 +62,7 @@ class DownloadService
   end
 
   def fetch_read_notifications
-    oldest_unread = user.notifications.status(true).newest.last
+    oldest_unread = user.notifications.unread(true).newest.last
     if oldest_unread && oldest_unread.updated_at.respond_to?(:iso8601)
       headers = {cache_control: %w(no-store no-cache)}
       since = oldest_unread.updated_at - 1

--- a/app/views/notifications/_filter-list.html.erb
+++ b/app/views/notifications/_filter-list.html.erb
@@ -7,8 +7,8 @@
         <%= params[:reason].underscore.humanize %>
       <% end %>
 
-      <%= filter_option :status do %>
-        <%= (params[:status] === 'true'? 'Unread' : 'Read') %>
+      <%= filter_option :unread do %>
+        <%= (params[:unread] === 'true'? 'Unread' : 'Read') %>
       <% end %>
 
       <%= filter_option :repo do %>

--- a/app/views/notifications/_sidebar.html.erb
+++ b/app/views/notifications/_sidebar.html.erb
@@ -21,9 +21,9 @@
 
   <%= menu_separator %>
 
-  <% @statuses.each do |status, count| %>
-    <%= filter_link :status, status, count do %>
-      <% if status %>
+  <% @unread_notifications.each do |unread_notification, count| %>
+    <%= filter_link :unread, unread_notification, count do %>
+      <% if unread_notification %>
         <%= octicon 'mail', height: 16, class: 'sidebar-icon star-active' %>
         Unread
       <% else %>
@@ -33,7 +33,7 @@
 
     <% end %>
   <% end %>
-  <%= menu_separator unless @statuses.empty? %>
+  <%= menu_separator unless @unread_notifications.empty? %>
 
   <% @types.each do |type, count| %>
     <%= filter_link :type, type, count do %>

--- a/test/controllers/notifications_controller_test.rb
+++ b/test/controllers/notifications_controller_test.rb
@@ -90,7 +90,7 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
     notification2 = create(:notification, user: @user, archived: false)
     notification3 = create(:notification, user: @user, archived: false)
 
-    post '/notifications/archive_selected', params: { status: true, id: ['all'], value: true }
+    post '/notifications/archive_selected', params: { unread: true, id: ['all'], value: true }
 
     assert_response :ok
 

--- a/test/services/download_service_test.rb
+++ b/test/services/download_service_test.rb
@@ -29,7 +29,7 @@ class DownloadServiceTest < ActiveSupport::TestCase
     user = create(:morty)
     create(:notification, last_read_at: 5.days.ago, updated_at: 30.minutes.ago, user: user)
     # one second before oldest unread notification
-    unread_since =( user.notifications.status(true).first.updated_at - 1).iso8601
+    unread_since =( user.notifications.unread(true).first.updated_at - 1).iso8601
     download_service = DownloadService.new(user)
     stub_notifications_request(
       url: "https://api.github.com/notifications?all=true&per_page=100&since=#{unread_since}"
@@ -83,7 +83,7 @@ class DownloadServiceTest < ActiveSupport::TestCase
   test '#download handles no new notifications' do
     user = create(:morty)
     download_service = DownloadService.new(user)
-    unread_since =( user.notifications.status(true).first.updated_at - 1).iso8601
+    unread_since =( user.notifications.unread(true).first.updated_at - 1).iso8601
     stub_notifications_request(
       url: "https://api.github.com/notifications?all=true&per_page=100&since=#{unread_since}",
       body: ''


### PR DESCRIPTION
Changes things to reflect the state in the DB and make it more easily understood by endusers:
`https://octobox.shopify.io/?status=true` becomes `https://octobox.shopify.io/?unread=true`