### PR TITLE
Parallel API requests when muting

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -106,9 +106,7 @@ class NotificationsController < ApplicationController
   # HEAD 204
   #
   def mute_selected
-    selected_notifications.each do |notification|
-      notification.mute
-    end
+    Notification.mute(selected_notifications)
     head :ok
   end
 

--- a/test/controllers/notifications_controller_test.rb
+++ b/test/controllers/notifications_controller_test.rb
@@ -131,18 +131,11 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
     notification1 = create(:notification, user: @user, archived: false)
     notification2 = create(:notification, user: @user, archived: false)
     notification3 = create(:notification, user: @user, archived: false)
-    User.any_instance.stubs(:github_client).returns(mock.tap { |client|
-      client.expects(:update_thread_subscription).with(notification1.github_id, ignored: true).returns true
-      client.expects(:update_thread_subscription).with(notification2.github_id, ignored: true).returns true
-      client.expects(:mark_thread_as_read).with(notification1.github_id, read: true).returns true
-      client.expects(:mark_thread_as_read).with(notification2.github_id, read: true).returns true
-    })
+
+    Notification.expects(:mute).with([notification1, notification2])
+
     post '/notifications/mute_selected', params: { id: [notification1.id, notification2.id] }
     assert_response :ok
-
-    assert notification1.reload.archived?
-    assert notification2.reload.archived?
-    refute notification3.reload.archived?
   end
 
   test 'mutes all notifications in current scope' do
@@ -151,20 +144,11 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
     notification1 = create(:notification, user: @user, archived: false)
     notification2 = create(:notification, user: @user, archived: false)
     notification3 = create(:notification, user: @user, archived: false)
-    User.any_instance.stubs(:github_client).returns(mock.tap { |client|
-      client.expects(:update_thread_subscription).with(notification1.github_id, ignored: true).returns true
-      client.expects(:update_thread_subscription).with(notification2.github_id, ignored: true).returns true
-      client.expects(:update_thread_subscription).with(notification3.github_id, ignored: true).returns true
-      client.expects(:mark_thread_as_read).with(notification1.github_id, read: true).returns true
-      client.expects(:mark_thread_as_read).with(notification2.github_id, read: true).returns true
-      client.expects(:mark_thread_as_read).with(notification3.github_id, read: true).returns true
-    })
+
+    Notification.expects(:mute).with([notification1, notification2, notification3])
+
     post '/notifications/mute_selected', params: { id: ['all'] }
     assert_response :ok
-
-    assert notification1.reload.archived?
-    assert notification2.reload.archived?
-    assert notification3.reload.archived?
   end
 
   test 'marks read multiple notifications' do
@@ -173,8 +157,8 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
     notification2 = create(:notification, user: @user, archived: false)
     notification3 = create(:notification, user: @user, archived: false)
     User.any_instance.stubs(:github_client).returns(mock.tap { |client|
-      client.expects(:mark_thread_as_read).with(notification1.github_id, read: true).returns true
-      client.expects(:mark_thread_as_read).with(notification2.github_id, read: true).returns true
+      client.expects(:mark_thread_as_read).with(notification1.github_id).returns true
+      client.expects(:mark_thread_as_read).with(notification2.github_id).returns true
     })
     post '/notifications/mark_read_selected', params: { id: [notification1.id, notification2.id] }
     assert_response :ok
@@ -191,9 +175,9 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
     notification2 = create(:notification, user: @user, archived: false)
     notification3 = create(:notification, user: @user, archived: false)
     User.any_instance.stubs(:github_client).returns(mock.tap { |client|
-      client.expects(:mark_thread_as_read).with(notification1.github_id, read: true).returns true
-      client.expects(:mark_thread_as_read).with(notification2.github_id, read: true).returns true
-      client.expects(:mark_thread_as_read).with(notification3.github_id, read: true).returns true
+      client.expects(:mark_thread_as_read).with(notification1.github_id).returns true
+      client.expects(:mark_thread_as_read).with(notification2.github_id).returns true
+      client.expects(:mark_thread_as_read).with(notification3.github_id).returns true
     })
     post '/notifications/mark_read_selected', params: { id: ['all'] }
     assert_response :ok

--- a/test/models/notification_test.rb
+++ b/test/models/notification_test.rb
@@ -8,7 +8,7 @@ class NotificationTest < ActiveSupport::TestCase
     user = create(:user)
     notification = create(:notification, user: user)
     user.stubs(:github_client).returns(mock.tap { |client|
-      client.expects(:mark_thread_as_read).with(notification.github_id, read: true).returns true
+      client.expects(:mark_thread_as_read).with(notification.github_id).returns true
     })
     notification.mark_read
     refute notification.reload.unread?
@@ -27,16 +27,6 @@ class NotificationTest < ActiveSupport::TestCase
     notification = create(:notification, unread: true)
     notification.mark_read
     refute notification.reload.unread?
-  end
-
-  test 'mute ignores the thread and marks it as read' do
-    user = create(:user)
-    notification = create(:notification, user: user, archived: false)
-    user.stubs(:github_client).returns(mock.tap { |client|
-      client.expects(:update_thread_subscription).with(notification.github_id, ignored: true).returns true
-      client.expects(:mark_thread_as_read).with(notification.github_id, read: true).returns true
-    })
-    assert notification.mute
   end
 
   test 'unarchive_if_updated unarchives when updated_at is newer' do

--- a/test/models/notification_test.rb
+++ b/test/models/notification_test.rb
@@ -4,15 +4,6 @@ require 'test_helper'
 class NotificationTest < ActiveSupport::TestCase
   include NotificationTestHelper
 
-  test 'ignore_thread sends ignore request to github' do
-    user = create(:user)
-    notification = create(:notification, user: user, archived: false)
-    user.stubs(:github_client).returns(mock.tap { |client|
-      client.expects(:update_thread_subscription).with(notification.github_id, ignored: true).returns true
-    })
-    assert notification.ignore_thread
-  end
-
   test 'mark_read updates the github thread' do
     user = create(:user)
     notification = create(:notification, user: user)


### PR DESCRIPTION
This PR significantly speeds up muting multiple notifications as it parallelizes all the http requests (two per notification) to the GitHub API using the underlying Hydra API in Typhoeus.

Extra credit to @nodunayo for this PR, we worked on it together 🚄 