### PR TITLE
Add sidekiq scheduler for notification jobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ coverage
 public/assets
 public/docs
 .database
+config/sidekiq_custom_schedule.yml

--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem 'git'
 gem 'rgb'
 gem 'sidekiq'
 gem 'sidekiq-unique-jobs'
+gem 'sidekiq-scheduler'
 gem 'gemoji'
 
 # Supported databases

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,6 +65,8 @@ GEM
       dotenv (= 2.2.1)
       railties (>= 3.2, < 5.2)
     erubi (1.7.1)
+    et-orbi (1.1.0)
+      tzinfo
     ethon (0.11.0)
       ffi (>= 1.3.0)
     execjs (2.7.0)
@@ -221,6 +223,8 @@ GEM
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.9.0)
     ruby_dep (1.5.0)
+    rufus-scheduler (3.4.2)
+      et-orbi (~> 1.0)
     safe_yaml (1.0.4)
     sass (3.5.6)
       sass-listen (~> 4.0.0)
@@ -246,6 +250,11 @@ GEM
       connection_pool (~> 2.2, >= 2.2.0)
       rack-protection (>= 1.5.0)
       redis (>= 3.3.5, < 5)
+    sidekiq-scheduler (2.2.1)
+      redis (>= 3, < 5)
+      rufus-scheduler (~> 3.2)
+      sidekiq (>= 3)
+      tilt (>= 1.4.0)
     sidekiq-unique-jobs (5.0.10)
       sidekiq (>= 4.0, <= 6.0)
       thor (~> 0)
@@ -333,6 +342,7 @@ DEPENDENCIES
   rubocop
   sassc-rails
   sidekiq
+  sidekiq-scheduler
   sidekiq-unique-jobs
   simplecov
   skylight

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -206,6 +206,8 @@ You can set the `OCTOBOX_SIDEKIQ_SCHEDULE_ENABLED` environment variable, which w
 
 The schedule, [located here](./config/sidekiq_schedule.yml), defines what is to be run and can be overriden using the `OCTOBOX_SIDEKIQ_SCHEDULE_PATH` variable in case you want to customize the schedule at all.
 
+We gitignore the path `config/sidekiq_custom_schedule.yml` for the convenience of adding a custom schedule that doesn't get committed to your fork.
+
 #### Heroku
 
 Create a Heroku Scheduler

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -190,6 +190,8 @@ When enabled, user settings pages will have an 'Notification Refresh Interval' o
 
 **Note**: This is *not* enabled on the hosted version (octobox.io).
 
+### Option 1
+
 Now that you've set all to go you can configure the app to sync the notifications automatically, there is a rake task that will do this for every user
 
 ```
@@ -197,6 +199,12 @@ rake tasks:sync_notifications
 ```
 
 You will need to configure this to run automatically
+
+### Option 2
+
+You can set the `OCTOBOX_SIDEKIQ_SCHEDULE_ENABLED` environment variable, which will enable `sidekiq-scheduler`.
+
+The schedule, [located here](./config/sidekiq_schedule.yml), defines what is to be run and can be overriden using the `OCTOBOX_SIDEKIQ_SCHEDULE_PATH` variable in case you want to customize the schedule at all.
 
 #### Heroku
 

--- a/app/workers/sync_all_user_notifications_worker.rb
+++ b/app/workers/sync_all_user_notifications_worker.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class SyncAllUserNotificationsWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: :sync_notifications, unique: :until_and_while_executing
+
+  def perform
+    User.find_each do |user|
+      SyncNotificationsWorker.perform_async(user.id)
+    end
+  end
+end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,9 +1,16 @@
 # frozen_string_literal: true
 
+require 'sidekiq-scheduler'
+
 Sidekiq.configure_server do |config|
   config.redis = { url: Octobox.config.redis_url }
 end
 
 Sidekiq.configure_client do |config|
   config.redis = { url: Octobox.config.redis_url }
+end
+
+if Octobox.config.sidekiq_schedule_enabled?
+  Sidekiq.schedule = YAML.load_file(Octobox.config.sidekiq_schedule_path)
+  Sidekiq::Scheduler.reload_schedule!
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 require 'sidekiq/web'
+if Octobox.config.sidekiq_schedule_enabled?
+  require 'sidekiq-scheduler/web'
+end
 require 'admin_constraint'
 
 Rails.application.routes.draw do

--- a/config/sidekiq_schedule.yml
+++ b/config/sidekiq_schedule.yml
@@ -1,0 +1,5 @@
+sync_notifications:
+  cron: '*/10 * * * *'
+  class: SyncAllUserNotificationsWorker
+  queue: sync_notifications
+  description: 'Automatically Sync Notifications for all Users'

--- a/lib/octobox/configurator.rb
+++ b/lib/octobox/configurator.rb
@@ -60,6 +60,16 @@ module Octobox
     end
     attr_writer :max_notifications_to_sync
 
+    def sidekiq_schedule_enabled?
+      @sidekiq_schedule_enabled || ENV['OCTOBOX_SIDEKIQ_SCHEDULE_ENABLED'].present?
+    end
+    attr_writer :sidekiq_schedule_enabled
+
+    def sidekiq_schedule_path
+      @sidekiq_schedule_path || ENV.fetch('OCTOBOX_SIDEKIQ_SCHEDULE_PATH', Rails.root.join('config', 'sidekiq_schedule.yml'))
+    end
+    attr_writer :sidekiq_schedule_path
+
     def restricted_access_enabled
       @restricted_access_enabled || ENV['RESTRICTED_ACCESS_ENABLED'].present?
     end


### PR DESCRIPTION
Notifications can not be synced using sidekiq! :tada:
If we make use of `sidekiq-scheduler`, we can get notifications to sync automatically on a schedule.

How is this setup
---
- If you set the env var `OCTOBOX_SIDEKIQ_SCHEDULE_ENABLED`, then it will enable schedules using the default built in schedule.
- I don't want to use the default one? Override the path using `OCTOBOX_SIDEKIQ_SCHEDULE_PATH`
