### PR TITLE
Rescue Octokit errors when downloading a subject

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -96,7 +96,8 @@ class Notification < ApplicationRecord
 
   def download_subject
     user.github_client.get(subject_url)
-  rescue Octokit::Forbidden, Octokit::NotFound
+  rescue Octokit::Forbidden, Octokit::NotFound => e
+    Rails.logger.warn("\n\n\033[32m[#{Time.now}] WARNING -- #{e.message}\033[0m\n\n")
   end
 
   def update_subject

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -102,7 +102,6 @@ class Notification < ApplicationRecord
 
   def update_subject
     return unless Octobox.config.fetch_subject
-
     if subject
       # skip syncing if the notification was updated around the same time as subject
       return if updated_at - subject.updated_at < 2.seconds

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -102,21 +102,24 @@ class Notification < ApplicationRecord
   def update_subject
     return unless Octobox.config.fetch_subject
 
-    remote_subject = download_subject
-    return unless remote_subject.present?
-
     if subject
       # skip syncing if the notification was updated around the same time as subject
       return if updated_at - subject.updated_at < 2.seconds
 
       case subject_type
       when 'Issue', 'PullRequest'
+        remote_subject = download_subject
+        return unless remote_subject.present?
+
         subject.state = remote_subject.merged_at.present? ? 'merged' : remote_subject.state
         subject.save(touch: false) if subject.changed?
       end
     else
       case subject_type
       when 'Issue', 'PullRequest'
+        remote_subject = download_subject
+        return unless remote_subject.present?
+
         create_subject({
           state: remote_subject.merged_at.present? ? 'merged' : remote_subject.state,
           author: remote_subject.user.login,
@@ -124,6 +127,9 @@ class Notification < ApplicationRecord
           updated_at: remote_subject.updated_at
         })
       when 'Commit', 'Release'
+        remote_subject = download_subject
+        return unless remote_subject.present?
+
         create_subject({
           author: remote_subject.author.login,
           created_at: remote_subject.created_at,


### PR DESCRIPTION
We just tried to update our internal GitHub version and ran into a snag where we didn't update the scope for the OAuth app and therefore downloading the subject caused a `500`.

This PR catches the two most likely errors from the API, and short circuits the `update_subject` method if there isn't a remote subject.

Since these are private methods I didn't add any tests, but I'm more than happy to if folks think it's needed.