### PR TITLE
Google analytics option

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -126,10 +126,10 @@ GITHUB_CLIENT_ID=yourclientid GITHUB_CLIENT_SECRET=yourclientsecret docker-compo
 
 ### Production environment
 
-First, Create a network interface 
+First, Create a network interface
 
 ```bash
-docker network create octobox-network 
+docker network create octobox-network
 ```
 
 Second, download and run postgres instance
@@ -138,7 +138,7 @@ Second, download and run postgres instance
 docker run -d --network octobox-network --name=database.service.octobox.internal -e POSTGRES_PASSWORD=development -v pg_data:/var/lib/postgresql/data postgres:9.6-alpine
 ```
 
-**Note**: you should name your database instance `database.service.octobox.internal` so that `octobox` container can connect to it. 
+**Note**: you should name your database instance `database.service.octobox.internal` so that `octobox` container can connect to it.
 
 Then, run the following command to download the latest docker image and start octobox in the background.
 
@@ -271,3 +271,9 @@ To enable this feature set the following environment variable:
     FETCH_SUBJECT=true
 
 If you want this feature to work for private repositories, you'll need to [Customize the Scopes on Github](#customizing-the-scopes-on-github) adding `repo` scope to allow Octobox to get subject information for private issues and pull requests.
+
+## Google Analytics
+
+To enable Google analytics tracking set the following environment variable:
+
+    GA_ANALYTICS_ID=UA-XXXXXX-XX

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,6 +24,16 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="turbolinks-cache-control" content="no-preview">
 
+    <% if rails.env.production? && ENV["GA_ANALYTICS_ID"].present? %>
+      <script>
+        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+        ga('create', '<%= ENV["GA_ANALYTICS_ID"] %>', 'auto');
+      </script>
+    <% end %>
+
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
   </head>
@@ -39,5 +49,9 @@
     </div>
 
     <%= yield %>
+
+    <script>
+      if (typeof ga === 'function') { ga('send', 'pageview', location.pathname+location.search) }
+    </script>
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,7 +24,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="turbolinks-cache-control" content="no-preview">
 
-    <% if rails.env.production? && ENV["GA_ANALYTICS_ID"].present? %>
+    <% if Rails.env.production? && ENV["GA_ANALYTICS_ID"].present? %>
       <script>
         (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
         (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,7 +24,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="turbolinks-cache-control" content="no-preview">
 
-    <% if Rails.env.production? && ENV["GA_ANALYTICS_ID"].present? %>
+    <% if Rails.env.production? && Rails.application.secrets.google_analytics_id.present? %>
       <script>
         (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
         (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -13,6 +13,7 @@
 default: &default
   github_client_id:     <%= ENV['GITHUB_CLIENT_ID']     %>
   github_client_secret: <%= ENV['GITHUB_CLIENT_SECRET'] %>
+  google_analytics_id:  <%= ENV['GA_ANALYTICS_ID'] %>
 
 development:
   <<: *default


### PR DESCRIPTION
I'd like to measure usage of the UI on https://octobox.io with Google Analytics, without forcing everyone running their own to also use that tracking, so it's enabled with an `ENV` var.