### PR TITLE
Changed loading of lib/octobox to fix test coverage

### DIFF
--- a/config/initializers/octokit.rb
+++ b/config/initializers/octokit.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+require Rails.root.join('lib/octobox')
+
 Octokit.configure do |c|
   c.api_endpoint = Octobox.config.github_api_prefix
   c.web_endpoint = Octobox.config.github_domain


### PR DESCRIPTION
I noticed that the test coverage report was marking `lib/octobox` and `lib/octobox/configurator` as having 0% coverage, this moves the require into an initializer so that simplecov sees the file being required.