### PR TITLE
Add support for a "native" desktop app link in the dropdown

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -63,6 +63,12 @@
             <%= octicon 'book', height: 16, class: 'text-muted' %>
             User Documentation
           <% end %>
+           <% if Octobox.config.native_link %>
+              <%= link_to Octobox.config.native_link, class: 'dropdown-item' do %>
+                <%= octicon 'desktop-download', height: 16, class: 'text-muted' %>
+                Download Desktop App
+              <% end %>
+          <% end %>
           <% if File.exist?(Rails.root.join('public', 'docs', 'index.html')) %>
             <%= link_to "docs/", class: 'dropdown-item' do %>
               <%= octicon 'code', height: 16, class: 'text-muted' %>

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -321,6 +321,12 @@ If you have modified the Octobox code in any way, in order to comply with the AG
 can do this by setting the `SOURCE_REPO` environment variable to the url of a GitHub repo with the modified source.  For instance, if
 you run this from a fork in the 'NotOctobox' org, you would set `SOURCE_REPO=https://github.com/NotOctobox/octobox`.
 
+## Adding a link to a "native" desktop app link
+
+Some applications allow you to create "native" applications for the desktop. This includes software such as [Nativefier](https://www.npmjs.com/package/nativefier).
+
+If your installation uses this, set the environment variable `OCTOBOX_NATIVE_LINK` to add a link to the dropdown menu.
+
 ## Adding a custom initializer
 
 If you have some need to run custom Ruby code or wish to configure Octobox directly on application load, you may add a file named

--- a/lib/octobox/configurator.rb
+++ b/lib/octobox/configurator.rb
@@ -111,6 +111,11 @@ module Octobox
     end
     attr_writer :github_team_id
 
+    def native_link
+      ENV['OCTOBOX_NATIVE_LINK'] || nil
+    end
+    attr_writer :native_link
+
     def source_repo
       env_value = ENV['SOURCE_REPO'].blank? ? nil : ENV['SOURCE_REPO']
       @source_repo || env_value || 'https://github.com/octobox/octobox'


### PR DESCRIPTION
Adds and documents support for a "desktop app" link in the dropdown menu

<img width="359" alt="image" src="https://user-images.githubusercontent.com/3074765/44875484-52c6b600-ac6c-11e8-9901-336c00963d3c.png">

