### PR TITLE
Enable pg_stat_statements postgres extension

### DIFF
--- a/db/migrate/20180817172203_enable_pg_stat_statements_extension.rb
+++ b/db/migrate/20180817172203_enable_pg_stat_statements_extension.rb
@@ -1,0 +1,5 @@
+class EnablePgStatStatementsExtension < ActiveRecord::Migration[5.2]
+  def change
+    enable_extension 'pg_stat_statements'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_16_142404) do
+ActiveRecord::Schema.define(version: 2018_08_17_172203) do
 
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
 
   create_table "labels", force: :cascade do |t|


### PR DESCRIPTION
Helpful for analyzing slow queries and unused indexes in the database.

More details: https://www.postgresql.org/docs/current/static/pgstatstatements.html

- [ ] Need to make sure this works with the standard docker postgresql image.