### PR TITLE
Fix json notification response when zero

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -242,6 +242,10 @@ class NotificationsController < ApplicationController
   end
 
   def per_page
+    @per_page ||= restrict_per_page
+  end
+
+  def restrict_per_page
     per_page = params[:per_page].to_i rescue 20
     per_page = 20 if per_page < 1
     raise ActiveRecord::RecordNotFound if per_page > 100

--- a/app/views/notifications/index.json.jbuilder
+++ b/app/views/notifications/index.json.jbuilder
@@ -1,7 +1,7 @@
 json.pagination do
   json.total_notifications @total
   json.page @page
-  json.total_pages((@total.to_f / @cur_selected).ceil)
+  json.total_pages((@total.to_f / @per_page).ceil)
   json.per_page @cur_selected
 end
 

--- a/test/controllers/notifications_controller_test.rb
+++ b/test/controllers/notifications_controller_test.rb
@@ -260,4 +260,31 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test 'renders pagination info for notifications in json' do
+    sign_in_as(@user)
+
+    get notifications_path(format: :json)
+
+    assert_response :success
+    json = JSON.parse(response.body)
+    notification_count = Notification.inbox.where(user: @user).count
+    assert_equal notification_count, json["pagination"]["total_notifications"]
+    assert_equal 0, json["pagination"]["page"]
+    assert_equal (notification_count.to_f / 20).ceil, json["pagination"]["total_pages"]
+    assert_equal [notification_count, 20].min, json["pagination"]["per_page"]
+  end
+
+  test 'renders pagination info for zero notifications in json' do
+    sign_in_as(@user)
+    Notification.destroy_all
+
+    get notifications_path(format: :json)
+
+    assert_response :success
+    json = JSON.parse(response.body)
+    assert_equal 0, json["pagination"]["total_notifications"]
+    assert_equal 0, json["pagination"]["page"]
+    assert_equal 0, json["pagination"]["total_pages"]
+    assert_equal 0, json["pagination"]["per_page"]
+  end
 end


### PR DESCRIPTION
A divide by zero exception occurs when no notifications are returned in json. 

![screen shot 2017-06-15 at 2 24 59 pm](https://user-images.githubusercontent.com/6825/27195872-711f79ee-51d6-11e7-8c38-615c16e43c3f.png)

Adds a test to verify the pagination attributes of the json response for 1 or more notifications as well as zero notifications. Makes total_pages use the `@per_page` instance variable instead of `@cur_selected`, to avoid the divide by zero issue.

