### PR TITLE
Add open-graph and twitter meta data to layout

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,6 +20,16 @@
 
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
+
+    <meta property="og:title" content="Octobox">
+    <meta property="og:description" content="Take back control of your GitHub notifications">
+    <meta property="og:image" content="<%= asset_url 'app-icon.png' %>">
+    <meta property="og:url" content="<%= root_url %>">
+    <meta property="og:type" content="article" />
+    <meta property="og:site_name" content="Octobox" />
+
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:creator" content="teabass">
   </head>
 
   <body class="flex-body">


### PR DESCRIPTION
Enables Twitter, Facebook and others to so more info when https://octobox.io is shared, example:
![screen shot 2018-06-18 at 16 31 06](https://user-images.githubusercontent.com/1060/41546293-2e7a8f64-7315-11e8-9bb9-cc2818b58719.png)
