### PR TITLE
Fix refresh button animation, shortcut

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -113,8 +113,8 @@ document.addEventListener("turbolinks:load", function() {
       $(this).toggleClass("star-active star-inactive");
       $.post('/notifications/'+$(this).data('id')+'/star')
     });
-    $('.sync .octicon').on('click', function() {
-      $(this).toggleClass('spinning')
+    $('a.sync').on('click', function() {
+      $('.sync .octicon').toggleClass('spinning')
     });
     recoverPreviousCursorPosition();
 


### PR DESCRIPTION
Fixes refresh button to

* Not require you click on the spinner directly, instead of anywhere on the button for the animation to work (pictured):
![](http://screenshots.chrisarcand.com/p3u95.gif)
* Also fixes keyboard shortcut, which wouldn't show the animation if you used it