### PR TITLE
Add basic statistics to settings page

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -20,7 +20,10 @@ class UsersController < ApplicationController
   def profile; end
 
   def edit # :nodoc:
+    counts = current_user.notifications.group(:repository_full_name).count
     @latest_git_sha = Git.open(Rails.root).object('HEAD').sha[0..6] rescue nil
+    @total = counts.sum(&:last)
+    @most_active = counts.sort_by(&:last).reverse.first(10)
   end
 
   # Update a user profile. Only updates the current user

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -89,6 +89,29 @@
     </div>
   </div>
 
+  <div class="panel panel-default">
+    <div class="panel-heading">
+      <h3 class="panel-title">Statistics</h3>
+    </div>
+    <div class="panel-body">
+      <p>
+        <%= pluralize @total, 'notification' %> synced since you started using Octobox <%= distance_of_time_in_words_to_now current_user.created_at %> ago.
+      </p>
+      <% if @most_active %>
+        <p>
+          <strong>Most active repositories</strong>
+        </p>
+        <ul>
+          <% @most_active.each do |repository_full_name, count| %>
+            <li>
+              <%= link_to repository_full_name, "#{Octobox.config.github_domain}/#{repository_full_name}" %> - <%= pluralize count, 'notification' %>
+            </li>
+          <% end %>
+        </ul>
+      <% end %>
+    </div>
+  </div>
+
   <div class="panel panel-danger">
     <div class="panel-heading">
       <h3 class="panel-title">Danger zone</h3>


### PR DESCRIPTION
Shows your total number of notifications and the top 10 most active repos for you to the settings page, example screenshot:

<img width="531" alt="screen shot 2018-06-21 at 18 57 00" src="https://user-images.githubusercontent.com/1060/41737380-080933fc-7587-11e8-95de-e7d8847bce74.png">
