### PR TITLE
Fixed bug where select-all checkbox stays indeterminate

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -90,16 +90,16 @@ document.addEventListener("turbolinks:load", function() {
 
     $('input.archive, input.unarchive').change(function() {
       if ( hasMarkedRows() ) {
-        var prop = hasMarkedRows(true) ? 'indeterminate' : 'checked';
-        $(".js-select_all").prop(prop, true);
         $('button.archive_selected, button.unarchive_selected, button.mute_selected').removeClass('hidden');
-        if ( prop === 'checked' ) {
+        if ( !hasMarkedRows(true) ) {
+          $(".js-select_all").prop('checked', true).prop('indeterminate', false);
           $('button.select_all').removeClass('hidden');
         } else {
+          $(".js-select_all").prop('checked', false).prop('indeterminate', true);
           $('button.select_all').addClass('hidden');
         }
       } else {
-        $(".js-select_all").prop('checked', false);
+        $(".js-select_all").prop('checked', false).prop('indeterminate', false);
         $('button.archive_selected, button.unarchive_selected, button.mute_selected, button.select_all').addClass('hidden');
       }
       var marked_unread_length = getMarkedRows().filter('.active').length;


### PR DESCRIPTION
Yesterday I noticed that when you've selected one notification then deselect it, the select-all checkbox stays indeterminate, gif example:

![octobox](https://user-images.githubusercontent.com/1060/29877614-022a1208-8d98-11e7-9f75-44003d37e561.gif)

This PR fixes that odd behaviour and makes sure that both the `checked` and `indeterminate` properties on the input are set correctly as `indeterminate` seems to take priority over `checked` if they are both set to true, gif after fixing:

![octobox2](https://user-images.githubusercontent.com/1060/29877723-52714088-8d98-11e7-8b94-b168e2365efb.gif)
