### PR TITLE
Scroll more naturally on mobile safari

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -45,13 +45,15 @@ html {
 }
 .flex-sidebar {
   flex: 0 0 250px;
-  overflow: auto;
+  overflow: scroll;
+  -webkit-overflow-scrolling: touch;
   padding-bottom: 60px;
 }
 .flex-main {
   flex: 1;
   min-width: 0;
-  overflow: auto;
+  overflow: scroll;
+  -webkit-overflow-scrolling: touch;
 }
 .flex-container {
   padding: 15px;


### PR DESCRIPTION
The scrolling on iOS isn't the smooth flicky style of most web pages due to the way we use overflow, this custom attribute fixes it, found via https://css-tricks.com/snippets/css/momentum-scrolling-on-ios-overflow-elements/