### PR TITLE
Fix/721 add momentum scrolling on ios devices

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -454,6 +454,9 @@ td.keys {
   }
   .flex-sidebar {
     position: absolute;
+    // enable momentum scrolling on mobile safari
+    overflow-y: scroll;
+    -webkit-overflow-scrolling: touch;
     bottom: 0;
     top: 0;
     width: $sidebar-width;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -74,6 +74,8 @@ html {
       > .card {
         height: 100%;
         overflow-y: scroll;
+        // enable momentum scrolling on mobile safari
+        -webkit-overflow-scrolling: touch;
         > .card-header {
           position: absolute;
           z-index: 1;


### PR DESCRIPTION
Enabled in devices of medium size and under

1. sidebar
2. issue list

Note [this](https://stackoverflow.com/questions/30102792/css-media-query-target-only-ios-devices) seemed to work, so could perhaps we can use this if we are not happy targeting by screen size 😄 