### PR TITLE
Add link in settings page to oauth app permissions on GitHub

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -570,3 +570,7 @@ td.keys {
 .opencollective{
   fill: #ddd;
 }
+
+.octicon.inverse{
+  fill: #fff;
+}

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -40,6 +40,21 @@
   <% end %>
 
   <hr>
+
+  <div class="panel panel-default">
+    <div class="panel-heading">
+      <h3 class="panel-title">Manage Oauth Access</h3>
+    </div>
+    <div class="panel-body">
+      <p>Octobox can only show notifications for Organsiations that you've granted it access to via GitHub</p>
+      <p>If you've been added to a new Organisation you may need to enable or request access for Octobox to sync notifications for those repositories.</p>
+      <%= link_to "#{Octobox.config.github_domain}/settings/connections/applications/#{Rails.application.secrets.github_client_id}", class: 'btn btn-default' do %>
+        <%= octicon 'tools' %>&nbsp;
+        Manage Oauth Access on GitHub
+      <% end %>
+    </div>
+  </div>
+
   <div class="panel panel-danger">
     <div class="panel-heading">
       <h3 class="panel-title">Danger zone</h3>
@@ -47,7 +62,10 @@
     <div class="panel-body">
       <p>Deleting your Octobox account permanently removes all data associate with your user from Octobox's database.</p>
       <p>Once you have deleted your account, logging in again will create a new account associated with your GitHub user and load existing notifications.</p>
-      <%= link_to 'Delete my Octobox account', current_user, method: :delete, class: 'btn btn-danger', data: { confirm: 'Are you sure you want to do this?' } %>
+      <%= link_to current_user, method: :delete, class: 'btn btn-danger', data: { confirm: 'Are you sure you want to do this?' } do %>
+        <%= octicon 'trashcan', class: 'inverse' %>&nbsp;
+        Delete my Octobox account
+      <% end %>
     </div>
   </div>
   <%= render 'layouts/footer' %>


### PR DESCRIPTION
When you get added to a new Organisation on GitHub Octobox doesn't always get access to those new notifications, which leads to confusion and support requests. 

This PR adds a link to manage the permissions you've given to the Oauth app on GitHub with a bit of an explanation.

Untested on GitHub Enterprise but it "should" just work 🙈 

Also added a little trashcan icon to the delete account button.

Screenshot:

![screen shot 2017-06-07 at 3 05 12 pm](https://user-images.githubusercontent.com/1060/26882786-475e06aa-4b93-11e7-83cd-ac76069ed22b.png)
