### PR TITLE
Improve blankslates

### DIFF
--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -63,23 +63,33 @@
               <%= octicon 'thumbsup', height: 32, class: 'blankslate-icon' %>
               <h3>You're in the clear!</h3>
               <p>There are no notifications that need your attention.</p>
-              <p><i>Expecting notifications? Make sure <a href="https://github.com/settings/notifications">Web Notifications</a> are enabled on your GitHub account.</i></p>
+              <p>
+                <%= link_to sync_notifications_path(filters), method: :post, class: 'btn btn-outline-secondary sync' do %>
+                  <%= octicon 'sync', height: 18 %>
+                  <span class='ml-1'>Refresh</span>
+                <% end %>
+              </p>
+              <% unless current_user.notifications.any? %>
+                <p><i>Expecting notifications? Make sure <a href="https://github.com/settings/notifications">Web Notifications</a> are enabled on your GitHub account.</i></p>
+              <% end %>
               <% if current_user.last_synced_at %>
                 <p class='text-muted'>
-                <small>Last sync: <%= time_ago_in_words current_user.last_synced_at %> ago</small>
+                  <small>Last sync: <%= time_ago_in_words current_user.last_synced_at %> ago</small>
                 </p>
               <% end %>
             </div>
           <% else %>
             <div class="blankslate blankslate-spacious blankslate-clean-background">
-              <%= octicon 'mail-read', height: 32, class: 'blankslate-icon' %>
-              <%= octicon 'thumbsup', height: 32, class: 'blankslate-icon' %>
+              <%= octicon 'search', height: 32, class: 'blankslate-icon' %>
+              <%= octicon 'gist-secret', height: 32, class: 'blankslate-icon' %>
               <h3>Nothing to see here.</h3>
-              <p>You can always try <%= link_to 'refreshing', sync_notifications_path(filters), method: :post %>.</p>
-              <p><i>Expecting notifications? Make sure <a href="https://github.com/settings/notifications">Web Notifications</a> are enabled on your GitHub account.</i></p>
+              <p>You can always try <%= link_to 'refreshing', sync_notifications_path(filters), method: :post %> or <%= link_to 'removing filters', root_path %>.</p>
+              <% unless current_user.notifications.any? %>
+                <p><i>Expecting notifications? Make sure <a href="https://github.com/settings/notifications">Web Notifications</a> are enabled on your GitHub account.</i></p>
+              <% end %>
               <% if current_user.last_synced_at %>
                 <p class='text-muted'>
-                <small>Last sync: <%= time_ago_in_words current_user.last_synced_at %> ago</small>
+                  <small>Last sync: <%= time_ago_in_words current_user.last_synced_at %> ago</small>
                 </p>
               <% end %>
             </div>


### PR DESCRIPTION
Couple small tweaks to the section that shows when there are no notifications to show:

When you've reached inbox-zero:

![screen shot 2018-08-10 at 14 40 39](https://user-images.githubusercontent.com/1060/43961114-fba47580-9cab-11e8-8fea-c3716aed081b.png)

When your filtering/searching turned up no results:

![screen shot 2018-08-10 at 14 33 56](https://user-images.githubusercontent.com/1060/43961138-0a8b2800-9cac-11e8-9481-39f2b1cde141.png)
