### PR TITLE
Pin the filter/action bar to the top of the notifications table

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -598,6 +598,7 @@ td.keys {
 .card-notifications {
   margin-bottom: 20px;
   .card-header {
+    background-color: #f6f6f6;
     padding: 6px 8px;
     .pagination{
       margin: 6px 0px 0px;

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -7,7 +7,7 @@
   <div class="flex-main">
     <div class="flex-container">
       <div class="card card-notifications justify-content-between">
-        <div class="card-header">
+        <div class="card-header sticky-top">
           <% if @notifications.to_a.any? %>
             <div class="per-page btn-group float-right d-none d-md-block" data-toggle="tooltip" data-placement="left" title="Notifications per page">
               <button type="button" class="btn btn-sm btn-outline-secondary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">


### PR DESCRIPTION
Sticks the filter/action bar to the top when you scroll down on desktop

Fixes #817

![screen shot 2018-08-20 at 16 52 02](https://user-images.githubusercontent.com/1060/44351512-f3adb800-a499-11e8-9e4c-892012248aba.png)

