### PR TITLE
Add .dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+.git
+.gitignore
+README.md
+
+log
+tmp
+coverage/
+.bundle
+.ruby-version
+
+.DS_Store
+.AppleDouble
+.LSOverride
+
+.dockerignore
+docker-compose.yml


### PR DESCRIPTION
TIL about `.dockerignore` file ([docs](https://docs.docker.com/engine/reference/builder/#dockerignore-file)), so I thought I'd add one to octobox to keep the image size nice and small 🐳 