### PR TITLE
Fix Mobile Sidebar Height

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -428,6 +428,7 @@ td.keys {
 
   .flex-content {
     position: relative;
+    height: 100%;
     -webkit-transition: all .25s ease-out;
          -o-transition: all .25s ease-out;
             transition: all .25s ease-out;


### PR DESCRIPTION
This fixes the issue with sidebar height on mobile by extending the parent container to height 100%.

Fixes #283 and fixes #456.

![localhost-3000--reason subscribed repo apollographql 2fapollo 3](https://user-images.githubusercontent.com/816517/30410366-9f8497c6-98d8-11e7-80a7-45f456119b0f.png)
