### PR TITLE
move scheduler config into the server config block

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -4,13 +4,14 @@ require 'sidekiq-scheduler'
 
 Sidekiq.configure_server do |config|
   config.redis = { url: Octobox.config.redis_url }
+  if Octobox.config.sidekiq_schedule_enabled?
+    config.on(:startup) do
+      Sidekiq.schedule = YAML.load_file(Octobox.config.sidekiq_schedule_path)
+      Sidekiq::Scheduler.reload_schedule!
+    end
+  end
 end
 
 Sidekiq.configure_client do |config|
   config.redis = { url: Octobox.config.redis_url }
-end
-
-if Octobox.config.sidekiq_schedule_enabled?
-  Sidekiq.schedule = YAML.load_file(Octobox.config.sidekiq_schedule_path)
-  Sidekiq::Scheduler.reload_schedule!
 end


### PR DESCRIPTION
address #639 

this addresses the problem where you might encounter
an `invalid uri scheme ''` error as sidekiq doesn't
seem to know about the redis_url