### PR TITLE
Add icon and colour for security alert notifications

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,6 +14,7 @@ $panel-default-heading-bg: #f8f8f8;
 $panel-footer-bg: $panel-default-heading-bg;
 $subscribed-color: #a128ca;
 $team_mention-color: #5d477e;
+$security_alert-color: #800000;
 
 @import "bootstrap-sprockets";
 @import "bootstrap";
@@ -534,6 +535,17 @@ td.keys {
 
 .text-team_mention{
   fill: $team_mention-color;
+  &.sidebar-icon {
+    fill: $text-muted;
+  }
+}
+
+.label-security_alert{
+  background-color: $security_alert-color;
+}
+
+.text-security_alert{
+  fill: $security_alert-color;
   &.sidebar-icon {
     fill: $text-muted;
   }

--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -1,12 +1,13 @@
 module NotificationsHelper
   REASON_LABELS = {
-    'comment'      => 'primary',
-    'author'       => 'success',
-    'state_change' => 'info',
-    'mention'      => 'warning',
-    'assign'       => 'danger',
-    'subscribed'   => 'subscribed',
-    'team_mention' => 'team_mention'
+    'comment'        => 'primary',
+    'author'         => 'success',
+    'state_change'   => 'info',
+    'mention'        => 'warning',
+    'assign'         => 'danger',
+    'subscribed'     => 'subscribed',
+    'team_mention'   => 'team_mention',
+    'security_alert' => 'security_alert'
   }.freeze
 
   STATE_LABELS = {
@@ -16,11 +17,12 @@ module NotificationsHelper
   }
 
   SUBJECT_TYPES = {
-    'RepositoryInvitation' => 'mail-read',
-    'Issue'                => 'issue-opened',
-    'PullRequest'          => 'git-pull-request',
-    'Commit'               => 'git-commit',
-    'Release'              => 'tag'
+    'RepositoryInvitation'         => 'mail-read',
+    'Issue'                        => 'issue-opened',
+    'PullRequest'                  => 'git-pull-request',
+    'Commit'                       => 'git-commit',
+    'Release'                      => 'tag',
+    'RepositoryVulnerabilityAlert' => 'alert'
   }.freeze
 
   def filters

--- a/app/views/notifications/_filter-list.html.erb
+++ b/app/views/notifications/_filter-list.html.erb
@@ -16,7 +16,7 @@
       <% end %>
 
       <%= filter_option :type do %>
-        <%= params[:type].underscore.humanize %>
+        <%= params[:type].underscore.gsub('repository', '').humanize %>
       <% end %>
 
       <%= filter_option :owner do %>

--- a/app/views/notifications/_sidebar.html.erb
+++ b/app/views/notifications/_sidebar.html.erb
@@ -62,7 +62,7 @@
       <% else %>
           <%= octicon notification_icon(type), height: 16, class: 'sidebar-icon star-active' %>
       <% end %>
-      <%= type.underscore.humanize %>
+      <%= type.underscore.gsub('repository', '').humanize %>
 
     <% end %>
   <% end %>


### PR DESCRIPTION
Security alerts shipped on GitHub and come with a new notification type: https://github.com/blog/2470-introducing-security-alerts-on-github

Currently looks like this: 

![image](https://user-images.githubusercontent.com/1060/33368437-9b5b944a-d4e9-11e7-8056-54c2ef9bb28a.png)

This PR makes it look like this: 

![screen shot 2017-11-29 at 9 42 48 am](https://user-images.githubusercontent.com/1060/33368469-ae45a05a-d4e9-11e7-85ce-c3a103fbd7eb.png)

The icon and color are quite striking, but then so are the alert types!