### PR TITLE
when searching via q allow archived results to be returned

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -200,6 +200,8 @@ class NotificationsController < ApplicationController
       scope = scope.send(sub_scope, params[sub_scope]) if params[sub_scope].present?
     end
     scope = scope.search_by_subject_title(params[:q])   if params[:q].present?
+    scope = scope.unscope(where: :archived)             if params[:q].present?
+
     scope
   end
 

--- a/test/controllers/notifications_controller_test.rb
+++ b/test/controllers/notifications_controller_test.rb
@@ -57,6 +57,14 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
     assert_template 'notifications/index'
   end
 
+  test 'shows archived search results by default' do
+    sign_in_as(@user)
+    5.times.each { create(:notification, user: @user, archived: true, subject_title:'release-1') }
+
+    get '/?q=release'
+    assert_equal assigns(:notifications).length, 5
+  end
+
   test 'shows only 20 notifications per page' do
     sign_in_as(@user)
     25.times.each { create(:notification, user: @user, archived: false) }

--- a/test/controllers/notifications_controller_test.rb
+++ b/test/controllers/notifications_controller_test.rb
@@ -60,7 +60,6 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
   test 'shows archived search results by default' do
     sign_in_as(@user)
     5.times.each { create(:notification, user: @user, archived: true, subject_title:'release-1') }
-
     get '/?q=release'
     assert_equal assigns(:notifications).length, 5
   end


### PR DESCRIPTION
**headlines**

1) Show archived results when filtering by a query param

Not sure this entirely the best approach wdyt?

related issue https://github.com/octobox/octobox/pull/361