### PR TITLE
Kill long running requests after 20s in production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,4 +54,5 @@ group :production do
   gem 'rails_safe_tasks'
   gem 'bugsnag'
   gem 'puma_worker_killer'
+  gem "rack-timeout"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -185,6 +185,7 @@ GEM
     rack (2.0.3)
     rack-test (0.8.2)
       rack (>= 1.0, < 3)
+    rack-timeout (0.4.2)
     rails (5.1.4)
       actioncable (= 5.1.4)
       actionmailer (= 5.1.4)
@@ -325,6 +326,7 @@ DEPENDENCIES
   pg_search
   puma
   puma_worker_killer
+  rack-timeout
   rails (~> 5.1, >= 5.1.3)
   rails-controller-testing
   rails_safe_tasks

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -82,4 +82,6 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   config.lograge.enabled = true
+
+  Rack::Timeout.service_timeout = 20
 end


### PR DESCRIPTION
If they haven't completed by then, heroku will likely kill the request at the 30s mark