### PR TITLE
Gracefully handle Octokit::ServerError exceptions caused by 504 response codes

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,7 +11,7 @@ class ApplicationController < ActionController::Base
   rescue_from Octokit::Unauthorized, Octokit::Forbidden do |exception|
     handle_exception(exception, :service_unavailable, I18n.t("exceptions.octokit.unauthorized"))
   end
-  rescue_from Octokit::BadGateway, Octokit::ServiceUnavailable, Octokit::InternalServerError do |exception|
+  rescue_from Octokit::BadGateway, Octokit::ServiceUnavailable, Octokit::InternalServerError, Octokit::ServerError do |exception|
     handle_exception(exception, :service_unavailable, I18n.t("exceptions.octokit.unavailable"))
   end
   rescue_from Faraday::ClientError do |exception|

--- a/app/workers/sync_notifications_worker.rb
+++ b/app/workers/sync_notifications_worker.rb
@@ -11,7 +11,7 @@ class SyncNotificationsWorker
     user.sync_notifications
   rescue Octokit::Unauthorized, Octokit::Forbidden => exception
     handle_exception(exception, user)
-  rescue Octokit::BadGateway, Octokit::ServiceUnavailable => exception
+  rescue Octokit::BadGateway, Octokit::ServerError, Octokit::ServiceUnavailable => exception
     handle_exception(exception, user)
   rescue Faraday::ClientError => exception
     handle_exception(exception, user)

--- a/lib/tasks/tasks.rake
+++ b/lib/tasks/tasks.rake
@@ -4,7 +4,7 @@ namespace :tasks do
     User.find_each do |user|
       begin
         user.sync_notifications
-      rescue Octokit::BadGateway, Octokit::ServiceUnavailable => e
+      rescue Octokit::BadGateway, Octokit::ServerError, Octokit::ServiceUnavailable => e
         STDERR.puts "Failed to sync notifications for #{user.github_login}\n#{e.class}\n#{e.message}"
       end
     end


### PR DESCRIPTION
Noticed some of those 504 errors in bugsnag the other day, I'd guess the GitHub API was having a bad day, seems reasonable to treat them the same as Octokit::InternalServerError (500)