### PR TITLE
Fix cursor bug with archiving last notification

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -252,10 +252,11 @@ function resetCursorAfterRowsRemoved(ids) {
   while ( $.inArray(getIdsFromRows(current)[0], ids) > -1 && current.next().length > 0) {
     current = current.next();
   }
-  window.current_id = getIdsFromRows(current)[0];
-  if ( $.inArray(window.current_id, ids ) > -1 ) {
-    window.current_id = getIdsFromRows(getMarkedRows(true).last())[0];
+  while ( $.inArray(getIdsFromRows(current)[0], ids) > -1 && current.prev().length > 0) {
+    current = current.prev();
   }
+
+  window.current_id = getIdsFromRows(current)[0];
   Turbolinks.visit("/"+location.search);
 }
 


### PR DESCRIPTION
If you have your cursor on the last notification in the window and archive it, the selection would stay on the removed row (and the cursor would subsequently no longer work).

Scan up as well as down for a valid cursor location.

Fixes #416 

![](http://screenshots.chrisarcand.com/7pncu.gif)