### PR TITLE
Allow 'postgres://...' as the Heroku buildpack does

### DIFF
--- a/lib/database_config.rb
+++ b/lib/database_config.rb
@@ -14,6 +14,9 @@ module DatabaseConfig
         'postgresql'
       end
 
+      # Allow postgres://... as the Heroku buildpack dues
+      adapter = 'postgresql' if adapter == 'postgres'
+
       unless SUPPORTED_ADAPTERS.include?(adapter)
         raise "Unsupported database adapter #{adapter} specified"
       end


### PR DESCRIPTION
Heroku allows (and even provisions by default) you to use DATABASE_URL=postgres:// instead of postgresql://

https://devcenter.heroku.com/changelog-items/438

I'm not sure why, as according to Postgres docs it should be postgresql:
https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNSTRING

The Heroku Ruby buildpack just overwrites the adapter to postgresql here:
https://github.com/heroku/heroku-buildpack-ruby/blob/b2b59af270c7271f663c65c9e75bdceedfd0418b/lib/language_pack/ruby.rb#L758

This adds that same support here, as since we merged #531 we have this issue (raised ourselves):

![](https://camo.githubusercontent.com/febdf78912ca135c2e3b154ae7d7222d0a5a1f65/687474703a2f2f73637265656e73686f74732e6368726973617263616e642e636f6d2f736b6e74342e6a7067)

Note however that this makes me ponder whether DatabaseConfig is a good abstraction to have at all. DATABASE_URL is considered the canonical source of truth and Rails (along with Heroku) respects it; I'm not sure why it's really needed for MySQL support (it was added with https://github.com/octobox/octobox/pull/499) other than making the required checks to support both DB's a little prettier. We should consider just cleaning this all as such:

* Remove DatabaseConfig
* Allow Rails/Heroku/anyone to detail connection stuff in DATABASE_URL
and not screw with the YAML at all, letting Rails/Heroku merge them
together as needed. That should be enough for anyone running MySQL. (right?)
* Any checks for the adapter or whatever can be done through other
mechanisms. And quite honestly, the adapter is really the only thing
that we need outside the yaml anyway (for the pg_search check)

Anyway, this is the quick fix for now. I'm sure you could just add `postgres` to the supported adapters constant but that's no more clear, TBH.