### PR TITLE
Clear filters with escape keystroke

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -174,7 +174,7 @@ var shortcuts = {
   191: openModal,         // ?
   190: sync,              // .
   82:  sync,              // r
-  27:  clearFilters
+  27:  clearFilters       // esc
 };
 
 function cursorDown() {
@@ -280,7 +280,7 @@ function autoSync() {
   hasMarkedRows() || sync()
 }
 
-function clearFilters(){
+function clearFilters() {
   Turbolinks.visit("/");
 }
 

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -173,7 +173,8 @@ var shortcuts = {
   79:  openCurrentLink,   // o
   191: openModal,         // ?
   190: sync,              // .
-  82:  sync               // r
+  82:  sync,              // r
+  27:  clearFilters
 };
 
 function cursorDown() {
@@ -277,6 +278,10 @@ function sync() {
 
 function autoSync() {
   hasMarkedRows() || sync()
+}
+
+function clearFilters(){
+  Turbolinks.visit("/");
 }
 
 function setAutoSyncTimer() {

--- a/app/views/notifications/_help-box.html.erb
+++ b/app/views/notifications/_help-box.html.erb
@@ -97,6 +97,14 @@
                 Show this help menu
               </td>
             </tr>
+            <tr>
+              <td class="keys">
+                <div class="key">esc</div>
+              </td>
+              <td>
+                Clear applied filters
+              </td>
+            </tr>
           </tbody>
         </table>
       </div>


### PR DESCRIPTION
Worked on Issue #415 

Applied filters can be cleared with Esc key.

Fixes #415 