### PR TITLE
Handle GitHub API failures more elegantly on syncs

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -184,6 +184,12 @@ class NotificationsController < ApplicationController
       format.html { redirect_back fallback_location: root_path }
       format.json { head :ok }
     end
+  rescue Octokit::BadGateway, Octokit::ServiceUnavailable
+    flash[:error] = 'Syncing notifications with GitHub failed. Please try again.'
+    respond_to do |format|
+      format.html { redirect_back fallback_location: root_path }
+      format.json { head :service_unavailable }
+    end
   end
 
   private

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -184,7 +184,8 @@ class NotificationsController < ApplicationController
       format.html { redirect_back fallback_location: root_path }
       format.json { head :ok }
     end
-  rescue Octokit::BadGateway, Octokit::ServiceUnavailable
+  rescue Octokit::BadGateway, Octokit::ServiceUnavailable => e
+    logger.error("Failed to sync notifications for #{current_user.github_login} - #{e.class}: #{e.message}")
     flash[:error] = 'Syncing notifications with GitHub failed. Please try again.'
     respond_to do |format|
       format.html { redirect_back fallback_location: root_path }

--- a/test/controllers/notifications_controller_test.rb
+++ b/test/controllers/notifications_controller_test.rb
@@ -239,6 +239,23 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
     assert_response :ok
   end
 
+  test 'gracefully handles failed user notification syncs' do
+    sign_in_as(@user)
+    User.any_instance.stubs(:sync_notifications).raises(Octokit::BadGateway)
+
+    post "/notifications/sync"
+    assert_response :redirect
+    assert_equal "Syncing notifications with GitHub failed. Please try again.", flash[:error]
+  end
+
+  test 'gracefully handles failed user notification syncs as json' do
+    sign_in_as(@user)
+    User.any_instance.stubs(:sync_notifications).raises(Octokit::BadGateway)
+
+    post "/notifications/sync.json"
+    assert_response :service_unavailable
+  end
+
   test 'renders the inbox notifcation count in the sidebar' do
     sign_in_as(@user)
     create(:notification, user: @user, archived: false)


### PR DESCRIPTION
Closes #310, I'm fairly certain.

Like we do with the sync task, we should be catching API errors from GitHub and reporting on it, not falling apart and responding with a 500 error.