### PR TITLE
Add handler for notifications/sync on GET request

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,9 +15,10 @@ Rails.application.routes.draw do
     collection do
       post :archive_selected
       post :sync
+      get  :sync
       post :mute_selected
       post :mark_read_selected
-      get :unread_count
+      get  :unread_count
     end
 
     member do

--- a/test/controllers/notifications_controller_test.rb
+++ b/test/controllers/notifications_controller_test.rb
@@ -220,6 +220,13 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
     assert_response :ok
   end
 
+  test 'get to syncs redirects' do
+    sign_in_as(@user)
+
+    get "/notifications/sync"
+    assert_response :redirect
+  end
+
   test 'gracefully handles failed user notification syncs' do
     sign_in_as(@user)
     User.any_instance.stubs(:sync_notifications).raises(Octokit::BadGateway)


### PR DESCRIPTION
Sometimes when you leave Octobox open for a long time, a request to `POST /notifications/sync` gets interrupted. This, in turn, causes the app to send a `GET` request and 404.

Instead, handle that failure case by allowing `POST` or `GET`. `GET` is basically undocumented, as it's not listed in the `notifications_controller` doc, so the only supported way would remain a `POST` with a fallback on `GET` for this edge case.