### PR TITLE
Remove patch that was fixed in Rails 5.2

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -214,15 +214,7 @@ class NotificationsController < ApplicationController
   def current_notifications(scope = notifications_for_presentation)
     [:repo, :reason, :type, :unread, :owner, :state].each do |sub_scope|
       next unless params[sub_scope].present?
-      # This cast is required due to a bug in Rails 5.1
-      # TODO: Rails 5.2 fixes this, so this should be removed when that ships
-      # https://github.com/rails/rails/commit/68fe6b08ee72cc47263e0d2c9ff07f75c4b42761
-      if sub_scope == :reason
-        val = params[sub_scope].split(',')
-      else
-        type = scope.klass.type_for_attribute(sub_scope.to_s).class
-        val = scope.klass.type_for_attribute(sub_scope.to_s).cast(params[sub_scope])
-      end
+      val = params[sub_scope].split(',')
       scope = scope.send(sub_scope, val)
     end
     scope = scope.labels(params[:label]) if params[:label].present?


### PR DESCRIPTION
This cast was needed due to a bug in Rails 5.1.
Rails 5.2 fixes this, so we can remove it when that ships: [the fix](https://github.com/rails/rails/commit/68fe6b08ee72cc47263e0d2c9ff07f75c4b42761)
