### PR TITLE
Rescue Octokit::InternalServerErrors

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,7 +11,7 @@ class ApplicationController < ActionController::Base
   rescue_from Octokit::Unauthorized, Octokit::Forbidden do |exception|
     handle_exception(exception, :service_unavailable, I18n.t("exceptions.octokit.unauthorized"))
   end
-  rescue_from Octokit::BadGateway, Octokit::ServiceUnavailable do |exception|
+  rescue_from Octokit::BadGateway, Octokit::ServiceUnavailable, Octokit::InternalServerError do |exception|
     handle_exception(exception, :service_unavailable, I18n.t("exceptions.octokit.unavailable"))
   end
   rescue_from Faraday::ClientError do |exception|


### PR DESCRIPTION
The recent GitHub outage causes Octobox to 500 instead of gracefully fail; we should rescue this exception as well.