### PR TITLE
Don't install production gems in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,6 @@ RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
 COPY Gemfile Gemfile.lock /usr/src/app/
-RUN bundle install --without test
+RUN bundle install --without test production
 
 COPY . /usr/src/app


### PR DESCRIPTION
One more little tweak for https://github.com/octobox/octobox/issues/355

Currently we run the docker image in development mode which is probably pretty slow for some people but that's for another issue.