### PR TITLE
add last sync to filter bar

### DIFF
--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -44,6 +44,11 @@
           <%= mute_selected_button %>
           <%= mark_read_selected_button %>
           <%= render 'filter-list' %>
+          <% if current_user.last_synced_at %>
+            <span class='text-muted hidden-xs'>
+              <small>Last sync: <%= time_ago_in_words current_user.last_synced_at %> ago</small>
+            </span>
+          <% end %>
         </div>
 
         <table class='table table-hover table-notifications js-table-notifications' data-refresh-interval=<%= current_user.effective_refresh_interval %>>


### PR DESCRIPTION
Fixes #309  

Last sync info is hidden on phone sized devices, but not landscape tablets. 

Chrome emulated iPad Pro sizing
![screen shot 2018-05-30 at 8 22 06 pm](https://user-images.githubusercontent.com/7292/40754439-6ae90f48-6447-11e8-805e-8defc50a12a0.png)

Chrome emulated iPhone 6/7/8
![screen shot 2018-05-30 at 8 20 47 pm](https://user-images.githubusercontent.com/7292/40754467-86df7386-6447-11e8-9a35-6a758944d081.png)

Regular Chrome
![screen shot 2018-05-30 at 8 25 50 pm](https://user-images.githubusercontent.com/7292/40754497-adcd6570-6447-11e8-98bf-4e96db11236d.png)

