### PR TITLE
Fix escape press closing modal and clearing filters

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -181,7 +181,7 @@ var shortcuts = {
   191: openModal,         // ?
   190: sync,              // .
   82:  sync,              // r
-  27:  clearFilters       // esc
+  27:  escPressed,        // esc
 };
 
 function cursorDown() {
@@ -272,7 +272,7 @@ function toggleStar() {
 }
 
 function openModal() {
-  $("#help-box").modal();
+  $("#help-box").modal({ keyboard: false });
 }
 
 function openCurrentLink(e) {
@@ -286,6 +286,14 @@ function sync() {
 
 function autoSync() {
   hasMarkedRows() || sync()
+}
+
+function escPressed(e) {
+  if ($("#help-box").is(':visible')) {
+    $("#help-box").modal('hide');
+  } else {
+    clearFilters();
+  }
 }
 
 function clearFilters() {

--- a/app/views/notifications/_help-box.html.erb
+++ b/app/views/notifications/_help-box.html.erb
@@ -1,4 +1,4 @@
-<div id="help-box" class="modal" tabindex="-1" role="dialog">
+<div id="help-box" class="modal" role="dialog">
   <div class="modal-dialog modal-sm" role="document">
     <div class="modal-content">
       <div class="modal-header">
@@ -102,7 +102,7 @@
                 <div class="key">esc</div>
               </td>
               <td>
-                Clear applied filters
+                Close modal OR Clear applied filters
               </td>
             </tr>
           </tbody>


### PR DESCRIPTION
Addresses:  #507

This PR makes changes to what the escape key does. If a modal is open, it closes it, otherwise it clears filters. Rather than doing both of those things at the same time.

After reading https://stackoverflow.com/questions/16693079/how-to-disable-escape-key-for-twitter-bootstrap-modals/17888680 it was clear that removing `tabindex="-1"` was key to this (pun intended).
