### PR TITLE
Add API Tokens to User for use with the API

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -33,14 +33,13 @@ class ApplicationController < ActionController::Base
     return if logged_in?
     respond_to do |format|
       format.html { redirect_to root_path }
-      format.json { render json: {}, status: :unauthorized }
+      format.json { render json: { "error" => "unauthorized" }, status: :unauthorized }
     end
   end
 
   def current_user
-    user_id = cookies.permanent.signed[:user_id]
-    return nil unless user_id.present?
-    @current_user ||= User.find_by(id: user_id)
+    @current_user ||= authenticate_with_http_token { |token, _| User.find_by(api_token: token) }
+    @current_user ||= (cookies.permanent.signed[:user_id] && User.find_by(id: cookies.permanent.signed[:user_id]))
   end
 
   def logged_in?

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -36,8 +36,12 @@ class UsersController < ApplicationController
   #
   def update
     if current_user.update_attributes(update_user_params)
+      if params[:user][:regenerate_api_token]
+        current_user.regenerate_api_token
+      end
+
       respond_to do |format|
-        format.html { redirect_to root_path }
+        format.html { redirect_back(fallback_location: root_path) }
         format.json { head :ok }
       end
     else

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 class User < ApplicationRecord
+  has_secure_token :api_token
   has_many :notifications, dependent: :delete_all
 
   ERRORS = {

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -52,6 +52,31 @@
 
   <div class="panel panel-default">
     <div class="panel-heading">
+      <h3 class="panel-title">Octobox API Access</h3>
+    </div>
+    <div class="panel-body">
+      <p>This is your API Token for Octobox access. Keep it safe and do not commit it to version control.</p>
+
+      <ul class="list-inline">
+        <li>
+          <button onclick="document.getElementById('api_token').classList.remove('hide'); this.parentNode.classList.add('hide')" class="btn btn-default">Show API Token</button>
+        </li>
+        <li>
+          <%= form_tag current_user, method: :put do %>
+            <%= hidden_field_tag 'user[regenerate_api_token]', '1' %>
+            <%= submit_tag "Regenerate Token", class: 'btn btn-default' %>
+          <% end %>
+        </li>
+      </ul>
+
+      <div id="api_token" class="blankslate hide">
+        <code><%= current_user.api_token || 'None, please click the button to regenerate your token' %></code>
+      </div>
+    </div>
+  </div>
+
+  <div class="panel panel-default">
+    <div class="panel-heading">
       <h3 class="panel-title">Manage Oauth Access</h3>
     </div>
     <div class="panel-body">

--- a/db/migrate/20180223194652_add_api_token_to_user.rb
+++ b/db/migrate/20180223194652_add_api_token_to_user.rb
@@ -1,0 +1,6 @@
+class AddApiTokenToUser < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :api_token, :string
+    add_index :users, :api_token, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180201184741) do
+ActiveRecord::Schema.define(version: 20180223194652) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -56,7 +56,9 @@ ActiveRecord::Schema.define(version: 20180201184741) do
     t.datetime "last_synced_at"
     t.string "personal_access_token"
     t.integer "refresh_interval", default: 0
+    t.string "api_token"
     t.index ["access_token"], name: "index_users_on_access_token", unique: true
+    t.index ["api_token"], name: "index_users_on_api_token", unique: true
     t.index ["github_id"], name: "index_users_on_github_id", unique: true
   end
 

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -41,6 +41,14 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_equal assigns(:latest_git_sha).length, 7
   end
 
+  test 'updates api_token' do
+    sign_in_as(@user)
+    token = @user.api_token
+    patch user_url(@user), params: {user: {regenerate_api_token: '1'}}
+    @user.reload
+    assert_not_equal token, @user.api_token
+  end
+
   test 'updates personal_access_token' do
     create_token_user
     sign_in_as(@token_user)

--- a/test/factories/user.rb
+++ b/test/factories/user.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
     access_token { SecureRandom.hex(20) }
     github_login {"user#{github_id}"}
     last_synced_at { Time.parse('2016-12-19T12:00:00Z') }
+    api_token { SecureRandom.hex(10) }
 
     factory :token_user do
       personal_access_token 'deadbeef'

--- a/test/integration/api_token_authentication_test.rb
+++ b/test/integration/api_token_authentication_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+
+class ApiTokenAuthenticationTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = create(:user)
+  end
+
+  test 'will get notifications if authenticated with api token' do
+    get notifications_path(format: :json), headers: { 'Authorization' => "Bearer #{@user.api_token}" }
+    assert_response :success
+  end
+
+  test 'will get unauthorized if authenticated with wrong api token' do
+    get notifications_path(format: :json), headers: { 'Authorization' => "Bearer NOPE" }
+    assert_response :unauthorized
+  end
+end


### PR DESCRIPTION
What this does
---
- This adds an api token for use with the JSON API to all users
- It will not generate tokens for existing users, but will instead ask them to click the regenerate button (saves a migration)

cc @chrisarcand @tarebyte for review