### PR TITLE
Show loading screen on initial notification sync

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,7 +3,7 @@ class ApplicationController < ActionController::Base
   API_HEADER = 'X-Octobox-API'
 
   protect_from_forgery with: :exception, unless: -> { octobox_api_request? }
-  helper_method :current_user, :logged_in?
+  helper_method :current_user, :logged_in?, :initial_sync?
   before_action :authenticate_user!
 
   before_bugsnag_notify :add_user_info_to_bugsnag if Rails.env.production?
@@ -45,6 +45,10 @@ class ApplicationController < ActionController::Base
 
   def logged_in?
     !current_user.nil?
+  end
+
+  def initial_sync?
+    current_user.last_synced_at.nil?
   end
 
   def octobox_api_request?

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -9,11 +9,11 @@ class SessionsController < ApplicationController
 
   def create
     user = User.find_by_auth_hash(auth_hash) || User.new
-
     user.assign_from_auth_hash(auth_hash)
-    user.sync_notifications
 
     cookies.permanent.signed[:user_id] = {value: user.id, httponly: true}
+
+    user.sync_notifications unless initial_sync?
     redirect_to root_path
   end
 

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -38,7 +38,7 @@
           <%= select_all_button(@cur_selected, @total) %>
           <% end %>
           <%= link_to sync_notifications_path(filters), class: 'btn btn-default sync', 'data-toggle' => 'tooltip', 'data-placement' => 'bottom', 'data-turbolinks' => false, 'data-animation' => 'false', 'data-position' => 'bottom', 'title' => 'Refresh list', method: :post do %>
-            <%= octicon 'sync', :height => 16 %>
+            <%= octicon 'sync', height: 16, class: "#{'spinning' if initial_sync?}" %>
           <% end %>
           <%= archive_selected_button %>
           <%= mute_selected_button %>
@@ -49,6 +49,13 @@
         <table class='table table-hover table-notifications js-table-notifications' data-refresh-interval=<%= current_user.effective_refresh_interval %>>
           <% if @notifications.to_a.any? %>
             <%= render partial: 'notification', collection: @notifications %>
+          <% elsif initial_sync? %>
+            <div class="blankslate blankslate-spacious blankslate-clean-background">
+              <%= octicon 'cloud-download', height: 32, class: 'blankslate-icon' %>
+              <h3>Syncing your notifications for the first time...</h3>
+              <p>This might take a minute or two</p>
+            </div>
+            <%= javascript_tag "sync()" %>
           <% elsif no_url_filter_parameters_present %>
             <div class="blankslate blankslate-spacious blankslate-clean-background">
               <%= octicon 'mail-read', height: 32, class: 'blankslate-icon' %>

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -26,11 +26,11 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to root_path
   end
 
-  test 'POST #create forces the user to sync their notifications' do
+  test 'POST #create forces the user to sync their notifications if they have synced before' do
     OmniAuth.config.mock_auth[:github].uid = @user.github_id
 
     post '/auth/github/callback'
-    assert_requested @notifications_request, times: 2
+    assert_requested @notifications_request
   end
 
   test 'POST #create redirects to the root_path with an error message if they are not an org member' do

--- a/test/factories/user.rb
+++ b/test/factories/user.rb
@@ -3,6 +3,7 @@ FactoryGirl.define do
     sequence(:github_id, 1000000){|n| n}
     access_token { SecureRandom.hex(20) }
     github_login {"user#{github_id}"}
+    last_synced_at { Time.parse('2016-12-19T12:00:00Z') }
 
     factory :token_user do
       personal_access_token 'deadbeef'

--- a/test/services/download_service_test.rb
+++ b/test/services/download_service_test.rb
@@ -5,7 +5,7 @@ class DownloadServiceTest < ActiveSupport::TestCase
   include NotificationTestHelper
 
   test '#download fetches all read notification for a new user' do
-    user = create(:user)
+    user = create(:user, last_synced_at: nil)
     all_notifications = notifications_from_fixture('newuser_all_notifications.json')
     expected_attributes = build_expected_attributes(all_notifications)
     download_service = DownloadService.new(user)


### PR DESCRIPTION
When signing up as a new user, you'll currently stare at a blank screen while the OAuth callback endpoint is getting hit and your notifications are being synced for the first time. For users with a huge number of notifications, this can take a *long* time (multiple minutes) without any feedback to the user at all. It also usually times out and gives a confusing auth error, leaving the user wondering what happened.

These changes make an exception to the initial sync process, instead loading the page and triggering a sync event with a loading screen to assure the user that things are going and it'll take a bit.

Note: I'm *quite* removed from front end work; I know there's a million better ways to probably do this and the Javascript tag in the middle of the markup might be frowned upon. Feedback welcome, though this works just fine for my uses.

Note No. 2: This solution is really just a temporary shim. Syncs should eventually be run in background jobs but I didn't want to open that can of worms right now.

After authorizing the OAuth scopes for a new user, you'll be immediately welcomed to this screen while waiting for your notifications to sync, which stylistically matches the other content we put there:

![](http://screenshots.chrisarcand.com/mr2bh.gif)