### PR TITLE
Handle null bytes gracefully

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -44,7 +44,9 @@ class Notification < ApplicationRecord
   class << self
     def attributes_from_api_response(api_response)
       attrs = DownloadService::API_ATTRIBUTE_MAP.map do |attr, path|
-        [attr, api_response.to_h.dig(*path)]
+        value = api_response.to_h.dig(*path)
+        value.delete!("\u0000") if value.is_a?(String)
+        [attr, value]
       end.to_h
       if "RepositoryInvitation" == api_response.subject.type
         attrs[:subject_url] = "#{api_response.repository.html_url}/invitations"

--- a/test/fixtures/files/notifications.json
+++ b/test/fixtures/files/notifications.json
@@ -31,7 +31,7 @@
       "html_url": "https://github.com/octobox/octobox"
     },
     "subject": {
-      "title": "UI Updates",
+      "title": "UI Updates\u0000",
       "url": "https://api.github.com/repos/octobox/octobox/issues/56",
       "latest_comment_url": "https://api.github.com/repos/octobox/octobox/issues/comments/123",
       "type": "Issue"


### PR DESCRIPTION
Postgresql doesn't like null byte characters (`\u0000`) that sometimes come back in strings from the GitHub API, which was causing notification syncing to fail, as seen by @rallytime in https://github.com/octobox/octobox/issues/544

This deletes the null bytes from strings before trying to insert them into the database.

Fixes #544 