### PR TITLE
Rename FactoryGirl to FactoryBot

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ group :development, :test do
 end
 
 group :test do
-  gem 'factory_girl'
+  gem 'factory_bot'
   gem 'simplecov'
   gem 'codeclimate-test-reporter'
   gem 'webmock'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,7 +81,7 @@ GEM
     ethon (0.11.0)
       ffi (>= 1.3.0)
     execjs (2.7.0)
-    factory_girl (4.9.0)
+    factory_bot (4.8.2)
       activesupport (>= 3.0.0)
     faraday (0.12.2)
       multipart-post (>= 1.2, < 3)
@@ -301,7 +301,7 @@ DEPENDENCIES
   byebug
   codeclimate-test-reporter
   dotenv-rails
-  factory_girl
+  factory_bot
   faraday_middleware
   jbuilder
   jquery-rails

--- a/test/factories/notification.rb
+++ b/test/factories/notification.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :notification do
     sequence(:github_id, 1000000) { |n| n }
     repository_id 930405

--- a/test/factories/subject.rb
+++ b/test/factories/subject.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :subject do
     sequence(:url) { |n| "https://api.github.com/repos/octobox/octobox/issues/#{n}" }
     state 'open'

--- a/test/factories/user.rb
+++ b/test/factories/user.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :user do
     sequence(:github_id, 1000000){|n| n}
     access_token { SecureRandom.hex(20) }

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,14 +11,14 @@ require 'mocha/mini_test'
 
 Dir[Rails.root.join('test/support/**/*.rb')].each { |f| require f }
 
-FactoryGirl.find_definitions
+FactoryBot.find_definitions
 
 class ActiveSupport::TestCase
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
   fixtures :all
 
   # Add more helper methods to be used by all tests here...
-  include FactoryGirl::Syntax::Methods
+  include FactoryBot::Syntax::Methods
   include StubHelper
 end
 


### PR DESCRIPTION
Following https://github.com/thoughtbot/factory_bot/issues/921 and https://robots.thoughtbot.com/factory_bot this PR renames FactoryGirl to FactoryBot.