### PR TITLE
Show the latest Git SHA in Settings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem 'uglifier'
 gem 'pg_search'
 gem 'jbuilder'
 gem 'rake'
+gem 'git'
 
 group :development, :test do
   gem 'byebug', platform: :mri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,13 +50,13 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     arel (8.0.0)
     ast (2.3.0)
-    autoprefixer-rails (7.2.2)
+    autoprefixer-rails (7.2.3)
       execjs
     bindex (0.5.0)
     bootstrap-sass (3.3.7)
       autoprefixer-rails (>= 5.2.1)
       sass (>= 3.3.4)
-    bugsnag (6.2.0)
+    bugsnag (6.3.0)
     builder (3.2.3)
     byebug (9.1.0)
     codeclimate-test-reporter (1.0.7)
@@ -89,6 +89,7 @@ GEM
       faraday (>= 0.7.4, < 1.0)
     ffi (1.9.18)
     get_process_mem (0.2.1)
+    git (1.3.0)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     hashdiff (0.3.7)
@@ -163,10 +164,10 @@ GEM
     omniauth-github (1.3.0)
       omniauth (~> 1.5)
       omniauth-oauth2 (>= 1.4.0, < 2.0)
-    omniauth-oauth2 (1.4.0)
-      oauth2 (~> 1.0)
+    omniauth-oauth2 (1.5.0)
+      oauth2 (~> 1.1)
       omniauth (~> 1.2)
-    parallel (1.12.0)
+    parallel (1.12.1)
     parser (2.4.0.2)
       ast (~> 2.3)
     pg (0.21.0)
@@ -211,24 +212,23 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
-    rainbow (2.2.2)
-      rake
+    rainbow (3.0.0)
     rake (12.3.0)
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
     request_store (1.3.2)
-    rubocop (0.51.0)
+    rubocop (0.52.0)
       parallel (~> 1.10)
-      parser (>= 2.3.3.1, < 3.0)
+      parser (>= 2.4.0.2, < 3.0)
       powerpack (~> 0.1)
-      rainbow (>= 2.2.2, < 3.0)
+      rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.9.0)
     ruby_dep (1.5.0)
     safe_yaml (1.0.4)
-    sass (3.5.3)
+    sass (3.5.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -304,6 +304,7 @@ DEPENDENCIES
   dotenv-rails
   factory_girl
   faraday_middleware
+  git
   jbuilder
   jquery-rails
   kaminari

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -623,3 +623,7 @@ td.keys {
 .octicon.inverse{
   fill: #fff;
 }
+
+.settings-sha {
+  margin: 35px 0 10px;
+}

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -20,7 +20,7 @@ class UsersController < ApplicationController
   def profile; end
 
   def edit
-    @latest_git_sha = Git.open(Rails.root)&.object('HEAD').sha[0..6]
+    @latest_git_sha = Git.open(Rails.root).object('HEAD').sha[0..6] rescue nil
   end
 
   # Update a user profile. Only updates the current user

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -19,7 +19,9 @@ class UsersController < ApplicationController
   # }
   def profile; end
 
-  def edit; end
+  def edit
+    @latest_git_sha = Git.open(Rails.root)&.object('HEAD').sha[0..6]
+  end
 
   # Update a user profile. Only updates the current user
   #

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,5 +1,14 @@
 <div class="container">
-  <h1>Settings</h1>
+  <div class="row">
+    <div class="col-xs-6">
+      <h1>Settings</h1>
+    </div>
+    <div class="col-xs-6">
+      <% if @latest_git_sha %>
+        <p class="settings-sha pull-right" title="Latest Git commit SHA">Version: <%= @latest_git_sha %></p>
+      <% end %>
+    </div>
+  </div>
   <% if Octobox.refresh_interval_enabled? || Octobox.personal_access_tokens_enabled? %>
     <hr>
 

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -29,6 +29,18 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_template 'users/profile'
   end
 
+  test 'displays settings page' do
+    sign_in_as(@user)
+    get settings_path
+    assert_template 'users/edit'
+  end
+
+  test 'assigns latest git sha on settings page' do
+    sign_in_as(@user)
+    get settings_path
+    assert_equal assigns(:latest_git_sha).length, 7
+  end
+
   test 'updates personal_access_token' do
     create_token_user
     sign_in_as(@token_user)


### PR DESCRIPTION
Resolves #503 

Shows the latest Git SHA on the Settings page

![screenshot-2017-12-24 octobox](https://user-images.githubusercontent.com/1773614/34323570-82fa9394-e847-11e7-96ab-a0ea9ea4c0e8.png)
