### PR TITLE
Only mark threads as read if they are currently unread

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -50,6 +50,7 @@ class Notification < ApplicationRecord
   end
 
   def mark_read
+    return unless unread?
     self[:unread] = false
     save(touch: false) if changed?
     user.github_client.mark_thread_as_read(github_id, read: true)


### PR DESCRIPTION
Small optimization to help with https://github.com/octobox/octobox/issues/458, skip marking a notification as read if it's already read, should save a few API calls when users do "mark all as read"