### PR TITLE
chore: Allow 'false' or empty value for FETCH_SUBJECT to disable

### DIFF
--- a/lib/octobox/configurator.rb
+++ b/lib/octobox/configurator.rb
@@ -24,7 +24,7 @@ module Octobox
     end
 
     def fetch_subject
-      @fetch_subject || ENV['FETCH_SUBJECT'].present?
+      @fetch_subject || (ENV.has_key?('FETCH_SUBJECT') && ENV['FETCH_SUBJECT'].casecmp("true") == 0)
     end
     attr_writer :fetch_subject
 


### PR DESCRIPTION
config 'fetch_subject' should be only true if FETCH_SUBJECT is set to `true` (according to documentation)