### PR TITLE
Triage view

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -252,6 +252,8 @@ class NotificationsController < ApplicationController
       scope.starred
     elsif params[:archive].present?
       scope.archived
+    elsif params[:triage].present?
+      scope.triage
     else
       scope.inbox
     end

--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -42,12 +42,13 @@ module NotificationsHelper
       bot:        params[:bot],
       unlabelled: params[:unlabelled],
       assigned:   params[:assigned],
-      is_private: params[:is_private]
+      is_private: params[:is_private],
+      triage:     params[:triage]
     }
   end
 
   def inbox_selected?
-    !archive_selected? && !starred_selected? && !showing_search_results?
+    !archive_selected? && !starred_selected? && !showing_search_results? && !triage_selected?
   end
 
   def archive_selected?
@@ -62,6 +63,10 @@ module NotificationsHelper
     filters[:q].present?
   end
 
+  def triage_selected?
+    filters[:triage].present?
+  end
+
   def show_archive_icon?
     starred_selected? || showing_search_results?
   end
@@ -71,7 +76,7 @@ module NotificationsHelper
   end
 
   def bucket_param_keys
-    [:archive, :starred]
+    [:archive, :starred, :triage]
   end
 
   def filter_param_keys

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -27,6 +27,7 @@ class Notification < ApplicationRecord
   scope :archived, ->(value = true) { where(archived: value) }
   scope :newest,   -> { order('notifications.updated_at DESC') }
   scope :starred,  ->(value = true) { where(starred: value) }
+  scope :triage,   -> { state('open') }
 
   scope :repo,     ->(repo_name)    { where(arel_table[:repository_full_name].matches(repo_name)) }
   scope :type,     ->(subject_type) { where(subject_type: subject_type) }

--- a/app/views/notifications/_sidebar.html.erb
+++ b/app/views/notifications/_sidebar.html.erb
@@ -9,6 +9,15 @@
     <% end %>
   </li>
   <li role="presentation" class="nav-item">
+    <%= link_to root_path(triage: true, per_page: params[:per_page]), { :class=>"nav-link #{'active' if triage_selected?}" } do %>
+      <%= octicon 'list-unordered', height: 16, class: 'sidebar-icon text-info' %>
+      Triage
+      <% if triage_selected? %>
+        <span class="badge badge-light"><%= @unread_notifications.sum(&:last) %></span>
+      <% end %>
+    <% end %>
+  </li>
+  <li role="presentation" class="nav-item">
     <%= link_to root_path(archive: true, per_page: params[:per_page]), { :class=>"nav-link #{'active' if archive_selected?}" } do %>
       <%= octicon 'check', height: 16, class: 'sidebar-icon text-success' %>
       Archive


### PR DESCRIPTION
Mentioned this to @milesmcbain on [twitter](https://twitter.com/teabass/status/1026838963615621121), so I thought I'd open it up for discussion.

The idea behind triage view is all the things that have yet to be dealt with, instead of just working directly out of your inbox. 

<img width="240" alt="screen shot 2018-08-07 at 17 49 38" src="https://user-images.githubusercontent.com/1060/43790412-6c1babec-9a6a-11e8-81ac-0be5619be0c8.png">

It's a separate constant menu item on the right hand size that lists notification threads with subjects  (i.e. pull requests and issues) that are "open", regardless of their archived state, across everything they are involved in.

It needs `FETCH_SUBJECT` enabled on the install to work, so won't be available on https://octobox.io just yet, but I'm working on making that a possibility within the next couple weeks.

This list is still filterable in all the usual ways:

- type
- reason
- org
- repo
- label
- read/unread

<img width="1322" alt="screen shot 2018-08-07 at 17 42 52" src="https://user-images.githubusercontent.com/1060/43790331-35604bc6-9a6a-11e8-8dce-19432ca95e7b.png">

Would love to hear what other people's workflows are when triaging issues/pull requests and what's needed to make this really useful.

Some things that are likely already missing:

- Show issues/pull requests that are open on repos you're responsible for that haven't generated any notifications yet
- Filter by "no label" for things that haven't been labelled up yet (where having a label may suggest it's been triaged by someone already)
- Ability to filter out issues/prs that you can't do anything about, most likely because you happened to get mentioned on someone else's repo, perhaps one solution to this is only show threads/subjects that  you are subscribed to, so hitting "mute" would remove them from this view.
- Sorting options (newest, oldest, comment count etc)