### PR TITLE
Fix issue with casting in notifications filters

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -201,7 +201,7 @@ class NotificationsController < ApplicationController
       # https://github.com/rails/rails/commit/68fe6b08ee72cc47263e0d2c9ff07f75c4b42761
       type = scope.klass.type_for_attribute(sub_scope.to_s).class
       val = scope.klass.type_for_attribute(sub_scope.to_s).cast(params[sub_scope])
-      scope = scope.where(sub_scope => val)
+      scope = scope.send(sub_scope, val)
     end
     scope = scope.search_by_subject_title(params[:q]) if params[:q].present?
     scope = scope.unscope(where: :archived)           if params[:q].present?

--- a/test/controllers/notifications_controller_test.rb
+++ b/test/controllers/notifications_controller_test.rb
@@ -33,6 +33,52 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
     assert_template 'notifications/index', file: 'notifications/index.html.erb'
   end
 
+  test 'will render the home page with filters' do
+    sign_in_as(@user)
+
+    # Repo Filter
+    get '/?repo=a/b'
+    assert_response :success
+    assert_template 'notifications/index', file: 'notifications/index.html.erb'
+    assert_select "span.filter-options *", text: 'a/b'
+
+    # Reason Filter
+    get '/?reason=Assign'
+    assert_response :success
+    assert_template 'notifications/index', file: 'notifications/index.html.erb'
+    assert_select "span.filter-options *", text: 'Assign'
+
+    # Type Filter
+    get '/?type=repository_a_b'
+    assert_response :success
+    assert_template 'notifications/index', file: 'notifications/index.html.erb'
+    assert_select "span.filter-options *", text: 'A b'
+
+    # Unread Filter
+    get '/?unread=true'
+    assert_response :success
+    assert_template 'notifications/index', file: 'notifications/index.html.erb'
+    assert_select "span.filter-options *", text: 'Unread'
+
+    # Owner Filter
+    get '/?owner=bob'
+    assert_response :success
+    assert_template 'notifications/index', file: 'notifications/index.html.erb'
+    assert_select "span.filter-options *", text: 'bob'
+
+    # State Filter
+    get '/?state=archive'
+    assert_response :success
+    assert_template 'notifications/index', file: 'notifications/index.html.erb'
+    assert_select "span.filter-options *", text: 'Archive'
+
+    # query Filter
+    get '/?q=query'
+    assert_response :success
+    assert_template 'notifications/index', file: 'notifications/index.html.erb'
+    assert_select "span.filter-options *", text: 'Search: query'
+  end
+
   test 'renders the index page as json if authenticated' do
     sign_in_as(@user)
 


### PR DESCRIPTION
There is an issue where the scope is something like `repo`, but the actual column name is `repo_id`. This ends up causing an error like this: `error='ActiveRecord::StatementInvalid: PG::UndefinedColumn: ERROR:  column notifications.repo does not exist`

The fix here is to revert to using the `send` method, which will handle the column name conversion properly.

Fixes #519

cc @chrisarcand 