### PR TITLE
Subject -> notifications -> users

### DIFF
--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -28,6 +28,10 @@ class Subject < ApplicationRecord
     end
   end
 
+  def sync_involved_users
+    user_ids.each { |user_id| SyncNotificationsWorker.perform_async(user_id) }
+  end
+
   private
 
   def author_url_path

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -1,6 +1,7 @@
 class Subject < ApplicationRecord
   has_many :notifications, foreign_key: :subject_url, primary_key: :url
   has_many :labels
+  has_many :users, through: :notifications
 
   BOT_AUTHOR_REGEX = /\A(.*)\[bot\]\z/.freeze
   private_constant :BOT_AUTHOR_REGEX


### PR DESCRIPTION
I'm working towards being able to sync subjects in the background (sidekiq) via webhooks, related to https://github.com/octobox/octobox/issues/472

This means, if we see a subject has been updated, we can proactively sync all subscribed users (one's who've been notified about that subject before), which will speed up notification and subject syncing as most of the updates will already have been downloaded.

It also has a nice multiplying effect for installations with lots of users, like octobox.io, the more active users syncing notifications, the more up-to-date related users will be.

Dependent on #736 otherwise the performance is terrible!