### PR TITLE
Fix production loading

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -23,6 +23,6 @@ module Octobox
   class Application < Rails::Application
     require Rails.root.join('lib/octobox')
 
-    config.autoload_paths << Rails.root.join("lib")
+    config.eager_load_paths << Rails.root.join("lib")
   end
 end


### PR DESCRIPTION
Oops.

In Rails 5, autoload paths are no longer used in the production environment: https://github.com/rails/rails/commit/a71350cae0082193ad8c66d65ab62e8bb0b7853b

Fixes #404