### PR TITLE
 Store repository_full_name on Subject and setup proper relations with Repository

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -187,6 +187,7 @@ class Notification < ApplicationRecord
     if subject
       case subject_type
       when 'Issue', 'PullRequest'
+        subject.repository_full_name = repository_full_name
         subject.assignees = ":#{Array(remote_subject.assignees.try(:map, &:login)).join(':')}:"
         subject.state = remote_subject.merged_at.present? ? 'merged' : remote_subject.state
         subject.save(touch: false) if subject.changed?
@@ -195,6 +196,7 @@ class Notification < ApplicationRecord
       case subject_type
       when 'Issue', 'PullRequest'
         create_subject({
+          repository_full_name: repository_full_name,
           github_id: remote_subject.id,
           state: remote_subject.merged_at.present? ? 'merged' : remote_subject.state,
           author: remote_subject.user.login,
@@ -205,6 +207,7 @@ class Notification < ApplicationRecord
         })
       when 'Commit', 'Release'
         create_subject({
+          repository_full_name: repository_full_name,
           github_id: remote_subject.id,
           author: remote_subject.author&.login,
           html_url: remote_subject.html_url,

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -1,5 +1,6 @@
 class Repository < ApplicationRecord
   has_many :notifications, foreign_key: :repository_full_name, primary_key: :full_name
+  has_many :subjects, foreign_key: :repository_full_name, primary_key: :full_name
   belongs_to :app_installation
 
   validates :full_name, presence: true, uniqueness: true
@@ -7,9 +8,5 @@ class Repository < ApplicationRecord
 
   def github_app_installed?
     app_installation_id.present?
-  end
-
-  def subjects
-    Subject.repository(full_name)
   end
 end

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -1,5 +1,6 @@
 class Repository < ApplicationRecord
   has_many :notifications, foreign_key: :repository_full_name, primary_key: :full_name
+  has_many :users, -> { distinct }, through: :notifications
   has_many :subjects, foreign_key: :repository_full_name, primary_key: :full_name
   belongs_to :app_installation
 

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -2,6 +2,7 @@ class Subject < ApplicationRecord
   has_many :notifications, foreign_key: :subject_url, primary_key: :url
   has_many :labels, dependent: :delete_all
   has_many :users, through: :notifications
+  belongs_to :repository, foreign_key: :repository_full_name, primary_key: :full_name, optional: true
 
   BOT_AUTHOR_REGEX = /\A(.*)\[bot\]\z/.freeze
   private_constant :BOT_AUTHOR_REGEX
@@ -46,6 +47,7 @@ class Subject < ApplicationRecord
   def self.sync(remote_subject)
     subject = Subject.find_or_create_by(url: remote_subject['url'])
     subject.update({
+      repository_full_name: remote_subject['repository']['full_name'],
       github_id: remote_subject['id'],
       state: remote_subject['merged_at'].present? ? 'merged' : remote_subject['state'],
       author: remote_subject['user']['login'],

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -41,7 +41,7 @@ class Subject < ApplicationRecord
 
   def sync_involved_users
     return unless Octobox.github_app?
-    user_ids.each { |user_id| SyncNotificationsWorker.perform_async(user_id) }
+    involved_user_ids.each { |user_id| SyncNotificationsWorker.perform_async(user_id) }
   end
 
   def self.sync(remote_subject)
@@ -61,6 +61,10 @@ class Subject < ApplicationRecord
   end
 
   private
+
+  def involved_user_ids
+    (user_ids + Array(repository.try(:user_ids))).uniq
+  end
 
   def author_url_path
     if bot_author?

--- a/db/migrate/20180830145149_add_repository_full_name_to_subjects.rb
+++ b/db/migrate/20180830145149_add_repository_full_name_to_subjects.rb
@@ -1,0 +1,5 @@
+class AddRepositoryFullNameToSubjects < ActiveRecord::Migration[5.2]
+  def change
+    add_column :subjects, :repository_full_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_17_172203) do
+ActiveRecord::Schema.define(version: 2018_08_30_145149) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -85,6 +85,7 @@ ActiveRecord::Schema.define(version: 2018_08_17_172203) do
     t.string "html_url"
     t.string "assignees", default: "::"
     t.integer "github_id"
+    t.string "repository_full_name"
     t.index ["url"], name: "index_subjects_on_url"
   end
 

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -20,7 +20,7 @@ class RepositoryTest < ActiveSupport::TestCase
     repository = build(:repository, full_name: @repository.full_name)
     refute repository.valid?
   end
-  
+
   test 'github_app_installed if app_installation_id present' do
     @repository.app_installation_id = 1
     assert @repository.github_app_installed?
@@ -32,8 +32,8 @@ class RepositoryTest < ActiveSupport::TestCase
   end
 
   test 'finds subjects by full_name' do
-    subject = create(:subject, url: "https://api.github.com/repos/#{@repository.full_name}/issues/1")
-    subject2 = create(:subject, url: "https://api.github.com/repos/foo/bar/issues/1")
+    subject = create(:subject, url: "https://api.github.com/repos/#{@repository.full_name}/issues/1", repository_full_name: @repository.full_name)
+    subject2 = create(:subject, url: "https://api.github.com/repos/foo/bar/issues/1", repository_full_name: 'foo/bar')
     assert_equal @repository.subjects.length, 1
     assert_equal @repository.subjects.first, subject
   end


### PR DESCRIPTION
Switches the relationship between Subject and Repository to be an actual ActiveRecord one rather than a LIKE query.

Also enables us to speculatively sync all users who've been notified of something from a repository before (quite likely they are watching it) on creation of new issues/pull requests on that repo via the GitHub App webhook. 

That means for GitHub App users, they shouldn't need to use the sync button very often as they will be automatically synced whenever we see a new/updated issue/pr via the webhook.