### PR TITLE
Search results with same rank should be ordered by update_at DESC

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -4,6 +4,7 @@ class Notification < ApplicationRecord
     include PgSearch
     pg_search_scope :search_by_subject_title,
                     against: :subject_title,
+                    order_within_rank: 'notifications.updated_at DESC',
                     using: {
                       tsearch: {
                         prefix: true,


### PR DESCRIPTION
Also means that for most searches, newest results will be shown first.

Only affects postgresql, see 
https://github.com/Casecommons/pg_search#order_within_rank-breaking-ties