### PR TITLE
Encrypt access tokens

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ ruby '2.5.1'
 
 gem 'rails', '~> 5.2'
 gem 'bootstrap'
+gem "attr_encrypted", "~> 3.0.0"
 gem 'jquery-rails'
 gem 'kaminari'
 gem 'local_time'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,8 +46,10 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     arel (9.0.0)
     ast (2.4.0)
-    autoprefixer-rails (9.1.0)
+    attr_encrypted (3.0.3)
+      encryptor (~> 3.0.0)
       execjs
+    autoprefixer-rails (9.1.0)
     bindex (0.5.0)
     bootsnap (1.3.1)
       msgpack (~> 1.0)
@@ -71,6 +73,7 @@ GEM
     dotenv-rails (2.5.0)
       dotenv (= 2.5.0)
       railties (>= 3.2, < 6.0)
+    encryptor (3.0.0)
     erubi (1.7.1)
     et-orbi (1.1.4)
       tzinfo
@@ -329,6 +332,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  attr_encrypted (~> 3.0.0)
   bootsnap
   bootstrap
   bugsnag

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,8 +48,8 @@ GEM
     ast (2.4.0)
     attr_encrypted (3.0.3)
       encryptor (~> 3.0.0)
-      execjs
     autoprefixer-rails (9.1.0)
+      execjs
     bindex (0.5.0)
     bootsnap (1.3.1)
       msgpack (~> 1.0)

--- a/app.json
+++ b/app.json
@@ -15,6 +15,10 @@
   "website": "https://octobox.io/",
   "license": "AGPL-3.0-only",
   "env": {
+    "OCTOBOX_ATTRIBUTE_ENCRYPTION_KEY": {
+      "description": "Encryption key for access tokens in octobox",
+      "required": true
+    },
     "GITHUB_CLIENT_ID": {
       "description": "The GitHub Application Client ID",
       "required": true

--- a/app.json
+++ b/app.json
@@ -16,7 +16,7 @@
   "license": "AGPL-3.0-only",
   "env": {
     "OCTOBOX_ATTRIBUTE_ENCRYPTION_KEY": {
-      "description": "Encryption key for access tokens in octobox",
+      "description": "32 byte encryption key for access tokens in octobox",
       "required": true
     },
     "GITHUB_CLIENT_ID": {

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception, unless: -> { octobox_api_request? }
   helper_method :current_user, :logged_in?, :initial_sync?
   before_action :authenticate_user!
+  before_action :check_access_token_present
 
   before_bugsnag_notify :add_user_info_to_bugsnag if Rails.env.production?
 
@@ -44,6 +45,13 @@ class ApplicationController < ActionController::Base
 
   def logged_in?
     !current_user.nil?
+  end
+
+  def check_access_token_present
+    if current_user && current_user.access_token.nil?
+      cookies.delete(:user_id)
+      redirect_to root_url
+    end
   end
 
   def initial_sync?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 class User < ApplicationRecord
+  attr_encrypted :access_token, key: Octobox.config.attr_encyrption_key
+  attr_encrypted :personal_access_token, key: Octobox.config.attr_encyrption_key
+
   has_secure_token :api_token
   has_many :notifications, dependent: :delete_all
 
@@ -12,7 +15,7 @@ class User < ApplicationRecord
   }.freeze
 
   validates :github_id,    presence: true, uniqueness: true
-  validates :access_token, presence: true, uniqueness: true
+  validates :encrypted_access_token, presence: true, uniqueness: true
   validates :github_login, presence: true
   validates :refresh_interval, numericality: {
     only_integer: true,

--- a/db/migrate/20180423185221_add_encrypted_access_token_to_user.rb
+++ b/db/migrate/20180423185221_add_encrypted_access_token_to_user.rb
@@ -1,0 +1,11 @@
+class AddEncryptedAccessTokenToUser < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :encrypted_access_token, :string
+    add_column :users, :encrypted_access_token_iv, :string
+    remove_column :users, :access_token, :string
+
+    add_column :users, :encrypted_personal_access_token, :string
+    add_column :users, :encrypted_personal_access_token_iv, :string
+    remove_column :users, :personal_access_token, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -61,15 +61,16 @@ ActiveRecord::Schema.define(version: 2018_08_03_073302) do
 
   create_table "users", id: :serial, force: :cascade do |t|
     t.integer "github_id", null: false
-    t.string "access_token", null: false
     t.string "github_login", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "last_synced_at"
-    t.string "personal_access_token"
     t.integer "refresh_interval", default: 0
     t.string "api_token"
-    t.index ["access_token"], name: "index_users_on_access_token", unique: true
+    t.string "encrypted_access_token"
+    t.string "encrypted_access_token_iv"
+    t.string "encrypted_personal_access_token"
+    t.string "encrypted_personal_access_token_iv"
     t.index ["api_token"], name: "index_users_on_api_token", unique: true
     t.index ["github_id"], name: "index_users_on_github_id", unique: true
   end

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -11,6 +11,7 @@ in your GitHub settings for Octobox to work.
 * [Database Selection](#database-selection)
 * [Deployment to Heroku](#deployment-to-heroku)
 * [Deployment to OpenShift Online](#deployment-to-openshift-online)
+* [Encryption Key](#encryption-key)
 * [Local installation](#local-installation)
 * [Using Docker](#using-docker)
 * [Using reverse proxy](#using-reverse-proxy)
@@ -62,6 +63,12 @@ Octobox can be easily installed to [OpenShift Online](https://www.openshift.com/
 As OpenShift Online provides a free "Starter" tier its also a very inexpensive way to try out an personalized Octobox installation in the cloud.
 
 Please refer to the separate [OpenShift installation](../openshift/OPENSHIFT_INSTALLATION.md) document for detailed installation instructions.
+
+## Encryption Key
+
+Octobox uses [`encrypted_attr`](https://github.com/attr-encrypted/attr_encrypted) to store access tokens and personal access tokens on the user object.
+
+Therefore to install and launch Octobox, you must provide a 32 byte encryption key as the env var `OCTOBOX_ATTRIBUTE_ENCRYPTION_KEY`
 
 ## Local installation
 
@@ -170,7 +177,7 @@ docker run -d --network octobox-network --name=database.service.octobox.internal
 Then, run the following command to download the latest docker image and start octobox in the background.
 
 ```bash
-docker run -d --network octobox-network --name=octobox -e RAILS_ENV=development -e GITHUB_CLIENT_ID=yourclientid -e GITHUB_CLIENT_SECRET=yourclientsecret -e OCTOBOX_DATABASE_PASSWORD=development -e OCTOBOX_DATABASE_NAME=postgres -e OCTOBOX_DATABASE_USERNAME=postgres -e OCTOBOX_DATABASE_HOST=database.service.octobox.internal  -p 3000:3000 octoboxio/octobox:latest
+docker run -d --network octobox-network --name=octobox -e OCTOBOX_ATTRIBUTE_ENCRYPTION_KEY=my_key RAILS_ENV=development -e GITHUB_CLIENT_ID=yourclientid -e GITHUB_CLIENT_SECRET=yourclientsecret -e OCTOBOX_DATABASE_PASSWORD=development -e OCTOBOX_DATABASE_NAME=postgres -e OCTOBOX_DATABASE_USERNAME=postgres -e OCTOBOX_DATABASE_HOST=database.service.octobox.internal  -p 3000:3000 octoboxio/octobox:latest
 ```
 
 Octobox will be running on [http://localhost:3000](http://localhost:3000).

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -70,6 +70,8 @@ Octobox uses [`encrypted_attr`](https://github.com/attr-encrypted/attr_encrypted
 
 Therefore to install and launch Octobox, you must provide a 32 byte encryption key as the env var `OCTOBOX_ATTRIBUTE_ENCRYPTION_KEY`
 
+Protip: To generate a key, you can use `bin/rails secret | cut -c1-32`
+
 ## Local installation
 
 First things first, you'll need to install Ruby 2.5.1. I recommend using the excellent [rbenv](https://github.com/rbenv/rbenv),

--- a/lib/octobox/configurator.rb
+++ b/lib/octobox/configurator.rb
@@ -4,9 +4,9 @@ module Octobox
       @key ||= begin
         key = ENV['OCTOBOX_ATTRIBUTE_ENCRYPTION_KEY']
 
-        if key.nil? && (Rails.env.test? || Rails.env.development?)
-          "1" * 32 # Fake key for test and development
-        elsif key.nil? || key.size != 32
+        if key.nil?
+          Rails.application.secret_key_base[0..31]
+        elsif key.size != 32
           raise ArgumentError,
             'Must provide a 32 byte encryption key as the env var OCTOBOX_ATTRIBUTE_ENCRYPTION_KEY'
         else

--- a/lib/octobox/configurator.rb
+++ b/lib/octobox/configurator.rb
@@ -1,5 +1,20 @@
 module Octobox
   class Configurator
+    def attr_encyrption_key
+      @key ||= begin
+        key = ENV['OCTOBOX_ATTRIBUTE_ENCRYPTION_KEY']
+
+        if key.nil? && (Rails.env.test? || Rails.env.development?)
+          "1" * 32 # Fake key for test and development
+        elsif key.nil? || key.size != 32
+          raise ArgumentError,
+            'Must provide a 32 byte encryption key as the env var OCTOBOX_ATTRIBUTE_ENCRYPTION_KEY'
+        else
+          key
+        end
+      end
+    end
+
     def github_domain
       @github_domain || ENV.fetch('GITHUB_DOMAIN', 'https://github.com')
     end

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -7,6 +7,15 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     @user = create(:user)
   end
 
+  test 'authenticated users without access tokens are logged out' do
+    sign_in_as(@user)
+    @user.access_token = nil
+    @user.save(validate: false) # Requires access token
+
+    get '/settings'
+    assert_redirected_to root_path
+  end
+
   test 'GET #new redirects to /auth/github' do
     get '/login'
     assert_redirected_to '/auth/github'


### PR DESCRIPTION
Access tokens are sensitive pieces of information capable of accessing a users github account.

We were storing these in plain text, which was noticed because debug logging was logging them in production.

This commit changes all access tokens to be encrypted.

Note: This requires a rotation of all user sessions and requires the users to log back in / re-set their personal access tokens. This is required regardless as the tokens would have been leaking into logs.