### PR TITLE
HD dynamic favicon

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -65,23 +65,24 @@ function updateFavicon() {
       link.id = "favicon-count";
 
       if (canvas.getContext) {
-        canvas.height = canvas.width = 16;
+        canvas.height = canvas.width = 32;
         ctx = canvas.getContext('2d');
         img.onload = function () {
           ctx.drawImage(this, 0, 0);
 
           ctx.fillStyle = '#f93e00';
-          var width = ctx.measureText(txt).width;
-          ctx.fillRect(0, 0, width+2, 12);
+          ctx.font = 'bold 20px "helvetica", sans-serif';
 
-          ctx.font = 'bold 10px "helvetica", sans-serif';
+          var width = ctx.measureText(txt).width;
+          ctx.fillRect(0, 0, width+4, 24);
+
           ctx.fillStyle = '#fff';
-          ctx.fillText(txt, 1, 10);
+          ctx.fillText(txt, 2, 20);
 
           link.href = canvas.toDataURL('image/png');
           document.body.appendChild(link);
         };
-        img.src = "/favicon-16x16.png";
+        img.src = "/favicon-32x32.png";
       }
     }
   });


### PR DESCRIPTION
Hello,
When there is some notification, the favicon appears very blurred on retina/HDi screens.
This PR aims to fix this.

| Before | After |
|--|--|
|<img width="239" alt="schermata 2018-04-17 alle 22 46 58 copia" src="https://user-images.githubusercontent.com/6209647/38929829-f0b79e1a-430d-11e8-8bff-6f63e7a1666a.png">|<img width="232" alt="schermata 2018-04-17 alle 22 46 58 copia 2" src="https://user-images.githubusercontent.com/6209647/38929828-f0740308-430d-11e8-869e-e416955f39df.png">|

Screens taken on Firefox 59.0.2 on MacOS 10.13.3

