### PR TITLE
Respect github_domain config when linking to notification settings

### DIFF
--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -70,7 +70,7 @@
                 <% end %>
               </p>
               <% unless current_user.notifications.any? %>
-                <p><i>Expecting notifications? Make sure <a href="https://github.com/settings/notifications">Web Notifications</a> are enabled on your GitHub account.</i></p>
+                <p><i>Expecting notifications? Make sure <a href="<%= Octobox.config.github_domain %>/settings/notifications">Web Notifications</a> are enabled on your GitHub account.</i></p>
               <% end %>
               <% if current_user.last_synced_at %>
                 <p class='text-muted'>
@@ -85,7 +85,7 @@
               <h3>Nothing to see here.</h3>
               <p>You can always try <%= link_to 'refreshing', sync_notifications_path(filters), method: :post %> or <%= link_to 'removing filters', root_path %>.</p>
               <% unless current_user.notifications.any? %>
-                <p><i>Expecting notifications? Make sure <a href="https://github.com/settings/notifications">Web Notifications</a> are enabled on your GitHub account.</i></p>
+                <p><i>Expecting notifications? Make sure <a href="<%= Octobox.config.github_domain %>/settings/notifications">Web Notifications</a> are enabled on your GitHub account.</i></p>
               <% end %>
               <% if current_user.last_synced_at %>
                 <p class='text-muted'>


### PR DESCRIPTION
Small improvement for Enterprise installs, only place it shows up is on the blank slate if you have no notifications after syncing.