### PR TITLE
Handle invalid access tokens in DownloadService

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -50,6 +50,8 @@ class User < ApplicationRecord
   def sync_notifications
     download_service.download
     Rails.logger.info("\n\n\033[32m[#{Time.now}] INFO -- #{github_login} synced their notifications\033[0m\n\n")
+  rescue Octokit::Unauthorized => e
+    Rails.logger.warn("\n\n\033[32m[#{Time.now}] INFO -- #{github_login} failed to sync notifications -- #{e.message}\033[0m\n\n")
   end
 
   def download_service


### PR DESCRIPTION
When a user signs into octobox, we can use their personal token.
If we revoke this token, or that account leaves, or whatever happens - the notifications sync will 401.

This breaks the notifications sync rake tasks

Instead, rescue and throw a warning

cc @chrisarcand 