### PR TITLE
Add an index file for docs folder

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,8 @@
+# Octobox Documentation
+
+- [Installation](INSTALLATION.md)
+- [Installing Octobox on OpenShift](../openshift/OPENSHIFT_INSTALLATION.md)
+- [Contributing to Octobox](CONTRIBUTING.md)
+- [API Documentation](API_README.md)
+- [Code of Conduct](CODE_OF_CONDUCT.md)
+- [Support](SUPPORT.md)


### PR DESCRIPTION
Calling it README.md will get GitHub to render the markdown file if you 
go to https://github.com/octobox/octobox/tree/master/docs

Also adds a link to SUPPORT.md proposed in https://github.com/octobox/octobox/pull/723