### PR TITLE
Ignore dev files when deploying to heroku to reduce the slug size

### DIFF
--- a/.slugignore
+++ b/.slugignore
@@ -22,4 +22,4 @@ docker-compose-dev.yml
 .eslintignore
 .eslintrc
 
-app.json
+Dockerfile


### PR DESCRIPTION
Also adds the same extra dev files to .dockerignore 🦑 