### PR TITLE
Allow API requests past protect_from_forgery

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 class ApplicationController < ActionController::Base
-  protect_from_forgery with: :exception
+  API_HEADER = 'X-Octobox-API'
+
+  protect_from_forgery with: :exception, unless: -> { octobox_api_request? }
   helper_method :current_user, :logged_in?
   before_action :authenticate_user!
 
@@ -15,11 +17,16 @@ class ApplicationController < ActionController::Base
   end
 
   def current_user
-    return nil unless cookies.permanent.signed[:user_id].present?
-    @current_user ||= User.find_by(id: cookies.permanent.signed[:user_id])
+    user_id = cookies.permanent.signed[:user_id]
+    return nil unless user_id.present?
+    @current_user ||= User.find_by(id: user_id)
   end
 
   def logged_in?
     !current_user.nil?
+  end
+
+  def octobox_api_request?
+    request.headers[API_HEADER].present?
   end
 end

--- a/test/integration/protect_from_forgery_test.rb
+++ b/test/integration/protect_from_forgery_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+
+class ProtectFromForgeryTest < ActionDispatch::IntegrationTest
+  setup do
+    ActionController::Base.allow_forgery_protection = true
+  end
+
+  teardown do
+    ActionController::Base.allow_forgery_protection = false
+  end
+
+  test "raises an exception if request is made without key" do
+    assert_raises ActionController::InvalidAuthenticityToken do
+      post "/notifications/sync.json"
+    end
+  end
+
+  test "doesn't raise an exception if request is made with custom API header" do
+    post "/notifications/sync.json", headers: { ApplicationController::API_HEADER => 'true' }
+  end
+end


### PR DESCRIPTION
Allows API requests a method to bypass the CSRF protection. Adding a custom header that disables the protection makes it impossible for a browser to disable the CSRF protection but easy for the application using the API to opt out. Signed cookies are still used for authentication, so the API requests still need to authenticate first and pass the user_id.