### PR TITLE
Always show read/unread sidebar menu items

### DIFF
--- a/app/views/notifications/_sidebar.html.erb
+++ b/app/views/notifications/_sidebar.html.erb
@@ -29,17 +29,14 @@
 
   <%= menu_separator %>
 
-  <% @unread_notifications.each do |unread_notification, count| %>
-    <%= filter_link :unread, unread_notification, count do %>
-      <% if unread_notification %>
-        <%= octicon 'mail', height: 16, class: 'sidebar-icon star-active' %>
-        Unread
-      <% else %>
-        <%= octicon 'mail-read', height: 16, class: 'sidebar-icon star-active' %>
-        Read
-      <% end %>
+  <%= filter_link :unread, false, @unread_notifications[false] do %>
+      <%= octicon 'mail-read', height: 16, class: 'sidebar-icon star-active' %>
+      Read
+  <% end %>
 
-    <% end %>
+  <%= filter_link :unread, true, @unread_notifications[true] do %>
+      <%= octicon 'mail', height: 16, class: 'sidebar-icon star-active' %>
+      Unread
   <% end %>
   <%= menu_separator unless @unread_notifications.empty? %>
 


### PR DESCRIPTION
Shows a zero count if there are no unread messages.

Fixes #377 

Looks like this:

![screen shot 2018-08-07 at 10 47 54](https://user-images.githubusercontent.com/1060/43768622-a99dc31e-9a2f-11e8-9806-686784a45e71.png)
