### PR TITLE
Render emoji in labels on active filter menu

### DIFF
--- a/app/views/notifications/_filter-list.html.erb
+++ b/app/views/notifications/_filter-list.html.erb
@@ -32,7 +32,7 @@
       <% end %>
 
       <%= filter_option :label do %>
-        Label: <%= params[:label] %>
+        Label: <%= emojify(params[:label]) %>
       <% end %>
 
       <%= filter_option :q do %>


### PR DESCRIPTION
Before:

<img width="731" alt="screen shot 2018-08-07 at 17 01 36" src="https://user-images.githubusercontent.com/1060/43788234-d5b5c1b0-9a64-11e8-8fc1-ecd4a1ef2a6b.png">

After:

<img width="758" alt="screen shot 2018-08-07 at 17 02 55" src="https://user-images.githubusercontent.com/1060/43788251-dc53213e-9a64-11e8-92a1-38431b4538dd.png">

Also benefits from https://github.com/octobox/octobox/pull/750