### PR TITLE
Disable tooltips on focus for mobile

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -121,7 +121,7 @@ document.addEventListener("turbolinks:load", function() {
     checkAll($(".js-select_all").prop('checked'))
   })
 
-  $('[data-toggle="tooltip"]').tooltip()
+  $('[data-toggle="tooltip"]').tooltip({trigger: 'tooltip'})
 
   updateFavicon()
 });


### PR DESCRIPTION
Refreshing on the mobile UI takes two taps because of the tooltip being activated on focus as well as hover, so I've turned off the focus option.