### PR TITLE
Use API-given HTML URLs instead of parsing

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -122,6 +122,7 @@ class Notification < ApplicationRecord
         create_subject({
           state: remote_subject.merged_at.present? ? 'merged' : remote_subject.state,
           author: remote_subject.user.login,
+          html_url: remote_subject.html_url,
           created_at: remote_subject.created_at,
           updated_at: remote_subject.updated_at
         })
@@ -131,6 +132,7 @@ class Notification < ApplicationRecord
 
         create_subject({
           author: remote_subject.author.login,
+          html_url: remote_subject.html_url,
           created_at: remote_subject.created_at,
           updated_at: remote_subject.updated_at
         })

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -66,8 +66,9 @@ class Notification < ApplicationRecord
   end
 
   def web_url
-    Octobox::SubjectUrlParser.new(subject_url, latest_comment_url: latest_comment_url)
-      .to_web_url
+    url = subject.try(:html_url) || subject_url # Use the sync'd HTML URL if possible, else the API one
+    Octobox::SubjectUrlParser.new(url, latest_comment_url: latest_comment_url)
+      .to_html_url
   end
 
   def repo_url

--- a/db/migrate/20170907022825_add_html_url_to_subjects.rb
+++ b/db/migrate/20170907022825_add_html_url_to_subjects.rb
@@ -1,0 +1,5 @@
+class AddHtmlUrlToSubjects < ActiveRecord::Migration[5.1]
+  def change
+    add_column :subjects, :html_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170829135808) do
+ActiveRecord::Schema.define(version: 20170907022825) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,6 +44,7 @@ ActiveRecord::Schema.define(version: 20170829135808) do
     t.string "author"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "html_url"
     t.index ["url"], name: "index_subjects_on_url"
   end
 

--- a/lib/octobox/subject_url_parser.rb
+++ b/lib/octobox/subject_url_parser.rb
@@ -11,17 +11,31 @@ module Octobox
       @github_api_prefix = github_api_prefix
       @github_domain = github_domain
       @latest_comment_url = latest_comment_url
+
+      raise ArgumentError, "Unidentifiable URL: '#{url}'" unless html_url? || api_url?
     end
 
     # NOTE Releases are defaulted to the release index page
-    def to_web_url
-      web_url = url.gsub("#{github_api_prefix}/repos", github_domain)
-        .gsub('/pulls/', '/pull/')
-        .gsub('/commits/', '/commit/')
-        .gsub(/\/releases\/\d+/, '/releases/')
-      web_url << latest_comment_anchor
+    def to_html_url
+      html_url = if api_url?
+                   url.gsub("#{github_api_prefix}/repos", github_domain)
+                     .gsub('/pulls/', '/pull/')
+                     .gsub('/commits/', '/commit/')
+                     .gsub(/\/releases\/\d+/, '/releases/')
+                 else
+                   url
+                 end
+      html_url << latest_comment_anchor
 
-      web_url
+      html_url
+    end
+
+    def html_url?
+      /#{github_domain}/ =~ url
+    end
+
+    def api_url?
+      /#{github_api_prefix}/ =~ url
     end
 
     def pull_request?

--- a/lib/octobox/subject_url_parser.rb
+++ b/lib/octobox/subject_url_parser.rb
@@ -1,5 +1,12 @@
 module Octobox
   class SubjectUrlParser
+    # DEPRECATED
+    # This parser acts primarily as a hack to convert GitHub API URLs in to HTML ones
+    # With the recent addition of subject syncing, exact HTML URLs are available directly
+    # from the API and so this parsing need not happen.
+    #
+    # In the future this class will be replaced by one that simply handles comment anchor logic only.
+
     attr_reader :url,
                 :github_api_prefix,
                 :github_domain

--- a/test/lib/octobox/subject_url_parser_test.rb
+++ b/test/lib/octobox/subject_url_parser_test.rb
@@ -1,54 +1,79 @@
 require 'test_helper'
 
 class SubjectUrlParserTest < ActiveSupport::TestCase
-  test "to_web_url correctly converts an API issue to an HTML one" do
+  test "to_html_url correctly converts an API issue to an HTML one" do
     url = "https://api.github.com/repos/octokit/octokit.rb/issues/123"
     without_comment = Octobox::SubjectUrlParser.new(url)
     with_comment    = Octobox::SubjectUrlParser.new(url, latest_comment_url: "https://api.github.com/repos/octokit/octokit.rb/comments/1")
 
-    assert_equal "https://github.com/octokit/octokit.rb/issues/123", without_comment.to_web_url
-    assert_equal "https://github.com/octokit/octokit.rb/issues/123#issuecomment-1", with_comment.to_web_url
+    assert_equal "https://github.com/octokit/octokit.rb/issues/123", without_comment.to_html_url
+    assert_equal "https://github.com/octokit/octokit.rb/issues/123#issuecomment-1", with_comment.to_html_url
   end
 
-  test "to_web_url correctly coverts an API commit URL to an HTML one" do
+  test "to_html_url correctly coverts an API commit URL to an HTML one" do
     url = "https://api.github.com/repos/octocat/Hello-World/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e"
     without_comment = Octobox::SubjectUrlParser.new(url)
     with_comment    = Octobox::SubjectUrlParser.new(url, latest_comment_url: "https://api.github.com/repos/octocat/Hello-World/pulls/comments/1")
 
-    assert_equal "https://github.com/octocat/Hello-World/commit/6dcb09b5b57875f334f61aebed695e2e4193db5e", without_comment.to_web_url
-    assert_equal "https://github.com/octocat/Hello-World/commit/6dcb09b5b57875f334f61aebed695e2e4193db5e#commitcomment-1", with_comment.to_web_url
+    assert_equal "https://github.com/octocat/Hello-World/commit/6dcb09b5b57875f334f61aebed695e2e4193db5e", without_comment.to_html_url
+    assert_equal "https://github.com/octocat/Hello-World/commit/6dcb09b5b57875f334f61aebed695e2e4193db5e#commitcomment-1", with_comment.to_html_url
+  end
+
+  test "to_html_url correctly identifies and doesn't convert an already HTML url" do
+    url = "https://github.com/octokit/octokit.rb/issues/123"
+    without_comment = Octobox::SubjectUrlParser.new(url)
+    with_comment    = Octobox::SubjectUrlParser.new(url, latest_comment_url: "https://api.github.com/repos/octokit/octokit.rb/comments/1")
+
+    assert_equal "https://github.com/octokit/octokit.rb/issues/123", without_comment.to_html_url
+    assert_equal "https://github.com/octokit/octokit.rb/issues/123#issuecomment-1", with_comment.to_html_url
   end
 
   test "it correctly identifies an API pull request URL" do
-    assert_pull_request_url Octobox::SubjectUrlParser.new("https://api.github.com/repos/octocat/Hello-World/pulls/1347")
+    parser = Octobox::SubjectUrlParser.new("https://api.github.com/repos/octocat/Hello-World/pulls/1347")
+    assert parser.api_url?
+    assert_pull_request_url parser
   end
 
   test "it correctly identifies a HTML pull request URL" do
-    assert_pull_request_url Octobox::SubjectUrlParser.new("https://github.com/octocat/Hello-World/pull/1347")
+    parser = Octobox::SubjectUrlParser.new("https://github.com/octocat/Hello-World/pull/1347")
+    assert parser.html_url?
+    assert_pull_request_url parser
   end
 
   test "it correctly identifies an API issue URL" do
-    assert_issue_url Octobox::SubjectUrlParser.new("https://api.github.com/repos/octocat/Hello-World/issues/1347")
+    parser = Octobox::SubjectUrlParser.new("https://api.github.com/repos/octocat/Hello-World/issues/1347")
+    assert parser.api_url?
+    assert_issue_url parser
   end
 
   test "it correctly identifies a HTML issue URL" do
-    assert_issue_url Octobox::SubjectUrlParser.new("https://github.com/octocat/Hello-World/issues/1347")
+    parser = Octobox::SubjectUrlParser.new("https://github.com/octocat/Hello-World/issues/1347")
+    assert parser.html_url?
+    assert_issue_url parser
   end
 
   test "it correctly identifies an API commit URL" do
-    assert_commit_url Octobox::SubjectUrlParser.new("https://api.github.com/repos/octocat/Hello-World/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e")
+    parser = Octobox::SubjectUrlParser.new("https://api.github.com/repos/octocat/Hello-World/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e")
+    assert parser.api_url?
+    assert_commit_url parser
   end
 
   test "it correctly identifies a HTML commit URL" do
-    assert_commit_url Octobox::SubjectUrlParser.new("https://github.com/octocat/Hello-World/commit/6dcb09b5b57875f334f61aebed695e2e4193db5e")
+    parser = Octobox::SubjectUrlParser.new("https://github.com/octocat/Hello-World/commit/6dcb09b5b57875f334f61aebed695e2e4193db5e")
+    assert parser.html_url?
+    assert_commit_url parser
   end
 
   test "it correctly identifies an API release URL" do
-    assert_release_url Octobox::SubjectUrlParser.new("https://api.github.com/repos/octocat/Hello-World/releases/1")
+    parser = Octobox::SubjectUrlParser.new("https://api.github.com/repos/octocat/Hello-World/releases/1")
+    assert parser.api_url?
+    assert_release_url parser
   end
 
   test "it correctly identifies a HTML release URL" do
-    assert_release_url Octobox::SubjectUrlParser.new("https://github.com/octocat/Hello-World/releases/v1.0.0")
+    parser = Octobox::SubjectUrlParser.new("https://github.com/octocat/Hello-World/releases/v1.0.0")
+    assert parser.html_url?
+    assert_release_url parser
   end
 
   def assert_pull_request_url(parser)


### PR DESCRIPTION
This makes the necessary changes to sync the `html_url` field found on subjects and use that, if possible, instead of doing the hacky API => HTML URL parsing we currently do with notifications only. Note that it's currently backwards compatible with apps not using subject fetching.

In the future, I am hoping we stop kidding ourselves that we can continue to support a non-subject-fetching configuration of the app, what with the plethora of great features subject syncing is getting us and feedback we're getting from it. :stuck_out_tongue_winking_eye: In that event, we'd then remove the hacky parser entirely and just have something for comment anchoring only, as noted in my deprecation comment.

Also note that the backwards compatibility bit enables you to not bother having to go back and re-sync all subjects and notifications, if you don't want to. For example, note the URLs on the two releases here, where 1.5.1 has a subject and 1.5.0 does not:

![](http://screenshots.chrisarcand.com/6xd4v.gif)

Fixes #103