### PR TITLE
Add rack-canonical-host for redirecting to herokuapp subdomain to octobox.io

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem 'rgb'
 gem 'sidekiq'
 gem 'sidekiq-unique-jobs'
 gem 'sidekiq-scheduler'
+gem 'rack-canonical-host'
 gem 'gemoji'
 gem 'bootsnap', require: false
 gem 'bugsnag'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -190,6 +190,9 @@ GEM
       puma (>= 2.7, < 4)
     raabro (1.1.6)
     rack (2.0.5)
+    rack-canonical-host (0.2.3)
+      addressable (> 0, < 3)
+      rack (>= 1.0.0, < 3)
     rack-protection (2.0.3)
       rack
     rack-test (1.1.0)
@@ -355,6 +358,7 @@ DEPENDENCIES
   pg_search
   puma
   puma_worker_killer
+  rack-canonical-host
   rails (~> 5.2)
   rails-controller-testing
   rake

--- a/config.ru
+++ b/config.ru
@@ -2,4 +2,6 @@
 
 require_relative 'config/environment'
 
+use Rack::CanonicalHost, ENV['CANONICAL_HOST'] if ENV['CANONICAL_HOST']
+
 run Rails.application


### PR DESCRIPTION
Occasionally seeing traffic to http://octobox-io.herokuapp.com/ rather than https://octobox.io, which skips cloudflare https, so want to redirect anyone back to the canonical domain.

Enabled and configured with the `CANONICAL_HOST` ENV var, details of the gem: https://github.com/tylerhunt/rack-canonical-host