### PR TITLE
Remove count from favicon when the unread count becomes zero

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -46,17 +46,19 @@ function moveCursorToClickedRow(event) {
   setRowCurrent(target, true);
 }
 
+var unread_count = 0;
+
 function updateFavicon() {
   $.get( "/notifications/unread_count", function(data) {
-    var unread_count = data["count"];
-    var title = 'Octobox';
-    if (unread_count > 0) {
-      title += ' (' + unread_count +')';
-    }
+    if (data["count"] !== unread_count) {
+      unread_count = data["count"]
 
-    window.document.title = title;
+      var title = 'Octobox';
+      if (unread_count > 0) {
+        title += ' (' + unread_count +')';
+      }
+      window.document.title = title;
 
-    if ( unread_count > 0 ) {
       var old_link = document.getElementById('favicon-count');
       if ( old_link ) {
         $(old_link).remove();
@@ -73,21 +75,25 @@ function updateFavicon() {
       if (canvas.getContext) {
         canvas.height = canvas.width = 32;
         ctx = canvas.getContext('2d');
-        img.onload = function () {
-          ctx.drawImage(this, 0, 0);
 
-          ctx.fillStyle = '#f93e00';
-          ctx.font = 'bold 20px "helvetica", sans-serif';
+          img.onload = function () {
+            ctx.drawImage(this, 0, 0);
 
-          var width = ctx.measureText(txt).width;
-          ctx.fillRect(0, 0, width+4, 24);
+            if (unread_count > 0){
+              ctx.fillStyle = '#f93e00';
+              ctx.font = 'bold 20px "helvetica", sans-serif';
 
-          ctx.fillStyle = '#fff';
-          ctx.fillText(txt, 2, 20);
+              var width = ctx.measureText(txt).width;
+              ctx.fillRect(0, 0, width+4, 24);
 
-          link.href = canvas.toDataURL('image/png');
-          document.body.appendChild(link);
-        };
+              ctx.fillStyle = '#fff';
+              ctx.fillText(txt, 2, 20);
+            }
+
+            link.href = canvas.toDataURL('image/png');
+            document.body.appendChild(link);
+          };
+
         img.src = "/favicon-32x32.png";
       }
     }


### PR DESCRIPTION
The bug showed up when the `updateFavicon` call returns an unread count of zero, where it previously was one

The text (1) was being removed but the red count on the icon was not, resulting in a tab like this:

![screen shot 2018-08-07 at 11 28 59](https://user-images.githubusercontent.com/1060/43770755-2a2efffc-9a35-11e8-9464-0adfb44e1dd5.png)

This PR updates the favicon every time and only draws the red bit if the count is > 0, this also changes the behaviour to only updates the favicon and title if the count has changed since last check.