### PR TITLE
User sync in the background

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ gem 'sidekiq'
 gem 'sidekiq-unique-jobs'
 gem 'sidekiq-scheduler'
 gem 'rack-canonical-host'
+gem 'sidekiq-status'
 gem 'gemoji'
 gem 'bootsnap', require: false
 gem 'bugsnag'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,6 +61,8 @@ GEM
       concurrent-ruby (~> 1.0)
     builder (3.2.3)
     byebug (10.0.2)
+    chronic_duration (0.10.6)
+      numerizer (~> 0.1.1)
     codeclimate-test-reporter (1.0.8)
       simplecov (<= 0.13)
     concurrent-ruby (1.0.5)
@@ -154,6 +156,7 @@ GEM
     nio4r (2.3.1)
     nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
+    numerizer (0.1.1)
     oauth2 (1.4.0)
       faraday (>= 0.8, < 0.13)
       jwt (~> 1.0)
@@ -277,6 +280,10 @@ GEM
       rufus-scheduler (~> 3.2)
       sidekiq (>= 3)
       tilt (>= 1.4.0)
+    sidekiq-status (1.0.1)
+      chronic_duration
+      sidekiq (>= 3.0)
+      sidekiq-unique-jobs (= 6.0.6)
     sidekiq-unique-jobs (6.0.6)
       concurrent-ruby (~> 1.0, >= 1.0.5)
       sidekiq (>= 4.0, < 6.0)
@@ -370,6 +377,7 @@ DEPENDENCIES
   sassc-rails
   sidekiq
   sidekiq-scheduler
+  sidekiq-status
   sidekiq-unique-jobs
   simplecov
   skylight

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -315,7 +315,7 @@ function refreshOnSync() {
 
 function notify(message, type) {
   var alert_html = [
-    "<div class='alert alert-" + type + " fade in'>",
+    "<div class='alert alert-" + type + " fade show'>",
     "   <button class='close' data-dismiss='alert'>x</button>",
     message,
     "</div>"
@@ -409,8 +409,8 @@ $(document).ready(function() {
 
 // Sync Handling
 $(document).ready(function() {
-  if($(".js-syncing").length){ refreshOnSync() }
-  if($(".js-sync").length){ sync() }
+  if($(".js-is_syncing").length){ refreshOnSync() }
+  if($(".js-start_sync").length){ sync() }
 });
 
 var lastCheckedNotification = null;

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -294,6 +294,35 @@ function openCurrentLink(e) {
   getCurrentRow().find('td.notification-subject .link')[0].click();
 }
 
+function refreshOnSync() {
+  if(!$(".sync .octicon").hasClass("spinning")){
+    $(".sync .octicon").addClass("spinning");
+  }
+
+  jQuery.ajax({'url': "/notifications/syncing.json", data: {}, error: function(xhr, status) {
+      setTimeout(refreshOnSync, 2000)
+    }, success: function(data, status, xhr) {
+      if (data['error'] != null) {
+        $(".sync .octicon").removeClass("spinning");
+        $(".header-flash-messages").empty();
+        notify(data['error'], 'danger')
+      } else {
+        location.reload();
+      }
+    }
+  });
+}
+
+function notify(message, type) {
+  var alert_html = [
+    "<div class='alert alert-" + type + " fade in'>",
+    "   <button class='close' data-dismiss='alert'>x</button>",
+    message,
+    "</div>"
+  ].join("\n");
+  $(".header-flash-messages").append(alert_html);
+}
+
 function sync() {
   $("a.js-sync").click();
 }
@@ -376,6 +405,12 @@ $(document).ready(function() {
     $(".current.js-current").removeClass("current js-current");
     $( this ).find("td").first().addClass("current js-current");
   })
+});
+
+// Sync Handling
+$(document).ready(function() {
+  if($(".js-syncing").length){ refreshOnSync() }
+  if($(".js-sync").length){ sync() }
 });
 
 var lastCheckedNotification = null;

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -201,10 +201,36 @@ class NotificationsController < ApplicationController
   #   HEAD 204
   #
   def sync
-    current_user.sync_notifications
+    if params[:async]
+      current_user.sync_notifications(priority: true)
+      flash[:notice] = "Syncing notifcations in the background. The page will refresh automatically"
+    else
+      current_user.sync_notifications_in_foreground
+    end
+
     respond_to do |format|
-      format.html { redirect_back fallback_location: root_path }
+      format.html do
+        redirect_back fallback_location: root_path
+      end
       format.json { head :ok }
+    end
+  end
+
+  # Check if user is synchronizing notifications with GitHub
+  #
+  # ==== Example
+  #
+  # <code>POST notifications/syncing.json</code>
+  #   {} 204 (ok)
+  #
+  # <code>POST notifications/syncing.json</code>
+  #   {} 423 (locked)
+  #
+  def syncing
+    if current_user.syncing?
+      render json: {}, status: :locked
+    else
+      render json: {}, status: :ok
     end
   end
 

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -203,7 +203,7 @@ class NotificationsController < ApplicationController
   def sync
     if params[:async]
       current_user.sync_notifications(priority: true)
-      flash[:notice] = "Syncing notifcations in the background. The page will refresh automatically"
+      flash[:notice] = "Syncing notifications in the background. The page will refresh automatically"
     else
       current_user.sync_notifications_in_foreground
     end
@@ -230,7 +230,7 @@ class NotificationsController < ApplicationController
     if current_user.syncing?
       render json: {}, status: :locked
     else
-      render json: {}, status: :ok
+      render json: { error: Sidekiq::Status::get(current_user.sync_job_id, :exception) }, status: :ok
     end
   end
 

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -201,8 +201,8 @@ class NotificationsController < ApplicationController
   #   HEAD 204
   #
   def sync
-    if params[:async]
-      current_user.sync_notifications(priority: true)
+    if Octobox.config.background_jobs_enabled? && params[:async]
+      current_user.sync_notifications
       flash[:notice] = "Syncing notifications in the background. The page will refresh automatically"
     else
       current_user.sync_notifications_in_foreground

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -14,7 +14,7 @@ class SessionsController < ApplicationController
 
     cookies.permanent.signed[:user_id] = {value: user.id, httponly: true}
 
-    user.sync_notifications(priority: true) unless initial_sync?
+    user.sync_notifications unless initial_sync?
     redirect_to root_path
   end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -14,7 +14,7 @@ class SessionsController < ApplicationController
 
     cookies.permanent.signed[:user_id] = {value: user.id, httponly: true}
 
-    user.sync_notifications unless initial_sync?
+    user.sync_notifications(priority: true) unless initial_sync?
     redirect_to root_path
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -59,7 +59,8 @@ class User < ApplicationRecord
 
   def syncing?
     return false unless sync_job_id
-    !Sidekiq::Status::complete?(sync_job_id)
+    # We are syncing if we are queued or working, all other states mean we are not working
+    [:queued, :working].include?(Sidekiq::Status.status(sync_job_id))
   end
 
   def sync_notifications(priority: true)

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -1,5 +1,5 @@
 <% if current_user.syncing? %>
-  <span class="js-syncing"><!-- This causes the sync icon to spin --></span>
+  <span class="js-is_syncing"><!-- This causes the sync icon to spin --></span>
 <% end %>
 
 <div class="flex-content">
@@ -37,7 +37,7 @@
           </label>
           <%= select_all_button(@cur_selected, @total) %>
           <% end %>
-          <%= link_to sync_notifications_path(filters.merge(async: true)), class: 'btn btn-sm btn-outline-secondary btn-outline-dark js-sync', 'data-toggle' => 'tooltip', 'data-placement' => 'bottom', 'data-turbolinks' => false, 'data-animation' => 'false', 'data-position' => 'bottom', 'title' => 'Sync', 'aria-label' => 'Sync', method: :post do %>
+          <%= link_to sync_notifications_path(filters.merge(async: Octobox.config.background_jobs_enabled?)), class: 'btn btn-sm btn-outline-secondary btn-outline-dark js-sync', 'data-toggle' => 'tooltip', 'data-placement' => 'bottom', 'data-turbolinks' => false, 'data-animation' => 'false', 'data-position' => 'bottom', 'title' => 'Sync', 'aria-label' => 'Sync', method: :post do %>
             <%= octicon 'sync', height: 16, class: "#{'spinning' if initial_sync? || current_user.syncing?}" %>
           <% end %>
           <%= archive_selected_button unless archive_selected? %>
@@ -62,7 +62,7 @@
               <p>This might take a minute or two</p>
             </div>
             <% unless current_user.syncing? %>
-              <span class="js-sync"><!-- This causes a sync to occur --></span>
+              <span class="js-start_sync"><!-- This causes a sync to occur --></span>
             <% end %>
           <% elsif no_url_filter_parameters_present %>
             <div class="blankslate blankslate-spacious blankslate-clean-background">

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -1,3 +1,7 @@
+<% if current_user.syncing? %>
+  <span class="js-syncing"><!-- This causes the sync icon to spin --></span>
+<% end %>
+
 <div class="flex-content">
   <div class="flex-sidebar">
     <div class="flex-container">
@@ -33,8 +37,8 @@
           </label>
           <%= select_all_button(@cur_selected, @total) %>
           <% end %>
-          <%= link_to sync_notifications_path(filters), class: 'btn btn-sm btn-outline-secondary btn-outline-dark js-sync', 'data-toggle' => 'tooltip', 'data-placement' => 'bottom', 'data-turbolinks' => false, 'data-animation' => 'false', 'data-position' => 'bottom', 'title' => 'Sync', 'aria-label' => 'Sync', method: :post do %>
-            <%= octicon 'sync', height: 16, class: "#{'spinning' if initial_sync?}" %>
+          <%= link_to sync_notifications_path(filters.merge(async: true)), class: 'btn btn-sm btn-outline-secondary btn-outline-dark js-sync', 'data-toggle' => 'tooltip', 'data-placement' => 'bottom', 'data-turbolinks' => false, 'data-animation' => 'false', 'data-position' => 'bottom', 'title' => 'Sync', 'aria-label' => 'Sync', method: :post do %>
+            <%= octicon 'sync', height: 16, class: "#{'spinning' if initial_sync? || current_user.syncing?}" %>
           <% end %>
           <%= archive_selected_button unless archive_selected? %>
           <%= unarchive_selected_button unless inbox_selected? %>
@@ -57,6 +61,9 @@
               <h3>Syncing your notifications for the first time...</h3>
               <p>This might take a minute or two</p>
             </div>
+            <% unless current_user.syncing? %>
+              <span class="js-sync"><!-- This causes a sync to occur --></span>
+            <% end %>
           <% elsif no_url_filter_parameters_present %>
             <div class="blankslate blankslate-spacious blankslate-clean-background">
               <%= octicon 'mail-read', height: 32, class: 'blankslate-icon' %>

--- a/app/workers/sync_all_user_notifications_worker.rb
+++ b/app/workers/sync_all_user_notifications_worker.rb
@@ -5,8 +5,6 @@ class SyncAllUserNotificationsWorker
   sidekiq_options queue: :sync_notifications, unique: :until_and_while_executing
 
   def perform
-    User.find_each do |user|
-      SyncNotificationsWorker.perform_async_if_configured(user.id)
-    end
+    User.find_each(&:sync_notifications)
   end
 end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -2,6 +2,7 @@
 
 if Octobox.config.background_jobs_enabled?
   require 'sidekiq-scheduler'
+  require 'sidekiq-status'
 
   Sidekiq.configure_server do |config|
     config.redis = { url: Octobox.config.redis_url }
@@ -11,9 +12,12 @@ if Octobox.config.background_jobs_enabled?
         Sidekiq::Scheduler.reload_schedule!
       end
     end
+    Sidekiq::Status.configure_server_middleware config, expiration: 60.minutes
+    Sidekiq::Status.configure_client_middleware config, expiration: 60.minutes
   end
 
   Sidekiq.configure_client do |config|
     config.redis = { url: Octobox.config.redis_url }
+    Sidekiq::Status.configure_client_middleware config, expiration: 60.minutes
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'sidekiq/web'
+require 'sidekiq-status/web'
 if Octobox.config.sidekiq_schedule_enabled?
   require 'sidekiq-scheduler/web'
 end
@@ -31,6 +32,7 @@ Rails.application.routes.draw do
       post :archive_selected
       post :sync
       get  :sync
+      get  :syncing
       post :mute_selected
       post :mark_read_selected
       get  :unread_count

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,6 +1,5 @@
 ---
 :concurrency: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 }.to_i %> # From lib/database_config.rb
 :queues:
-  - [priority_sync_notifications, 10]
   - [sync_notifications, 1]
   - [sync_subjects, 1]

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,5 +1,6 @@
 ---
 :concurrency: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 }.to_i %> # From lib/database_config.rb
 :queues:
-  - sync_notifications
-  - sync_subjects
+  - [priority_sync_notifications, 10]
+  - [sync_notifications, 1]
+  - [sync_subjects, 1]

--- a/db/migrate/20180411201658_add_sync_job_id_to_user.rb
+++ b/db/migrate/20180411201658_add_sync_job_id_to_user.rb
@@ -1,0 +1,5 @@
+class AddSyncJobIdToUser < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :sync_job_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -102,6 +102,7 @@ ActiveRecord::Schema.define(version: 2018_08_17_172203) do
     t.string "encrypted_personal_access_token_iv"
     t.string "encrypted_app_token"
     t.string "encrypted_app_token_iv"
+    t.string "sync_job_id"
     t.index ["api_token"], name: "index_users_on_api_token", unique: true
     t.index ["github_id"], name: "index_users_on_github_id", unique: true
   end

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -40,7 +40,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     OmniAuth.config.mock_auth[:github].uid = @user.github_id
 
     post '/auth/github/callback'
-    assert_requested @notifications_request
+    assert_equal 1, SyncNotificationsWorker.jobs.size
   end
 
   test 'POST #create redirects to the root_path with an error message if they are not an org member' do

--- a/test/lib/tasks_test.rb
+++ b/test/lib/tasks_test.rb
@@ -10,8 +10,10 @@ class TasksTest < ActiveSupport::TestCase
     travel_to "2016-12-19T19:00:00Z" do
       user = create(:user)
 
-      Rails.application.load_tasks
-      Rake::Task['tasks:sync_notifications'].invoke
+      Sidekiq::Testing.inline! do
+        Rails.application.load_tasks
+        Rake::Task['tasks:sync_notifications'].invoke
+      end
 
       assert user.notifications.any?
     end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -146,6 +146,13 @@ class UserTest < ActiveSupport::TestCase
     assert_equal 60_000, @user.refresh_interval
   end
 
+  test 'sync_notifications sets job id and enqueues job' do
+    @user.sync_notifications
+    @user.reload
+    assert_not_nil @user.sync_job_id
+    assert_equal 1, SyncNotificationsWorker.jobs.size
+  end
+
   [{refresh_interval: 90_000, minimum_refresh_interval: 0, expected_result: nil},
    {refresh_interval: 90_000, minimum_refresh_interval: 60, expected_result: 60 * 60_000},
    {refresh_interval: 0, minimum_refresh_interval: 60, expected_result: nil},

--- a/test/support/omniauth.rb
+++ b/test/support/omniauth.rb
@@ -10,10 +10,21 @@ OmniAuth.config.mock_auth[:github] = OmniAuth::AuthHash.new(
 
 
 module SignInHelper
-  def sign_in_as(user)
+  def sign_in_as(user, initial_sync: false)
+    if initial_sync
+      @user.update(last_synced_at: nil)
+      @user.reload
+    end
+
     OmniAuth.config.mock_auth[:github].uid = user.github_id
     OmniAuth.config.mock_auth[:github].info = { 'nickname' => user.github_login }
     OmniAuth.config.mock_auth[:github].credentials.token = user.access_token
-    post '/auth/github/callback'
+    Sidekiq::Testing.inline! do
+      inline_sidekiq_status do
+        post '/auth/github/callback'
+      end
+    end
+
+    @user.reload
   end
 end

--- a/test/support/sidekiq_helper.rb
+++ b/test/support/sidekiq_helper.rb
@@ -5,6 +5,13 @@ Sidekiq::Testing.fake!
 Sidekiq::Logging.logger = nil
 Octobox.config.background_jobs_enabled = true
 
+def inline_sidekiq_status
+  Sidekiq::Status.stubs(:status).returns(:complete)
+  yield
+ensure
+  Sidekiq::Status.unstub(:status)
+end
+
 module SidekiqMinitestSupport
   def after_teardown
     Sidekiq::Worker.clear_all

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,6 +9,10 @@ require 'rails/test_help'
 require 'webmock/minitest'
 require 'mocha/minitest'
 
+require 'sidekiq_unique_jobs/testing'
+require 'sidekiq/testing'
+Sidekiq::Testing.fake!
+
 Dir[Rails.root.join('test/support/**/*.rb')].each { |f| require f }
 
 FactoryBot.find_definitions


### PR DESCRIPTION
What this does
---
Converts user syncing to allow background syncing by default from the app. Default syncing will still be foreground for non-UI based flows (API).

Adds a syncing poll endpoint that returns a `423 locked` if the user is syncing still and a `200 OK` otherwise. This is accomplished by storing the most recent job id for a user and checking the status of that job.

Why do we need this?
---
Provides a nicer user experience. Instead of a long sync request, we get a short sync enqueue and then auto-refresh when it's done.

It also reduces issues with timeouts for popular users with a lot of notifications (@rafaelfranca *cough*)

TODO
---
I wanted to mainly get your preliminary thoughts on this pattern, @chrisarcand @tarebyte @andrew, before I dedicate the time to clean it up and add tests.

Fixes #476 