### PR TITLE
Eager load existing notifications when syncing

### DIFF
--- a/app/services/download_service.rb
+++ b/app/services/download_service.rb
@@ -28,9 +28,11 @@ class DownloadService
 
   def process_unread_notifications(notifications)
     return if notifications.blank?
+    existing_notifications = user.notifications.where(github_id: notifications.map(&:id))
     notifications.each do |notification|
       begin
-        n =  user.notifications.find_or_initialize_by(github_id: notification[:id])
+        n = existing_notifications.find{|n| n.github_id == notification.id.to_i}
+        n = user.notifications.new(github_id: notification.id) if n.nil?
         n.update_from_api_response(notification, unarchive: true)
       rescue ActiveRecord::RecordNotUnique
         nil
@@ -40,9 +42,11 @@ class DownloadService
 
   def process_read_notifications(notifications)
     return if notifications.blank?
+    existing_notifications = user.notifications.where(github_id: notifications.map(&:id))
     notifications.each do |notification|
       next if notification.unread
-      n = user.notifications.find_or_initialize_by(github_id: notification.id)
+      n = existing_notifications.find{|n| n.github_id == notification.id.to_i }
+      n = user.notifications.new(github_id: notification.id) if n.nil?
       next unless n
       n.update_from_api_response(notification)
     end


### PR DESCRIPTION
A quick attempt to speed up the syncing of notifications, especially for new users, this eager loads the existing notifications for a user rather than letting `find_or_initialize_by` do it for every item in the API response.

Quick testing in development shows around ~20 extra sql queries killed, saving about 200ms on my account:

    Before: Completed 302 Found in 1541ms (ActiveRecord: 64.4ms | SQL count: 105)
    After:  Completed 302 Found in 1331ms (ActiveRecord: 42.4ms | SQL count: 82)

There's also some other savings to be made by inserting/upserting all the records in one go as well in future.