### PR TITLE
Rails supports a DATABASE_URL, handle invalid tokens in notifications sync, change subject_title to text

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -50,6 +50,8 @@ class User < ApplicationRecord
   def sync_notifications
     download_service.download
     Rails.logger.info("\n\n\033[32m[#{Time.now}] INFO -- #{github_login} synced their notifications\033[0m\n\n")
+  rescue Octokit::Unauthorized => e
+    Rails.logger.warn("\n\n\033[32m[#{Time.now}] INFO -- #{github_login} failed to sync notifications -- #{e.message}\033[0m\n\n")
   end
 
   def download_service

--- a/db/migrate/20180201184741_change_subject_title_from_string_to_text.rb
+++ b/db/migrate/20180201184741_change_subject_title_from_string_to_text.rb
@@ -1,0 +1,9 @@
+class ChangeSubjectTitleFromStringToText < ActiveRecord::Migration[5.1]
+  def up
+    change_column :notifications, :subject_title, :text
+  end
+
+  def down
+    change_column :notifications, :subject_title, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170907022825) do
+ActiveRecord::Schema.define(version: 20180201184741) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,7 +20,7 @@ ActiveRecord::Schema.define(version: 20170907022825) do
     t.integer "github_id"
     t.integer "repository_id"
     t.string "repository_full_name"
-    t.string "subject_title"
+    t.text "subject_title"
     t.string "subject_url"
     t.string "subject_type"
     t.string "reason"

--- a/test/lib/database_config_test.rb
+++ b/test/lib/database_config_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class DatabaseConfigTest < ActiveSupport::TestCase
+  DB_URL = "mysql2://user:password2@host.com:1234/database_name?pool=15&encoding=db_url_encoding"
+
   test 'chooses the right DB' do
     if ENV['DATABASE']
       assert_equal ENV['DATABASE'].downcase, ActiveRecord::Base.connection.adapter_name.downcase
@@ -10,6 +12,10 @@ class DatabaseConfigTest < ActiveSupport::TestCase
   end
 
   test 'adapter is specified properly' do
+    set_env('DATABASE_URL', DB_URL) do
+      assert_equal 'mysql2', DatabaseConfig.adapter
+    end
+
     set_env('DATABASE', 'mysql2') do
       assert_equal 'mysql2', DatabaseConfig.adapter
     end
@@ -26,6 +32,10 @@ class DatabaseConfigTest < ActiveSupport::TestCase
   end
 
   test 'username is specified properly' do
+    set_env('DATABASE_URL', DB_URL) do
+      assert_equal 'user', DatabaseConfig.username
+    end
+
     set_env('DATABASE', 'mysql2') do
       assert_equal 'root', DatabaseConfig.username
     end
@@ -45,6 +55,10 @@ class DatabaseConfigTest < ActiveSupport::TestCase
   end
 
   test 'encoding is specified properly' do
+    set_env('DATABASE_URL', DB_URL) do
+      assert_equal 'db_url_encoding', DatabaseConfig.encoding
+    end
+
     set_env('DATABASE', 'mysql2') do
       assert_equal 'utf8mb4', DatabaseConfig.encoding
     end
@@ -55,6 +69,10 @@ class DatabaseConfigTest < ActiveSupport::TestCase
   end
 
   test 'password is specified properly' do
+    set_env('DATABASE_URL', DB_URL) do
+      assert_equal 'password2', DatabaseConfig.password
+    end
+
     set_env('DATABASE', 'mysql2') do
       assert_equal '', DatabaseConfig.password
     end
@@ -69,6 +87,10 @@ class DatabaseConfigTest < ActiveSupport::TestCase
   end
 
   test 'connection_pool is specified properly' do
+    set_env('DATABASE_URL', DB_URL) do
+      assert_equal 15, DatabaseConfig.connection_pool
+    end
+
     set_env('DATABASE', 'mysql2') do
       assert_equal 5, DatabaseConfig.connection_pool
     end
@@ -83,6 +105,10 @@ class DatabaseConfigTest < ActiveSupport::TestCase
   end
 
   test 'database_name is specified properly' do
+    set_env('DATABASE_URL', DB_URL) do
+      assert_equal 'database_name', DatabaseConfig.database_name('test')
+    end
+
     set_env('DATABASE', 'mysql2') do
       assert_equal 'octobox_test', DatabaseConfig.database_name('test')
     end
@@ -97,6 +123,10 @@ class DatabaseConfigTest < ActiveSupport::TestCase
   end
 
   test 'host is specified properly' do
+    set_env('DATABASE_URL', DB_URL) do
+      assert_equal 'host.com', DatabaseConfig.host
+    end
+
     set_env('DATABASE', 'postgresql') do
       assert_equal 'localhost', DatabaseConfig.host
     end
@@ -111,6 +141,11 @@ class DatabaseConfigTest < ActiveSupport::TestCase
   end
 
   test 'is_mysql? and is_postgres?' do
+    set_env('DATABASE_URL', DB_URL) do
+      assert DatabaseConfig.is_mysql?, 'was not mysql, it should have been'
+      refute DatabaseConfig.is_postgres?, 'was postgres, it should not have been'
+    end
+
     set_env('DATABASE', 'postgresql') do
       assert DatabaseConfig.is_postgres?, 'was not postgres, it should have been'
       refute DatabaseConfig.is_mysql?, 'was mysql, it should not have been'


### PR DESCRIPTION
When a DATABASE URL is set, these values end up being wrong but only the adapter matters. The rest of the values are meaningless after boot, except for adapter which is used to check for search functionality

We only need the adapter to be set. The rest of the values _should_ reflect what ends up being set in the database.yml and should not be reliable past that point (when DATABASE_URL is set). This is similar to how Rails works.

Point form
---
- comes with a caveat. Since Rails doesnt load DB URL nicely into any configs we can't rely on it properly
- so Database Config will be wrong if you use a DB URL env var
- Which means we should _not_ rely on database config past configuring database.yml with the exception of the `is_mysql?` and `is_postgres?` checks

cc @chrisarcand 