### PR TITLE
Add subject syncing to octobox.io omissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,12 @@ You can use Octobox right now at [octobox.io](https://octobox.io), a shared inst
 
 **Note:** octobox.io has a few features intentionally disabled:
 
+* Subject syncing (includes authorship and open/closed/merged status information) ([#411](https://github.com/octobox/octobox/pull/411))
 * Auto refreshing of notifications page ([#200](https://github.com/octobox/octobox/pull/200))
 * Personal Access Tokens ([#185](https://github.com/octobox/octobox/pull/185))
 
 Features are disabled for various reasons, such as not wanting to store users' tokens at this time.
+Some features might never be enabled, and some just might have other prerequisite work pending completion.
 
 ### Install
 


### PR DESCRIPTION
I know some of the larger issues we've kept open pending deploying to octobox.io, but I'd like to add subject syncing and anything else to this list that isn't depoyed on octobox.io so we can actually close the related issues; it'd be a bit nicer to triage what's actually to-be-done in the issue tracker. The example here would be #4 

wdyt @andrew?