### PR TITLE
Link to last comment

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -65,17 +65,8 @@ class Notification < ApplicationRecord
   end
 
   def web_url
-    url = subject_url.gsub("#{Octobox.config.github_api_prefix}/repos", Octobox.config.github_domain)
-      .gsub('/pulls/', '/pull/')
-      .gsub('/commits/', '/commit/')
-      .gsub(/\/releases\/\d+/, '/releases/')
-    if latest_comment_url.present?
-      /comments\/(\d+)\z/.match(latest_comment_url) do |match|
-        url << "#issuecomment-#{match[1]}" if match[1]
-      end
-    end
-
-    url
+    Octobox::SubjectUrlParser.new(subject_url, latest_comment_url: latest_comment_url)
+      .to_web_url
   end
 
   def repo_url

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -65,10 +65,17 @@ class Notification < ApplicationRecord
   end
 
   def web_url
-    subject_url.gsub("#{Octobox.config.github_api_prefix}/repos", Octobox.config.github_domain)
-               .gsub('/pulls/', '/pull/')
-               .gsub('/commits/', '/commit/')
-               .gsub(/\/releases\/\d+/, '/releases/')
+    url = subject_url.gsub("#{Octobox.config.github_api_prefix}/repos", Octobox.config.github_domain)
+      .gsub('/pulls/', '/pull/')
+      .gsub('/commits/', '/commit/')
+      .gsub(/\/releases\/\d+/, '/releases/')
+    if latest_comment_url.present?
+      /comments\/(\d+)\z/.match(latest_comment_url) do |match|
+        url << "#issuecomment-#{match[1]}" if match[1]
+      end
+    end
+
+    url
   end
 
   def repo_url

--- a/app/services/download_service.rb
+++ b/app/services/download_service.rb
@@ -17,7 +17,8 @@ class DownloadService
     updated_at: [:updated_at],
     last_read_at: [:last_read_at],
     url: [:url],
-    github_id: [:id]
+    github_id: [:id],
+    latest_comment_url: [:subject, :latest_comment_url]
   }.freeze
 
   def download

--- a/db/migrate/20170829135808_add_latest_comment_url_to_notifications.rb
+++ b/db/migrate/20170829135808_add_latest_comment_url_to_notifications.rb
@@ -1,0 +1,5 @@
+class AddLatestCommentUrlToNotifications < ActiveRecord::Migration[5.1]
+  def change
+    add_column :notifications, :latest_comment_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170812203351) do
+ActiveRecord::Schema.define(version: 20170829135808) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -32,6 +32,7 @@ ActiveRecord::Schema.define(version: 20170812203351) do
     t.datetime "created_at", null: false
     t.boolean "starred", default: false
     t.string "repository_owner_name", default: ""
+    t.string "latest_comment_url"
     t.index "to_tsvector('english'::regconfig, (subject_title)::text)", name: "notifications_subject_title", using: :gin
     t.index ["user_id", "archived", "updated_at"], name: "index_notifications_on_user_id_and_archived_and_updated_at"
     t.index ["user_id", "github_id"], name: "index_notifications_on_user_id_and_github_id", unique: true

--- a/lib/octobox/subject_url_parser.rb
+++ b/lib/octobox/subject_url_parser.rb
@@ -1,0 +1,50 @@
+module Octobox
+  class SubjectUrlParser
+    attr_reader :url
+
+    def initialize(url, latest_comment_url: nil)
+      @url = url
+      @latest_comment_url = latest_comment_url
+    end
+
+    # NOTE Releases are defaulted to the release index page
+    def to_web_url
+      web_url = url.gsub("#{Octobox.config.github_api_prefix}/repos", Octobox.config.github_domain)
+        .gsub('/pulls/', '/pull/')
+        .gsub('/commits/', '/commit/')
+        .gsub(/\/releases\/\d+/, '/releases/')
+
+      if @latest_comment_url.present?
+        if pull_request? || issue? then web_url << "#issuecomment-#{comment_id}"
+        elsif commit? then web_url << "#commitcomment-#{comment_id}"
+        end
+      end
+
+      web_url
+    end
+
+    def pull_request?
+      /\/pull(?:s)?\// =~ url
+    end
+
+    def issue?
+      /\/issues\// =~ url
+    end
+
+    def commit?
+      /\/commit(?:s)?\// =~ url
+    end
+
+    def release?
+      /\/releases\// =~ url
+    end
+
+    private
+
+    def comment_id
+      return @comment_id if defined?(@comment_id)
+      match = /comments\/(?<comment_id>\d+)\z/.match(@latest_comment_url)
+      @comment_id = match[:comment_id] if match.present?
+    end
+  end
+end

--- a/lib/octobox/subject_url_parser.rb
+++ b/lib/octobox/subject_url_parser.rb
@@ -1,15 +1,21 @@
 module Octobox
   class SubjectUrlParser
-    attr_reader :url
+    attr_reader :url,
+                :github_api_prefix,
+                :github_domain
 
-    def initialize(url, latest_comment_url: nil)
+    delegate :config, to: Octobox
+
+    def initialize(url, github_api_prefix: config.github_api_prefix, github_domain: config.github_domain, latest_comment_url: nil)
       @url = url
+      @github_api_prefix = github_api_prefix
+      @github_domain = github_domain
       @latest_comment_url = latest_comment_url
     end
 
     # NOTE Releases are defaulted to the release index page
     def to_web_url
-      web_url = url.gsub("#{Octobox.config.github_api_prefix}/repos", Octobox.config.github_domain)
+      web_url = url.gsub("#{github_api_prefix}/repos", github_domain)
         .gsub('/pulls/', '/pull/')
         .gsub('/commits/', '/commit/')
         .gsub(/\/releases\/\d+/, '/releases/')

--- a/lib/octobox/subject_url_parser.rb
+++ b/lib/octobox/subject_url_parser.rb
@@ -13,12 +13,7 @@ module Octobox
         .gsub('/pulls/', '/pull/')
         .gsub('/commits/', '/commit/')
         .gsub(/\/releases\/\d+/, '/releases/')
-
-      if @latest_comment_url.present?
-        if pull_request? || issue? then web_url << "#issuecomment-#{comment_id}"
-        elsif commit? then web_url << "#commitcomment-#{comment_id}"
-        end
-      end
+      web_url << latest_comment_anchor
 
       web_url
     end
@@ -45,6 +40,14 @@ module Octobox
       return @comment_id if defined?(@comment_id)
       match = /comments\/(?<comment_id>\d+)\z/.match(@latest_comment_url)
       @comment_id = match[:comment_id] if match.present?
+    end
+
+    def latest_comment_anchor
+      return "" unless comment_id.present?
+
+      if pull_request? || issue? then "#issuecomment-#{comment_id}"
+      elsif commit? then "#commitcomment-#{comment_id}"
+      end
     end
   end
 end

--- a/test/lib/octobox/subject_url_parser_test.rb
+++ b/test/lib/octobox/subject_url_parser_test.rb
@@ -1,0 +1,82 @@
+require 'test_helper'
+
+class SubjectUrlParserTest < ActiveSupport::TestCase
+  test "to_web_url correctly converts an API issue to an HTML one" do
+    url = "https://api.github.com/repos/octokit/octokit.rb/issues/123"
+    without_comment = Octobox::SubjectUrlParser.new(url)
+    with_comment    = Octobox::SubjectUrlParser.new(url, latest_comment_url: "https://api.github.com/repos/octokit/octokit.rb/comments/1")
+
+    assert_equal "https://github.com/octokit/octokit.rb/issues/123", without_comment.to_web_url
+    assert_equal "https://github.com/octokit/octokit.rb/issues/123#issuecomment-1", with_comment.to_web_url
+  end
+
+  test "to_web_url correctly coverts an API commit URL to an HTML one" do
+    url = "https://api.github.com/repos/octocat/Hello-World/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e"
+    without_comment = Octobox::SubjectUrlParser.new(url)
+    with_comment    = Octobox::SubjectUrlParser.new(url, latest_comment_url: "https://api.github.com/repos/octocat/Hello-World/pulls/comments/1")
+
+    assert_equal "https://github.com/octocat/Hello-World/commit/6dcb09b5b57875f334f61aebed695e2e4193db5e", without_comment.to_web_url
+    assert_equal "https://github.com/octocat/Hello-World/commit/6dcb09b5b57875f334f61aebed695e2e4193db5e#commitcomment-1", with_comment.to_web_url
+  end
+
+  test "it correctly identifies an API pull request URL" do
+    assert_pull_request_url Octobox::SubjectUrlParser.new("https://api.github.com/repos/octocat/Hello-World/pulls/1347")
+  end
+
+  test "it correctly identifies a HTML pull request URL" do
+    assert_pull_request_url Octobox::SubjectUrlParser.new("https://github.com/octocat/Hello-World/pull/1347")
+  end
+
+  test "it correctly identifies an API issue URL" do
+    assert_issue_url Octobox::SubjectUrlParser.new("https://api.github.com/repos/octocat/Hello-World/issues/1347")
+  end
+
+  test "it correctly identifies a HTML issue URL" do
+    assert_issue_url Octobox::SubjectUrlParser.new("https://github.com/octocat/Hello-World/issues/1347")
+  end
+
+  test "it correctly identifies an API commit URL" do
+    assert_commit_url Octobox::SubjectUrlParser.new("https://api.github.com/repos/octocat/Hello-World/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e")
+  end
+
+  test "it correctly identifies a HTML commit URL" do
+    assert_commit_url Octobox::SubjectUrlParser.new("https://github.com/octocat/Hello-World/commit/6dcb09b5b57875f334f61aebed695e2e4193db5e")
+  end
+
+  test "it correctly identifies an API release URL" do
+    assert_release_url Octobox::SubjectUrlParser.new("https://api.github.com/repos/octocat/Hello-World/releases/1")
+  end
+
+  test "it correctly identifies a HTML release URL" do
+    assert_release_url Octobox::SubjectUrlParser.new("https://github.com/octocat/Hello-World/releases/v1.0.0")
+  end
+
+  def assert_pull_request_url(parser)
+    assert parser.pull_request?
+    refute parser.issue?
+    refute parser.commit?
+    refute parser.release?
+  end
+
+  def assert_issue_url(parser)
+    refute parser.pull_request?
+    assert parser.issue?
+    refute parser.commit?
+    refute parser.release?
+  end
+
+  def assert_commit_url(parser)
+    refute parser.pull_request?
+    refute parser.issue?
+    assert parser.commit?
+    refute parser.release?
+  end
+
+  def assert_release_url(parser)
+    refute parser.pull_request?
+    refute parser.issue?
+    refute parser.commit?
+    assert parser.release?
+  end
+end
+

--- a/test/models/notification_test.rb
+++ b/test/models/notification_test.rb
@@ -82,10 +82,13 @@ class NotificationTest < ActiveSupport::TestCase
     api_response = notifications_from_fixture('morty_notifications.json').first
     notification = create(:morty_updated)
     expected_attributes = notification.attributes.merge(
-      {last_read_at: '2016-12-19 22:01:45 UTC',
-       updated_at: Time.zone.parse('2016-12-19T22:01:45Z'),
-       unread: true,
-       archived: false}.stringify_keys)
+      {
+        last_read_at: '2016-12-19 22:01:45 UTC',
+        updated_at: Time.zone.parse('2016-12-19T22:01:45Z'),
+        unread: true,
+        archived: false,
+        latest_comment_url: "https://api.github.com/repos/octobox/octobox/issues/comments/123"
+      }.stringify_keys)
     notification.update_from_api_response(api_response, unarchive: true)
     assert notification.unread?
     refute notification.archived?


### PR DESCRIPTION
Closes #323

Notification links now lead to the latest comment on the issue/commit if applicable. This is tracked by syncing the `latest_comment_url` attribute on the notifications endpoint.

Since comment anchors are being toyed with as well, also moves our url parsing stuff in to it's own testable thing.

Note this change doesn't even require repo scope, so this can be deployed on octobox.io immediately if you like 😃 