### PR TITLE
Don't block page load whilst loading and parsing javascript

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,7 +27,7 @@
     <% end %>
 
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
-    <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
+    <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload', defer: true %>
 
     <meta property="og:title" content="Octobox">
     <meta property="og:description" content="The best way to manage your GitHub Notifications">


### PR DESCRIPTION
~~async is only true in production otherwise development breaks from sprockets adding each file individually as <script> tags 😆~~

Turns out async doesn't play well with turbolinks: https://github.com/turbolinks/turbolinks/issues/281