### PR TITLE
Change subject_title from string to text to support longer titles

### DIFF
--- a/db/migrate/20180201184741_change_subject_title_from_string_to_text.rb
+++ b/db/migrate/20180201184741_change_subject_title_from_string_to_text.rb
@@ -1,0 +1,9 @@
+class ChangeSubjectTitleFromStringToText < ActiveRecord::Migration[5.1]
+  def up
+    change_column :notifications, :subject_title, :text
+  end
+
+  def down
+    change_column :notifications, :subject_title, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170907022825) do
+ActiveRecord::Schema.define(version: 20180201184741) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,7 +20,7 @@ ActiveRecord::Schema.define(version: 20170907022825) do
     t.integer "github_id"
     t.integer "repository_id"
     t.string "repository_full_name"
-    t.string "subject_title"
+    t.text "subject_title"
     t.string "subject_url"
     t.string "subject_type"
     t.string "reason"


### PR DESCRIPTION
Subject Title is too short. At varchar(255), I was getting sql errors and exceptions due to the subject_title being too long.

This error went away when I switched to text.

cc @chrisarcand 