### PR TITLE
Issue #327 - send all params in the redirect url

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -223,7 +223,10 @@ class NotificationsController < ApplicationController
     return unless page > 1
     total_pages = (scope.count / per_page.to_f).ceil
     page_num = [page, total_pages].min
-    redirect_to url_for(page: page_num) if page_num != page
+    redirect_params = {
+      page: page_num
+    }.merge(params.except(:page).permit!)
+    redirect_to url_for(redirect_params) if page_num != page
   end
 
   def find_notification

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -223,9 +223,7 @@ class NotificationsController < ApplicationController
     return unless page > 1
     total_pages = (scope.count / per_page.to_f).ceil
     page_num = [page, total_pages].min
-    redirect_params = {
-      page: page_num
-    }.merge(params.except(:page).permit!)
+    redirect_params = params.permit!.merge(page: page_num)
     redirect_to url_for(redirect_params) if page_num != page
   end
 

--- a/test/controllers/notifications_controller_test.rb
+++ b/test/controllers/notifications_controller_test.rb
@@ -80,6 +80,14 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to '/?page=2'
   end
 
+  test 'redirect back to last page of results if page is out of bounds and send filters' do
+    sign_in_as(@user)
+    25.times.each { create(:notification, user: @user, archived: false, unread: true) }
+
+    get '/?page=3&reason=subscribed&unread=true'
+    assert_redirected_to '/?page=2&reason=subscribed&unread=true'
+  end
+
   test 'archives multiple notifications' do
     sign_in_as(@user)
     notification1 = create(:notification, user: @user, archived: false)


### PR DESCRIPTION
Issue #327

Only the page param was being sent. Now it allows all the filters to go through and override the page for the correct page number.