### PR TITLE
Make all of notifications controller accessible to JSON api like the docs suggest, add notification state to the json output

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 class NotificationsController < ApplicationController
-  skip_before_action :authenticate_user!, only: [:index]
-  before_action :authenticate_index!, only: [:index]
+  skip_before_action :authenticate_user!
+  before_action :authenticate_web_or_api!
   before_action :find_notification, only: [:star, :mark_read]
 
   # Return a listing of notifications, including a summary of unread repos, notification reasons, and notification types
@@ -56,7 +56,8 @@ class NotificationsController < ApplicationController
   #            "subject":{
   #               "title" : "Add JSON API",
   #               "url" : "https://api.github.com/repos/octobox/octobox/pulls/320",
-  #               "type" : "PullRequest"
+  #               "type" : "PullRequest",
+  #               "state" : "merged"
   #            },
   #            "repo":{
   #               "id": 320,
@@ -255,7 +256,7 @@ class NotificationsController < ApplicationController
     @notification = current_user.notifications.find(params[:id])
   end
 
-  def authenticate_index!
+  def authenticate_web_or_api!
     return if logged_in?
     respond_to do |format|
       format.html { render 'pages/home' }

--- a/app/views/notifications/index.json.jbuilder
+++ b/app/views/notifications/index.json.jbuilder
@@ -30,6 +30,7 @@ json.notifications do
       json.title notification.subject_title
       json.url notification.subject_url
       json.type notification.subject_type
+      json.state notification.state
     end
 
     json.repo do


### PR DESCRIPTION
It seems we were only showing index. A coworker had a small menu bar script that he wanted to sync from, but we had no way to sync from the app. This PR makes the entire controller API accessible like the docs also suggest.

We also add notification state to the JSON output.

cc @chrisarcand 