### PR TITLE
Add Safari pinned tab icon

### DIFF
--- a/app/views/layouts/_favicons.html.erb
+++ b/app/views/layouts/_favicons.html.erb
@@ -12,6 +12,7 @@
 <link rel="icon" type="image/png" sizes="96x96" href="/favicon-96x96.png">
 <link id="favicon" rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
 <link rel="manifest" href="/manifest.json">
+<link rel="mask-icon" href="<%= asset_path "octobox.svg" %>" color="black">
 <meta name="msapplication-TileColor" content="#ffffff">
 <meta name="msapplication-TileImage" content="/ms-icon-144x144.png">
 <meta name="theme-color" content="#ffffff">


### PR DESCRIPTION
Hi there! Just wanted to add a pinned tab icon for Safari. [Per the documentation](https://developer.apple.com/library/content/documentation/AppleApplications/Reference/SafariWebContent/pinnedTabs/pinnedTabs.html), it should be an SVG image, and you can select the color; I used the already-present SVG logo and went with classic black:

![Safari pinned tab icon](https://user-images.githubusercontent.com/2745/31202325-c63d71a8-a927-11e7-9555-530fec24ae77.png)

Let me know if you need anything else to merge!