### PR TITLE
Fix escape key on help modal triggering page reload

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -289,7 +289,9 @@ function autoSync() {
 }
 
 function clearFilters() {
-  Turbolinks.visit("/");
+  if ($("#help-box:hidden") == 0) {
+    Turbolinks.visit("/");
+  }
 }
 
 function setAutoSyncTimer() {


### PR DESCRIPTION
The help modal is a bootstrap modal that binds escape to exiting the modal. This conflicts with the escape keyboard shortcut, and as a result, any selections made are lost during the reload event. This PR stops the escape keyboard shortcut from performing its actions unless the help modal isn't visible.

I just started using Octobox today, and while learning it, I opened the keyboard shortcuts only to find my selection reset during close. Since this is probably one of the first ways people learn how to use shortcuts, I think it's worth fixing.