### PR TITLE
Fix database username env variable for stable release

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - GITHUB_CLIENT_ID=${GITHUB_CLIENT_ID}
       - GITHUB_CLIENT_SECRET=${GITHUB_CLIENT_SECRET}
       - OCTOBOX_DATABASE_NAME=postgres
-      - OCTOBOX_DATABASE_USER=postgres
+      - OCTOBOX_DATABASE_USERNAME=postgres
       - OCTOBOX_DATABASE_PASSWORD=development
       - OCTOBOX_DATABASE_HOST=database.service.octobox.internal
     networks:


### PR DESCRIPTION
Same fix as #518 when using `image: octoboxio/octobox:latest` 
