### PR TITLE
Subject sync error fixes

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -120,7 +120,14 @@ class Notification < ApplicationRecord
 
   def download_subject
     user.github_client.get(subject_url)
-  rescue Octokit::Forbidden, Octokit::NotFound, Octokit::ClientError => e
+
+  # If permissions changd and the user hasnt accepted, we get a 401
+  # We may receive a 403 Forbidden or a 403 Not Available
+  # We may be rate limited and get a 403 as well
+  # We may also get blocked by legal reasons (451)
+  # Regardless of the reason, any client error should be rescued and warned so we don't
+  # end up blocking other syncs
+  rescue Octokit::ClientError => e
     Rails.logger.warn("\n\n\033[32m[#{Time.now}] WARNING -- #{e.message}\033[0m\n\n")
     nil
   end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -122,6 +122,7 @@ class Notification < ApplicationRecord
     user.github_client.get(subject_url)
   rescue Octokit::Forbidden, Octokit::NotFound => e
     Rails.logger.warn("\n\n\033[32m[#{Time.now}] WARNING -- #{e.message}\033[0m\n\n")
+    nil
   end
 
   def update_subject

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -121,7 +121,7 @@ class Notification < ApplicationRecord
   def download_subject
     user.github_client.get(subject_url)
 
-  # If permissions changd and the user hasnt accepted, we get a 401
+  # If permissions changed and the user hasn't accepted, we get a 401
   # We may receive a 403 Forbidden or a 403 Not Available
   # We may be rate limited and get a 403 as well
   # We may also get blocked by legal reasons (451)

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -120,7 +120,7 @@ class Notification < ApplicationRecord
 
   def download_subject
     user.github_client.get(subject_url)
-  rescue Octokit::Forbidden, Octokit::NotFound => e
+  rescue Octokit::Forbidden, Octokit::NotFound, Octokit::ClientError => e
     Rails.logger.warn("\n\n\033[32m[#{Time.now}] WARNING -- #{e.message}\033[0m\n\n")
     nil
   end

--- a/test/fixtures/files/commit_notification_no_author.json
+++ b/test/fixtures/files/commit_notification_no_author.json
@@ -1,0 +1,44 @@
+[
+  {
+    "id": "420",
+    "repository": {
+      "id": 930405,
+      "owner": {
+        "login": "andrew",
+        "id": 1,
+        "avatar_url": "https://avatars3.githubusercontent.com/u/1060",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/andrew",
+        "html_url": "https://github.com/andrew",
+        "followers_url": "https://api.github.com/users/andrew/followers",
+        "following_url": "https://api.github.com/users/andrew/following{/other_user}",
+        "gists_url": "https://api.github.com/users/andrew/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/andrew/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/andrew/subscriptions",
+        "organizations_url": "https://api.github.com/users/andrew/orgs",
+        "repos_url": "https://api.github.com/users/andrew/repos",
+        "events_url": "https://api.github.com/users/andrew/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/andrew/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "name": "octobox",
+      "full_name": "octobox/octobox",
+      "description": "Take back control of your GitHub Notifications",
+      "private": false,
+      "fork": false,
+      "url": "https://api.github.com/repos/octobox/octobox",
+      "html_url": "https://github.com/octobox/octobox"
+    },
+    "subject": {
+      "title": "Test",
+      "url": "https://api.github.com/repos/octobox/octobox/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e",
+      "type": "Commit"
+    },
+    "reason": "subscribed",
+    "unread": true,
+    "updated_at": "2016-12-19T22:01:45Z",
+    "last_read_at": "2016-12-19T22:01:45Z",
+    "url": "https://api.github.com/notifications/threads/420"
+  }
+]

--- a/test/models/notification_test.rb
+++ b/test/models/notification_test.rb
@@ -164,6 +164,22 @@ class NotificationTest < ActiveSupport::TestCase
     assert_requested :get, subject.url
   end
 
+  test 'update_from_api_response updates the subject that returns a 40x error' do
+    Octobox.config.fetch_subject = true
+    url = 'https://api.github.com/repos/octobox/octobox/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e'
+    response = { status: 401, headers: { 'Content-Type' => 'application/json' } }
+    stub_request(:get, url).and_return(response)
+
+    api_response = notifications_from_fixture('commit_notification_no_author.json').first
+    notification = create(:morty_updated)
+
+    assert_no_difference 'Subject.count' do
+      notification.update_from_api_response(api_response, unarchive: true)
+    end
+  ensure
+    Octobox.config.fetch_subject = false
+  end
+
   test 'updated_from_api_response updates the existing subject if present' do
     stub_fetch_subject_enabled
     url = 'https://api.github.com/repos/octobox/octobox/pulls/403'


### PR DESCRIPTION
`Rails.logger.warn` returns true. This means that `download_subject`, upon failure, was actually `present?` and therefore would try to parse out the attributes from `true`. Instead, explicitly return nil.

```ruby
irb(main):001:0> Rails.logger.warn("banana")
banana
=> true
```

Any random `Octokit::ClientError` can also happen in some cases. For example, if you post-launch enable subjects and the access tokens for people who have not logged in does not allow you to get subjects due to a 401. In this case, also rescue that error. I've left a comment explaining this.