### PR TITLE
Use Rails 5.1 schema spacing

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,37 +16,37 @@ ActiveRecord::Schema.define(version: 20170111185505) do
   enable_extension "plpgsql"
 
   create_table "notifications", force: :cascade do |t|
-    t.integer  "user_id"
-    t.integer  "github_id"
-    t.integer  "repository_id"
-    t.string   "repository_full_name"
-    t.string   "subject_title"
-    t.string   "subject_url"
-    t.string   "subject_type"
-    t.string   "reason"
-    t.boolean  "unread"
-    t.datetime "updated_at",                            null: false
-    t.string   "last_read_at"
-    t.string   "url"
-    t.boolean  "archived",              default: false
-    t.datetime "created_at",                            null: false
-    t.boolean  "starred",               default: false
-    t.string   "repository_owner_name", default: ""
-    t.index ["user_id", "archived", "updated_at"], name: "index_notifications_on_user_id_and_archived_and_updated_at", using: :btree
-    t.index ["user_id", "github_id"], name: "index_notifications_on_user_id_and_github_id", unique: true, using: :btree
+    t.integer "user_id"
+    t.integer "github_id"
+    t.integer "repository_id"
+    t.string "repository_full_name"
+    t.string "subject_title"
+    t.string "subject_url"
+    t.string "subject_type"
+    t.string "reason"
+    t.boolean "unread"
+    t.datetime "updated_at", null: false
+    t.string "last_read_at"
+    t.string "url"
+    t.boolean "archived", default: false
+    t.datetime "created_at", null: false
+    t.boolean "starred", default: false
+    t.string "repository_owner_name", default: ""
+    t.index ["user_id", "archived", "updated_at"], name: "index_notifications_on_user_id_and_archived_and_updated_at"
+    t.index ["user_id", "github_id"], name: "index_notifications_on_user_id_and_github_id", unique: true
   end
 
   create_table "users", force: :cascade do |t|
-    t.integer  "github_id",                         null: false
-    t.string   "access_token",                      null: false
-    t.string   "github_login",                      null: false
-    t.datetime "created_at",                        null: false
-    t.datetime "updated_at",                        null: false
+    t.integer "github_id", null: false
+    t.string "access_token", null: false
+    t.string "github_login", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.datetime "last_synced_at"
-    t.string   "personal_access_token"
-    t.integer  "refresh_interval",      default: 0
-    t.index ["access_token"], name: "index_users_on_access_token", unique: true, using: :btree
-    t.index ["github_id"], name: "index_users_on_github_id", unique: true, using: :btree
+    t.string "personal_access_token"
+    t.integer "refresh_interval", default: 0
+    t.index ["access_token"], name: "index_users_on_access_token", unique: true
+    t.index ["github_id"], name: "index_users_on_github_id", unique: true
   end
 
 end


### PR DESCRIPTION
In Rails 5.1, Column arguments are no longer aligned for a given table in `schema.rb`.

For more information, see https://github.com/rails/rails/pull/25675

I'm submitting this commit as it's own change so that we don't have a confusing diff where everything looks different with an actual change hidden therein (like in the thing I'm actually working on...)