### PR TITLE
Remove "Octobox" title from header

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -153,6 +153,7 @@ html {
 @media (min-width: $screen-sm-min) {
   #search {
     float: left;
+    margin-left: -18px;
   }
 }
 @media (max-width: $screen-xs-max) {

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -12,9 +12,8 @@
           <%= octicon 'search', height: 16, class: 'text-muted' %>
         </button>
       <% end %>
-      <a class="navbar-brand" href="/">
+      <a class="navbar-brand" href="/" title='Octobox'>
         <%= octobox_icon(28) %>
-        <span class="hidden-xs">Octobox</span>
       </a>
     </div>
     <div class="collapse navbar-collapse" id="search">


### PR DESCRIPTION
Felt like having the name in the header along with the logo was a bit of wasted space:

![screen shot 2017-05-04 at 4 55 35 pm](https://cloud.githubusercontent.com/assets/1060/25712874/c2340e56-30ea-11e7-90bc-69e17c9cc30c.png)
