### PR TITLE
 Explicitly require database_config in application.rb

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -1,4 +1,5 @@
 require_relative 'boot'
+require_relative "../lib/database_config"
 
 require "rails"
 


### PR DESCRIPTION
lib files are only eagerloaded in development. This means that
database_config may not be available to boot. It will be fine, however,
if you first boot the application as spring will cache the database.yml file.

The moment you restart or spring dies, you will hit issues due to implicitly
requiring the file. To fix it, we need to explicitly require lib/database_config.rb

cc @chrisarcand 