### PR TITLE
Add ability to filter by bot

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -71,13 +71,17 @@ class NotificationsController < ApplicationController
   #
   def index
     scope = notifications_for_presentation
-    @states                = scope.distinct.joins(:subject).group('subjects.state').count
     @types                 = scope.distinct.group(:subject_type).count
     @unread_notifications  = scope.distinct.group(:unread).count
     @reasons               = scope.distinct.group(:reason).count
     @unread_repositories   = scope.distinct.group(:repository_full_name).count
-    @unlabelled            = scope.unlabelled.count
-    @bot_notifications     = scope.bot_author.count
+
+    if Octobox.config.fetch_subject
+      @states                = scope.distinct.joins(:subject).group('subjects.state').count
+      @unlabelled            = scope.unlabelled.count
+      @bot_notifications     = scope.bot_author.count
+    end
+
     scope = current_notifications(scope)
     check_out_of_bounds(scope)
 

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -77,6 +77,7 @@ class NotificationsController < ApplicationController
     @reasons               = scope.distinct.group(:reason).count
     @unread_repositories   = scope.distinct.group(:repository_full_name).count
     @unlabelled            = scope.unlabelled.count
+    @bot_notifications     = scope.bot_author.count
     scope = current_notifications(scope)
     check_out_of_bounds(scope)
 
@@ -229,6 +230,7 @@ class NotificationsController < ApplicationController
       scope = scope.send(sub_scope, val)
     end
     scope = scope.unlabelled if params[:unlabelled].present?
+    scope = scope.bot_author if params[:bot].present?
     scope = scope.labels(params[:label]) if params[:label].present?
     scope = scope.search_by_subject_title(params[:q]) if params[:q].present?
     scope = scope.unscope(where: :archived)           if params[:q].present?

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -43,6 +43,8 @@ class Notification < ApplicationRecord
   scope :with_subject, -> { includes(:subject).where.not(subjects: { url: nil }) }
   scope :without_subject, -> { includes(:subject).where(subjects: { url: nil }) }
 
+  scope :bot_author, -> { joins(:subject).where('subjects.author ILIKE ?', '%[bot]') }
+
   paginates_per 20
 
   class << self

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -43,7 +43,7 @@ class Notification < ApplicationRecord
   scope :with_subject, -> { includes(:subject).where.not(subjects: { url: nil }) }
   scope :without_subject, -> { includes(:subject).where(subjects: { url: nil }) }
 
-  scope :bot_author, -> { joins(:subject).where('subjects.author LIKE ?', '%[bot]') }
+  scope :bot_author, -> { joins(:subject).where('subjects.author LIKE ? OR subjects.author LIKE ?', '%[bot]', '%-bot') }
 
   paginates_per 20
 

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -43,7 +43,7 @@ class Notification < ApplicationRecord
   scope :with_subject, -> { includes(:subject).where.not(subjects: { url: nil }) }
   scope :without_subject, -> { includes(:subject).where(subjects: { url: nil }) }
 
-  scope :bot_author, -> { joins(:subject).where('subjects.author ILIKE ?', '%[bot]') }
+  scope :bot_author, -> { joins(:subject).where('subjects.author LIKE ?', '%[bot]') }
 
   paginates_per 20
 

--- a/app/views/notifications/_sidebar.html.erb
+++ b/app/views/notifications/_sidebar.html.erb
@@ -44,15 +44,6 @@
   <%= menu_separator unless @unread_notifications.empty? %>
 
   <% if display_subject? %>
-    <% if @bot_notifications > 0 %>
-      <%= filter_link :bot, true, @bot_notifications do %>
-        <%= octicon 'hubot', height: 18, class: 'sidebar-icon' %>
-        Bots
-      <% end %>
-
-      <%= menu_separator %>
-    <% end %>
-
     <% @states.sort_by{|state, count| state.to_s }.reverse_each do |state, count| %>
       <% next if state.nil? %>
       <%= filter_link :state, state, count do %>
@@ -64,14 +55,21 @@
       <% end %>
     <% end %>
     <%= menu_separator unless @states.empty? %>
-  <% end %>
 
-  <% if @unlabelled > 0 %>
-    <%= filter_link :unlabelled, true, @unlabelled do %>
-      <%= octicon 'tag', height: 16, class: 'sidebar-icon' %>
-      Unlabelled
+    <% if @bot_notifications > 0 %>
+      <%= filter_link :bot, true, @bot_notifications do %>
+        <%= octicon 'hubot', height: 18, class: 'sidebar-icon' %>
+        Bots
+      <% end %>
     <% end %>
-    <%= menu_separator %>
+    <% if @unlabelled > 0 %>
+      <%= filter_link :unlabelled, true, @unlabelled do %>
+        <%= octicon 'tag', height: 16, class: 'sidebar-icon' %>
+        Unlabelled
+      <% end %>
+    <% end %>
+
+    <%= menu_separator if @unlabelled > 0 || @bot_notifications > 0 %>
   <% end %>
 
   <% @types.sort_by{|type, count| type.downcase }.each do |type, count| %>

--- a/app/views/notifications/_sidebar.html.erb
+++ b/app/views/notifications/_sidebar.html.erb
@@ -44,6 +44,15 @@
   <%= menu_separator unless @unread_notifications.empty? %>
 
   <% if display_subject? %>
+    <% if @bot_notifications > 0 %>
+      <%= filter_link :bot, true, @bot_notifications do %>
+        <%= octicon 'hubot', height: 18, class: 'sidebar-icon' %>
+        Bots
+      <% end %>
+
+      <%= menu_separator %>
+    <% end %>
+
     <% @states.sort_by{|state, count| state.to_s }.reverse_each do |state, count| %>
       <% next if state.nil? %>
       <%= filter_link :state, state, count do %>


### PR DESCRIPTION
Semi-related to https://github.com/octobox/octobox/issues/599 and #752 

Adds a sidebar menu item for issues and prs created by offical bot accounts (names that end in `[bot]`)

![screen shot 2018-08-10 at 09 44 41](https://user-images.githubusercontent.com/1060/43949175-a831a610-9c84-11e8-83a6-89a04993a875.png)
