### PR TITLE
Fix issue where mark_read and mute could fail with no notifications

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -60,6 +60,7 @@ class Notification < ApplicationRecord
 
   def self.mark_read(notifications)
     unread = notifications.select(&:unread)
+    return if unread.empty?
     user = unread.first.user
     conn = user.github_client.client_without_redirects
     manager = Typhoeus::Hydra.new(max_concurrency: Octobox.config.max_concurrency)
@@ -72,6 +73,7 @@ class Notification < ApplicationRecord
   end
 
   def self.mute(notifications)
+    return if notifications.empty?
     user = notifications.to_a.first.user
     conn = user.github_client.client_without_redirects
     manager = Typhoeus::Hydra.new(max_concurrency: Octobox.config.max_concurrency)

--- a/test/models/notification_test.rb
+++ b/test/models/notification_test.rb
@@ -48,6 +48,10 @@ class NotificationTest < ActiveSupport::TestCase
     assert notification2.reload.archived?
   end
 
+  test '#mute doesnt fail if there is no notifications given' do
+    Notification.mute([])
+  end
+
   test '#mark_read marks multiple notifications as read' do
     user = create(:user)
 
@@ -61,6 +65,12 @@ class NotificationTest < ActiveSupport::TestCase
 
     refute notification1.reload.unread?
     refute notification2.reload.unread?
+  end
+
+  test '#mark_read doesnt fail if nothing is to be marked as read' do
+    user = create(:user)
+    notification1 = create(:notification, user: user, unread: false)
+    Notification.mark_read([notification1])
   end
 
   test 'update_from_api_response updates attributes' do


### PR DESCRIPTION
When no notifications are given, or end up being given (via unread), we should just return.
This was being hit by users at Shopify with `mark_read`

<img width="724" alt="image" src="https://user-images.githubusercontent.com/3074765/40814717-e349a69c-657c-11e8-9aa3-1f36649feae5.png">
 