### PR TITLE
Store and use github_id on labels

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -231,7 +231,7 @@ class NotificationsController < ApplicationController
   end
 
   def notifications_for_presentation
-    eager_load_relation = Octobox.config.fetch_subject ? :subject : nil
+    eager_load_relation = Octobox.config.fetch_subject ? {subject: :labels} : nil
     scope = current_user.notifications.includes(eager_load_relation)
 
     if params[:starred].present?

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -11,14 +11,15 @@ class Subject < ApplicationRecord
 
   def update_labels(remote_labels)
     remote_labels.each do |l|
-      label = labels.find_by_id(l.id)
+      label = labels.find_by_github_id(l.id)
       if label.nil?
         labels.create({
-          id: l.id,
+          github_id: l.id,
           color: l.color,
           name: l.name,
         })
       else
+        label.github_id = l.id # smoothly migrate legacy labels
         label.color = l.color
         label.name = l.name
         label.save if label.changed?

--- a/db/migrate/20180326173747_add_github_id_to_labels.rb
+++ b/db/migrate/20180326173747_add_github_id_to_labels.rb
@@ -1,0 +1,5 @@
+class AddGithubIdToLabels < ActiveRecord::Migration[5.1]
+  def change
+    add_column :labels, :github_id, :integer
+  end
+end

--- a/db/migrate/20180326173747_add_github_id_to_labels.rb
+++ b/db/migrate/20180326173747_add_github_id_to_labels.rb
@@ -1,5 +1,6 @@
 class AddGithubIdToLabels < ActiveRecord::Migration[5.1]
   def change
     add_column :labels, :github_id, :integer
+    Label.delete_all # delete previous invalid labels
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180223194652) do
+ActiveRecord::Schema.define(version: 20180326173747) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 20180223194652) do
     t.bigint "subject_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "github_id"
     t.index ["name"], name: "index_labels_on_name"
     t.index ["subject_id"], name: "index_labels_on_subject_id"
   end


### PR DESCRIPTION
WIP fixes #561

As mentioned in https://github.com/octobox/octobox/issues/561#issuecomment-376222137, this separates the remote id from github and the local id.

The main thing I've not tested here is the migration path for users who've been running the existing (broken) label support, I think we'll need to either:

- also look up labels by name+colour to make sure we don't get dupes (may require extra indexes)
- just delete all existing labels during the database migration to add the github_id column, that way everyone just redownloads all labels on subjects next time the subject changes.

Either way we might want a rake task that will update the labels on all subjects for a smooth upgrade path for people who've ran into issues.