### PR TITLE
Fix muting and marking as read notifications losing current scope when selecting beyond current page size

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -201,14 +201,14 @@ function mute() {
   if (getDisplayedRows().length === 0) return;
   if ( $(".js-table-notifications tr").length === 0 ) return;
   var ids = getIdsFromRows(getMarkedOrCurrentRows());
-  $.post( "/notifications/mute_selected", { 'id[]': ids}).done(function() {resetCursorAfterRowsRemoved(ids)});
+  $.post( "/notifications/mute_selected" + location.search, { 'id[]': ids}).done(function() {resetCursorAfterRowsRemoved(ids)});
 }
 
 function markReadSelected() {
   if (getDisplayedRows().length === 0) return;
   var rows = getMarkedOrCurrentRows();
   rows.addClass('blur-action');
-  $.post("/notifications/mark_read_selected", {'id[]': getIdsFromRows(rows)}).done(function () {
+  $.post("/notifications/mark_read_selected" + location.search, {'id[]': getIdsFromRows(rows)}).done(function () {
     rows.removeClass('blur-action')
     rows.removeClass('active');
     updateFavicon();


### PR DESCRIPTION
Turns out that the `Mute` and `Mark as Read` functions were missed when https://github.com/octobox/octobox/pull/308 was added, which looks like it's been causing some performance issues with https://octobox.io where people are inadvertently marking all of their notifications as read, not just the ones in the current view.

@nodunayo and I stumbled across this when we were testing some performance improvements and accidentally made 400+ simultaneous http requests to the GitHub API and got blocked in the process 😬 