### PR TITLE
Show star and fork counts again on homepage

### DIFF
--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -11,8 +11,8 @@
       <% end %>
       </p>
       <p>
-        <a class="github-button" href="https://github.com/octobox/octobox" data-icon="octicon-star" data-style="mega" data-count-href="/octobox/octobox/stargazers" data-count-api="/repos/octobox/octobox#stargazers_count" data-count-aria-label="# stargazers on GitHub" aria-label="Star octobox/octobox on GitHub">Star</a>
-        <a class="github-button" href="https://github.com/octobox/octobox/fork" data-icon="octicon-repo-forked" data-style="mega" data-count-href="/octobox/octobox/network" data-count-api="/repos/octobox/octobox#forks_count" data-count-aria-label="# forks on GitHub" aria-label="Fork octobox/octobox on GitHub">Fork</a>
+        <a class="github-button" href="https://github.com/octobox/octobox" data-icon="octicon-star" data-size="large" data-show-count="true" aria-label="Star octobox/octobox on GitHub">Star</a>
+        <a class="github-button" href="https://github.com/octobox/octobox/fork" data-icon="octicon-repo-forked" data-size="large" data-show-count="true" aria-label="Fork octobox/octobox on GitHub">Fork</a>
       </p>
     </div>
 


### PR DESCRIPTION
At some point the github-buttons project removed the `mega` size and the badges became small and stopped showing counts, this makes them big and shows counts again.

Before:

![screen shot 2018-08-02 at 11 52 58](https://user-images.githubusercontent.com/1060/43579682-d1d658a2-964a-11e8-8266-60e8e57b0abc.png)

After:

![screen shot 2018-08-02 at 11 52 27](https://user-images.githubusercontent.com/1060/43579686-d645085c-964a-11e8-93cf-3429f739f3b4.png)
