### PR TITLE
Fix notification for bootstrap 4

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -12,7 +12,7 @@ module ApplicationHelper
 
   def flash_messages
     flash.each do |msg_type, message|
-      concat(content_tag(:div, message, class: "alert #{bootstrap_class_for(msg_type)} fade in") do
+      concat(content_tag(:div, message, class: "alert #{bootstrap_class_for(msg_type)} fade show") do
         concat content_tag(:button, 'x', class: 'close', data: { dismiss: 'alert' })
         concat message
       end)


### PR DESCRIPTION
`fade in` is bootstrap 3, `fade show` is bootstrap 4: https://getbootstrap.com/docs/4.0/components/alerts/#dismissing