### PR TITLE
Fix bot author URLs

### DIFF
--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -1,7 +1,24 @@
 class Subject < ApplicationRecord
   has_many :notifications, foreign_key: :subject_url, primary_key: :url
 
+  BOT_AUTHOR_REGEX = /\A(.*)\[bot\]\z/.freeze
+  private_constant :BOT_AUTHOR_REGEX
+
   def author_url
-    "#{Octobox.config.github_domain}/#{author}"
+    "#{Octobox.config.github_domain}#{author_url_path}"
+  end
+
+  private
+
+  def author_url_path
+    if bot_author?
+      "/apps/#{BOT_AUTHOR_REGEX.match(author)[1]}"
+    else
+      "/#{author}"
+    end
+  end
+
+  def bot_author?
+    BOT_AUTHOR_REGEX.match?(author)
   end
 end

--- a/test/models/subject_test.rb
+++ b/test/models/subject_test.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+class NotificationTest < ActiveSupport::TestCase
+  test 'author_url returns a user url with users' do
+    subject = create(:subject, author: "Fryguy")
+    assert_equal "https://github.com/Fryguy", subject.author_url
+  end
+
+  test 'author_url returns a GitHub apps URL with bots' do
+    subject = create(:subject, author: "greenkeeper[bot]")
+    assert_equal "https://github.com/apps/greenkeeper", subject.author_url
+  end
+end


### PR DESCRIPTION
Fixes #478

I left the author[bot] look because I think it's sort of nice to see that it's a bot; someone else is welcome to make it look prettier if they like.