### PR TITLE
Use alpine docker base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,12 @@
-FROM ruby:2.4.1
-RUN \
-    apt-get update \
-    && apt-get install -y --no-install-recommends netcat nodejs \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+FROM ruby:2.4.1-alpine
+RUN apk add --update \
+  build-base \
+  netcat-openbsd \
+  git \
+  nodejs \
+  postgresql-dev \
+  tzdata \
+  && rm -rf /var/cache/apk/*
 # throw errors if Gemfile has been modified since Gemfile.lock
 RUN bundle config --global frozen 1
 RUN mkdir -p /usr/src/app


### PR DESCRIPTION
Switching to the alpine version of ruby:2.4.1 to see if it works, switches from using apt-get to apk as well.

Fixes https://github.com/octobox/octobox/issues/355