### PR TITLE
Show pagination on small screens

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -578,6 +578,9 @@ td.keys {
   .panel-heading,
   .panel-footer {
     padding: 6px 8px;
+    .pagination{
+      margin: 6px 0px 0px;
+    }
   }
 
   .bold {

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -89,13 +89,13 @@
             </div>
           <% end %>
         </table>
+
+        <div class="panel-footer visible-xs-block visible-sm-block">
+          <%= paginate @notifications, left: 1, right: 1, window: 0 %>
+        </div>
       </div>
 
-      <div class="text-center visible-xs-block">
-        <%= paginate @notifications, left: 1, right: 1, window: 0 %>
-      </div>
-
-      <div class="text-center visible-sm-block visible-md-block visible-lg-block visible-xl-block">
+      <div class="text-center visible-md-block visible-lg-block visible-xl-block">
         <%= paginate @notifications %>
       </div>
 


### PR DESCRIPTION
Pagination on `xs` and `sm` disappeared at some point, hidden behind the 100% height table, this brings it back!