### PR TITLE
Add header link to opencollective page

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -70,6 +70,11 @@
           </li>
         <% end %>
       </ul>
+      <ul class="nav navbar-nav navbar-right">
+        <li>
+          <a href="https://opencollective.com/octobox/" class='opencollective' data-toggle="tooltip" data-placement="bottom" title='Support Octobox on OpenCollective' target='_blank'><%= octicon 'gift', height: 16 %></a>
+        </li>
+      </ul>
     </div><!-- /.navbar-collapse -->
 
 

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -72,7 +72,7 @@
       </ul>
       <ul class="nav navbar-nav navbar-right">
         <li>
-          <a href="https://opencollective.com/octobox/" class='opencollective' data-toggle="tooltip" data-placement="bottom" title='Support Octobox on OpenCollective' target='_blank'><%= octicon 'gift', height: 16 %></a>
+          <a href="https://opencollective.com/octobox/" class='opencollective' target='_blank'><%= octicon 'gift', height: 16, data: {toggle: "tooltip", placement: "bottom"}, title: 'Support Octobox on OpenCollective' %></a>
         </li>
       </ul>
     </div><!-- /.navbar-collapse -->


### PR DESCRIPTION
Hopefully will encourage more people to support the project via our @opencollective page: https://opencollective.com/octobox/

n.b. hidden on small screens for now

![screen shot 2017-05-04 at 6 17 27 pm](https://cloud.githubusercontent.com/assets/1060/25716161/0a42da6e-30f6-11e7-8b8a-07af1339be6c.png)
