### PR TITLE
Don't run fetch_unread_notifications for new users

### DIFF
--- a/app/services/download_service.rb
+++ b/app/services/download_service.rb
@@ -81,6 +81,6 @@ class DownloadService
   def new_user_fetch
     headers = {cache_control: %w(no-store no-cache)}
     notifications = fetch_notifications(params: {all: true, headers: headers})
-    process_notifications(notifications)
+    process_notifications(notifications, unarchive: true)
   end
 end

--- a/app/services/download_service.rb
+++ b/app/services/download_service.rb
@@ -26,10 +26,10 @@ class DownloadService
 
     if user.last_synced_at
       fetch_read_notifications
+      fetch_unread_notifications
     else
       new_user_fetch
     end
-    fetch_unread_notifications
     user.update_column(:last_synced_at, timestamp)
   end
 


### PR DESCRIPTION
I'm pretty sure that we don't need to make this extra http request for new users as the `#new_user_fetch` method passes `all: true`, so it already will have synced all the notifications for the user, both read and unread.

Opening this to check that I'm not crazy and/or remember how this crazy bit of code actually works!