### PR TITLE
Show bot and unlabelled filters in filter menu when active

### DIFF
--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -27,19 +27,21 @@ module NotificationsHelper
 
   def filters
     {
-      reason:   params[:reason],
-      unread:   params[:unread],
-      repo:     params[:repo],
-      type:     params[:type],
-      archive:  params[:archive],
-      starred:  params[:starred],
-      owner:    params[:owner],
-      per_page: params[:per_page],
-      q:        params[:q],
-      state:    params[:state],
-      label:    params[:label],
-      author:   params[:author],
-      assigned: params[:assigned]
+      reason:     params[:reason],
+      unread:     params[:unread],
+      repo:       params[:repo],
+      type:       params[:type],
+      archive:    params[:archive],
+      starred:    params[:starred],
+      owner:      params[:owner],
+      per_page:   params[:per_page],
+      q:          params[:q],
+      state:      params[:state],
+      label:      params[:label],
+      author:     params[:author],
+      bot:        params[:bot],
+      unlabelled: params[:unlabelled],
+      assigned:   params[:assigned]
     }
   end
 

--- a/app/views/notifications/_filter-list.html.erb
+++ b/app/views/notifications/_filter-list.html.erb
@@ -39,6 +39,14 @@
         Search: <%= params[:q] %>
       <% end %>
 
+      <%= filter_option :bot do %>
+        <%= (params[:bot] === 'true'? 'Bot' : 'Human') %>
+      <% end %>
+
+      <%= filter_option :unlabelled do %>
+        <%= (params[:unlabelled] === 'true'? 'Unabelled' : 'Labelled') %>
+      <% end %>
+
       <%= filter_option :author do %>
         Author: <%= params[:author] %>
       <% end %>


### PR DESCRIPTION
Adds the Bot and Unlabelled filters to the filter bar which got missed in the original pull requests