### PR TITLE
Ask for repo scope when subject fetching is enabled

### DIFF
--- a/lib/octobox/configurator.rb
+++ b/lib/octobox/configurator.rb
@@ -16,7 +16,10 @@ module Octobox
     end
 
     def scopes
-      default_scopes = Octobox.restricted_access_enabled? ? 'notifications, read:org' : 'notifications'
+      default_scopes = 'notifications'
+      default_scopes += ', read:org' if Octobox.restricted_access_enabled?
+      default_scopes += ', repo'     if fetch_subject
+
       ENV.fetch('GITHUB_SCOPE', default_scopes)
     end
 


### PR DESCRIPTION
Discovered this setting up a new Octobox instance. Confusing to have subject fetching enabled but the application doesn't realize it needs it for new users!

I didn't add a top level fetch_subject_enabled?, I'm not sure if that's actually useful or not, but feel free to add one if you want.