### PR TITLE
Show git commit sha on heroku if available 

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -21,7 +21,7 @@ class UsersController < ApplicationController
 
   def edit # :nodoc:
     counts = current_user.notifications.group(:repository_full_name).count
-    @latest_git_sha = Git.open(Rails.root).object('HEAD').sha[0..6] rescue nil
+    @latest_git_sha = ENV['HEROKU_SLUG_COMMIT'] || Git.open(Rails.root).object('HEAD').sha rescue nil
     @total = counts.sum(&:last)
     @most_active = counts.sort_by(&:last).reverse.first(10)
   end

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -5,7 +5,11 @@
     </div>
     <div class="col-xs-6">
       <% if @latest_git_sha %>
-        <p class="settings-sha pull-right" title="Latest Git commit SHA">Version: <%= @latest_git_sha %></p>
+        <p class="settings-sha pull-right" title="Latest Git commit SHA">
+          Version:
+          <%= link_to @latest_git_sha[0..6], Octobox.config.source_repo + "/commit/#{@latest_git_sha}", target: '_blank' %>
+
+        </p>
       <% end %>
     </div>
   </div>

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -38,7 +38,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   test 'assigns latest git sha on settings page' do
     sign_in_as(@user)
     get settings_path
-    assert_equal assigns(:latest_git_sha).length, 7
+    assert_equal assigns(:latest_git_sha).length, 40
   end
 
   test 'updates api_token' do


### PR DESCRIPTION
Requires [dyno-metadata](https://devcenter.heroku.com/articles/dyno-metadata) labs feature enabled for the heroku app, which I've done on https://octobox.io. 

To enable the labs feature, run this command:

```bash
heroku labs:enable runtime-dyno-metadata -a your-heroku-octobox-app-name
```

Also links the sha to the commit on the source repository if present