### PR TITLE
fix: Respect OCTOBOX_DATABASE_HOST env in docker-start

### DIFF
--- a/bin/docker-start
+++ b/bin/docker-start
@@ -1,7 +1,8 @@
 #!/bin/sh
 set -e
 
-while ! nc -z database.service.octobox.internal 5432; do
+db_host=${OCTOBOX_DATABASE_HOST:-database.service.octobox.internal}
+while ! nc -z  $db_host 5432; do
   echo "Waiting for database to be available..."
   sleep 1
 done


### PR DESCRIPTION
docker-compose.yml in https://github.com/octobox/octobox/blob/6e37cf176361bbbc7fbe553bed2d74839f12a87b/docker-compose.yml#L26
actually refers to this env variable, so it should
be evaluated in the startup script, too.