### PR TITLE
Add a filter for unlabelled issues and pull requests

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -76,6 +76,7 @@ class NotificationsController < ApplicationController
     @unread_notifications  = scope.distinct.group(:unread).count
     @reasons               = scope.distinct.group(:reason).count
     @unread_repositories   = scope.distinct.group(:repository_full_name).count
+    @unlabelled            = scope.unlabelled.count
     scope = current_notifications(scope)
     check_out_of_bounds(scope)
 
@@ -227,6 +228,7 @@ class NotificationsController < ApplicationController
       end
       scope = scope.send(sub_scope, val)
     end
+    scope = scope.unlabelled if params[:unlabelled].present?
     scope = scope.labels(params[:label]) if params[:label].present?
     scope = scope.search_by_subject_title(params[:q]) if params[:q].present?
     scope = scope.unscope(where: :archived)           if params[:q].present?

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -35,9 +35,12 @@ class Notification < ApplicationRecord
 
   scope :state,    ->(state) { joins(:subject).where('subjects.state = ?', state) }
 
-  scope :labels,    ->(label_name) { joins(:labels).where('labels.name = ?', label_name)}
+  scope :labelable,   -> { where(subject_type: ['Issue', 'PullRequest']) }
+  scope :labels,      ->(label_name) { joins(:labels).where('labels.name = ?', label_name)}
+  scope :unlabelled,  -> { labelable.with_subject.left_outer_joins(:labels).where(labels: {id: nil})}
 
   scope :subjectable, -> { where(subject_type: ['Issue', 'PullRequest', 'Commit', 'Release']) }
+  scope :with_subject, -> { includes(:subject).where.not(subjects: { url: nil }) }
   scope :without_subject, -> { includes(:subject).where(subjects: { url: nil }) }
 
   paginates_per 20

--- a/app/views/notifications/_sidebar.html.erb
+++ b/app/views/notifications/_sidebar.html.erb
@@ -57,6 +57,14 @@
     <%= menu_separator unless @states.empty? %>
   <% end %>
 
+  <% if @unlabelled > 0 %>
+    <%= filter_link :unlabelled, true, @unlabelled do %>
+      <%= octicon 'tag', height: 16, class: 'sidebar-icon' %>
+      Unlabelled
+    <% end %>
+    <%= menu_separator %>
+  <% end %>
+
   <% @types.sort_by{|type, count| type.downcase }.each do |type, count| %>
     <%= filter_link :type, type, count do %>
       <% if notification_icon(type).nil? %>


### PR DESCRIPTION
As mentioned in #752, being able to triage things by focusing on items that haven't been labelled yet is very useful.

Only works if you have subject syncing enabled (`FETCH_SUBJECT`), so won't work on https://octobox.io just yet.

![screen shot 2018-08-08 at 11 44 12](https://user-images.githubusercontent.com/1060/43832814-8d16d826-9b00-11e8-8c91-881c0059a1ee.png)

Alternative icon could be a question mark:

![screen shot 2018-08-08 at 11 47 36](https://user-images.githubusercontent.com/1060/43832928-e87faea4-9b00-11e8-8128-a3a7e8f41201.png)
