### PR TITLE
Add open collective section to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,78 @@ Notifications are marked as read and disappear from the list as soon as you load
 
 Octobox adds an extra "archived" state to each notification so you can mark it as "done". If new activity happens on the thread/issue/pr, the next time you sync the app the relevant item will be unarchived and moved back into your inbox.
 
+## Backers
+
+Support us with a monthly donation and help us continue our activities. [Become a backer](https://opencollective.com/octobox#backer)
+
+<a href="https://opencollective.com/octobox/backer/0/website" target="_blank"><img src="https://opencollective.com/octobox/backer/0/avatar.svg"></a>
+<a href="https://opencollective.com/octobox/backer/1/website" target="_blank"><img src="https://opencollective.com/octobox/backer/1/avatar.svg"></a>
+<a href="https://opencollective.com/octobox/backer/2/website" target="_blank"><img src="https://opencollective.com/octobox/backer/2/avatar.svg"></a>
+<a href="https://opencollective.com/octobox/backer/3/website" target="_blank"><img src="https://opencollective.com/octobox/backer/3/avatar.svg"></a>
+<a href="https://opencollective.com/octobox/backer/4/website" target="_blank"><img src="https://opencollective.com/octobox/backer/4/avatar.svg"></a>
+<a href="https://opencollective.com/octobox/backer/5/website" target="_blank"><img src="https://opencollective.com/octobox/backer/5/avatar.svg"></a>
+<a href="https://opencollective.com/octobox/backer/6/website" target="_blank"><img src="https://opencollective.com/octobox/backer/6/avatar.svg"></a>
+<a href="https://opencollective.com/octobox/backer/7/website" target="_blank"><img src="https://opencollective.com/octobox/backer/7/avatar.svg"></a>
+<a href="https://opencollective.com/octobox/backer/8/website" target="_blank"><img src="https://opencollective.com/octobox/backer/8/avatar.svg"></a>
+<a href="https://opencollective.com/octobox/backer/9/website" target="_blank"><img src="https://opencollective.com/octobox/backer/9/avatar.svg"></a>
+<a href="https://opencollective.com/octobox/backer/10/website" target="_blank"><img src="https://opencollective.com/octobox/backer/10/avatar.svg"></a>
+<a href="https://opencollective.com/octobox/backer/11/website" target="_blank"><img src="https://opencollective.com/octobox/backer/11/avatar.svg"></a>
+<a href="https://opencollective.com/octobox/backer/12/website" target="_blank"><img src="https://opencollective.com/octobox/backer/12/avatar.svg"></a>
+<a href="https://opencollective.com/octobox/backer/13/website" target="_blank"><img src="https://opencollective.com/octobox/backer/13/avatar.svg"></a>
+<a href="https://opencollective.com/octobox/backer/14/website" target="_blank"><img src="https://opencollective.com/octobox/backer/14/avatar.svg"></a>
+<a href="https://opencollective.com/octobox/backer/15/website" target="_blank"><img src="https://opencollective.com/octobox/backer/15/avatar.svg"></a>
+<a href="https://opencollective.com/octobox/backer/16/website" target="_blank"><img src="https://opencollective.com/octobox/backer/16/avatar.svg"></a>
+<a href="https://opencollective.com/octobox/backer/17/website" target="_blank"><img src="https://opencollective.com/octobox/backer/17/avatar.svg"></a>
+<a href="https://opencollective.com/octobox/backer/18/website" target="_blank"><img src="https://opencollective.com/octobox/backer/18/avatar.svg"></a>
+<a href="https://opencollective.com/octobox/backer/19/website" target="_blank"><img src="https://opencollective.com/octobox/backer/19/avatar.svg"></a>
+<a href="https://opencollective.com/octobox/backer/20/website" target="_blank"><img src="https://opencollective.com/octobox/backer/20/avatar.svg"></a>
+<a href="https://opencollective.com/octobox/backer/21/website" target="_blank"><img src="https://opencollective.com/octobox/backer/21/avatar.svg"></a>
+<a href="https://opencollective.com/octobox/backer/22/website" target="_blank"><img src="https://opencollective.com/octobox/backer/22/avatar.svg"></a>
+<a href="https://opencollective.com/octobox/backer/23/website" target="_blank"><img src="https://opencollective.com/octobox/backer/23/avatar.svg"></a>
+<a href="https://opencollective.com/octobox/backer/24/website" target="_blank"><img src="https://opencollective.com/octobox/backer/24/avatar.svg"></a>
+<a href="https://opencollective.com/octobox/backer/25/website" target="_blank"><img src="https://opencollective.com/octobox/backer/25/avatar.svg"></a>
+<a href="https://opencollective.com/octobox/backer/26/website" target="_blank"><img src="https://opencollective.com/octobox/backer/26/avatar.svg"></a>
+<a href="https://opencollective.com/octobox/backer/27/website" target="_blank"><img src="https://opencollective.com/octobox/backer/27/avatar.svg"></a>
+<a href="https://opencollective.com/octobox/backer/28/website" target="_blank"><img src="https://opencollective.com/octobox/backer/28/avatar.svg"></a>
+<a href="https://opencollective.com/octobox/backer/29/website" target="_blank"><img src="https://opencollective.com/octobox/backer/29/avatar.svg"></a>
+
+
+## Sponsors
+
+Become a sponsor and get your logo on our README on Github with a link to your site. [Become a sponsor](https://opencollective.com/octobox#sponsor)
+
+<a href="https://opencollective.com/octobox/sponsor/0/website" target="_blank"><img src="https://opencollective.com/octobox/sponsor/0/avatar.svg"></a>
+<a href="https://opencollective.com/octobox/sponsor/1/website" target="_blank"><img src="https://opencollective.com/octobox/sponsor/1/avatar.svg"></a>
+<a href="https://opencollective.com/octobox/sponsor/2/website" target="_blank"><img src="https://opencollective.com/octobox/sponsor/2/avatar.svg"></a>
+<a href="https://opencollective.com/octobox/sponsor/3/website" target="_blank"><img src="https://opencollective.com/octobox/sponsor/3/avatar.svg"></a>
+<a href="https://opencollective.com/octobox/sponsor/4/website" target="_blank"><img src="https://opencollective.com/octobox/sponsor/4/avatar.svg"></a>
+<a href="https://opencollective.com/octobox/sponsor/5/website" target="_blank"><img src="https://opencollective.com/octobox/sponsor/5/avatar.svg"></a>
+<a href="https://opencollective.com/octobox/sponsor/6/website" target="_blank"><img src="https://opencollective.com/octobox/sponsor/6/avatar.svg"></a>
+<a href="https://opencollective.com/octobox/sponsor/7/website" target="_blank"><img src="https://opencollective.com/octobox/sponsor/7/avatar.svg"></a>
+<a href="https://opencollective.com/octobox/sponsor/8/website" target="_blank"><img src="https://opencollective.com/octobox/sponsor/8/avatar.svg"></a>
+<a href="https://opencollective.com/octobox/sponsor/9/website" target="_blank"><img src="https://opencollective.com/octobox/sponsor/9/avatar.svg"></a>
+<a href="https://opencollective.com/octobox/sponsor/10/website" target="_blank"><img src="https://opencollective.com/octobox/sponsor/10/avatar.svg"></a>
+<a href="https://opencollective.com/octobox/sponsor/11/website" target="_blank"><img src="https://opencollective.com/octobox/sponsor/11/avatar.svg"></a>
+<a href="https://opencollective.com/octobox/sponsor/12/website" target="_blank"><img src="https://opencollective.com/octobox/sponsor/12/avatar.svg"></a>
+<a href="https://opencollective.com/octobox/sponsor/13/website" target="_blank"><img src="https://opencollective.com/octobox/sponsor/13/avatar.svg"></a>
+<a href="https://opencollective.com/octobox/sponsor/14/website" target="_blank"><img src="https://opencollective.com/octobox/sponsor/14/avatar.svg"></a>
+<a href="https://opencollective.com/octobox/sponsor/15/website" target="_blank"><img src="https://opencollective.com/octobox/sponsor/15/avatar.svg"></a>
+<a href="https://opencollective.com/octobox/sponsor/16/website" target="_blank"><img src="https://opencollective.com/octobox/sponsor/16/avatar.svg"></a>
+<a href="https://opencollective.com/octobox/sponsor/17/website" target="_blank"><img src="https://opencollective.com/octobox/sponsor/17/avatar.svg"></a>
+<a href="https://opencollective.com/octobox/sponsor/18/website" target="_blank"><img src="https://opencollective.com/octobox/sponsor/18/avatar.svg"></a>
+<a href="https://opencollective.com/octobox/sponsor/19/website" target="_blank"><img src="https://opencollective.com/octobox/sponsor/19/avatar.svg"></a>
+<a href="https://opencollective.com/octobox/sponsor/20/website" target="_blank"><img src="https://opencollective.com/octobox/sponsor/20/avatar.svg"></a>
+<a href="https://opencollective.com/octobox/sponsor/21/website" target="_blank"><img src="https://opencollective.com/octobox/sponsor/21/avatar.svg"></a>
+<a href="https://opencollective.com/octobox/sponsor/22/website" target="_blank"><img src="https://opencollective.com/octobox/sponsor/22/avatar.svg"></a>
+<a href="https://opencollective.com/octobox/sponsor/23/website" target="_blank"><img src="https://opencollective.com/octobox/sponsor/23/avatar.svg"></a>
+<a href="https://opencollective.com/octobox/sponsor/24/website" target="_blank"><img src="https://opencollective.com/octobox/sponsor/24/avatar.svg"></a>
+<a href="https://opencollective.com/octobox/sponsor/25/website" target="_blank"><img src="https://opencollective.com/octobox/sponsor/25/avatar.svg"></a>
+<a href="https://opencollective.com/octobox/sponsor/26/website" target="_blank"><img src="https://opencollective.com/octobox/sponsor/26/avatar.svg"></a>
+<a href="https://opencollective.com/octobox/sponsor/27/website" target="_blank"><img src="https://opencollective.com/octobox/sponsor/27/avatar.svg"></a>
+<a href="https://opencollective.com/octobox/sponsor/28/website" target="_blank"><img src="https://opencollective.com/octobox/sponsor/28/avatar.svg"></a>
+<a href="https://opencollective.com/octobox/sponsor/29/website" target="_blank"><img src="https://opencollective.com/octobox/sponsor/29/avatar.svg"></a>
+
+
 ## Getting Started
 
 ### Octobox.io


### PR DESCRIPTION
I've setup an Open Collective page https://opencollective.com/octobox to see if the community is interested in contributing towards the support and hosting costs of Octobox and https://octobox.io, this PR adds the dynamic OpenCollective icons to show the supporters and sponsors of the project:

![screen shot 2017-04-07 at 2 48 42 pm](https://cloud.githubusercontent.com/assets/1060/24802948/901bdf06-1ba1-11e7-819e-6f9018782480.png)

Hosting costs currently run at $34/month on Heroku which support around 2,100 users and with almost half a million notifications indexed, my hope is that we can cover the hosting costs and eventually make funds available for anyone to be paid for features/improvements/fixes/maintenance if they wish.