### PR TITLE
Sync github_id onto subjects

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -166,6 +166,7 @@ class Notification < ApplicationRecord
       case subject_type
       when 'Issue', 'PullRequest'
         create_subject({
+          github_id: remote_subject.id,
           state: remote_subject.merged_at.present? ? 'merged' : remote_subject.state,
           author: remote_subject.user.login,
           html_url: remote_subject.html_url,
@@ -174,6 +175,7 @@ class Notification < ApplicationRecord
         })
       when 'Commit', 'Release'
         create_subject({
+          github_id: remote_subject.id,
           author: remote_subject.author&.login,
           html_url: remote_subject.html_url,
           created_at: remote_subject.created_at,

--- a/db/migrate/20180816142404_add_github_id_to_subjects.rb
+++ b/db/migrate/20180816142404_add_github_id_to_subjects.rb
@@ -1,0 +1,5 @@
+class AddGithubIdToSubjects < ActiveRecord::Migration[5.2]
+  def change
+    add_column :subjects, :github_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_03_073302) do
+ActiveRecord::Schema.define(version: 2018_08_16_142404) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -56,6 +56,7 @@ ActiveRecord::Schema.define(version: 2018_08_03_073302) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "html_url"
+    t.integer "github_id"
     t.index ["url"], name: "index_subjects_on_url"
   end
 

--- a/test/factories/subject.rb
+++ b/test/factories/subject.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :subject do
     sequence(:url) { |n| "https://api.github.com/repos/octobox/octobox/issues/#{n}" }
+    sequence(:github_id, 1000000) { |n| n }
     state 'open'
     author 'andrew'
   end


### PR DESCRIPTION
Will come in useful later when linking to certain parts of the issue/pr page on GitHub, like #709