### PR TITLE
Revert "Scroll more naturally on mobile safari"

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -45,15 +45,13 @@ html {
 }
 .flex-sidebar {
   flex: 0 0 250px;
-  overflow: scroll;
-  -webkit-overflow-scrolling: touch;
+  overflow: auto;
   padding-bottom: 60px;
 }
 .flex-main {
   flex: 1;
   min-width: 0;
-  overflow: scroll;
-  -webkit-overflow-scrolling: touch;
+  overflow: auto;
 }
 .flex-container {
   padding: 15px;


### PR DESCRIPTION
Reverts octobox/octobox#391 to fix https://github.com/octobox/octobox/issues/393, need to make `overflow: auto` apart from on mobile.