### PR TITLE
Added tooltips to all selection buttons

### DIFF
--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -52,20 +52,20 @@ module NotificationsHelper
   end
 
   def mute_selected_button
-    function_button('Mute selected', 'mute', 'mute_selected') unless params[:archive]
+    function_button('Mute selected', 'mute', 'mute_selected', 'Mute selected items') unless params[:archive]
   end
 
   def mark_read_selected_button
-    function_button('Mark as read', 'eye', 'mark_read_selected')
+    function_button('Mark as read', 'eye', 'mark_read_selected', 'Mark items as read')
   end
 
   def archive_selected_button
     action = params[:archive] ? 'unarchive' : 'archive'
-    function_button("#{action.capitalize} selected", 'checklist', "archive_toggle #{action}_selected")
+    function_button("#{action.capitalize} selected", 'checklist', "archive_toggle #{action}_selected", 'Archive selected items')
   end
 
   def select_all_button(cur_selected, total)
-    button_tag(type: 'button', class: "select_all btn btn-default hidden", 'data-toggle': "tooltip", 'data-placement': "top", 'title': "Number of items selected") do
+    button_tag(type: 'button', class: "select_all btn btn-default hidden", 'data-toggle': "tooltip", 'data-placement': "bottom", 'title': "Number of items selected") do
       octicon('check', height: 16) +
         content_tag(:span, " #{cur_selected}", class: 'bold hidden-xs') +
         " |" +
@@ -73,8 +73,8 @@ module NotificationsHelper
     end if cur_selected < total
   end
 
-  def function_button(title, octicon, css_class)
-    button_tag(type: 'button', class: "#{css_class} btn btn-default hidden") do
+  def function_button(title, octicon, css_class, tooltip)
+    button_tag(type: 'button', class: "#{css_class} btn btn-default hidden", 'data-toggle': "tooltip", 'data-placement': "bottom", 'title': tooltip ) do
       octicon(octicon, height: 16) + content_tag(:span, " #{title}", class: 'hidden-xs')
     end
   end


### PR DESCRIPTION
This is in response to an issue on the tooltips for the selection buttons. #330

I added a parameter to the `function_button` that takes in a tooltip that will display across all those buttons

I also changed the the tooltip for select all to the bottom for consistency. 

Very sorry but I have not been able to test that this works locally because I have no space on my puny little MacBook for docker vms! Can someone please confirm that these appear ok and have not wrecked the UI 