### PR TITLE
Add custom worker options so that sidekiq can be optionally enabled

### DIFF
--- a/app/controllers/hooks_controller.rb
+++ b/app/controllers/hooks_controller.rb
@@ -6,22 +6,22 @@ class HooksController < ApplicationController
   def create
     case event_header
     when 'issues', 'issue_comment'
-      SyncSubjectWorker.perform_async(payload['issue'])
+      SyncSubjectWorker.perform_async_if_configured(payload['issue'])
     when 'pull_request'
-      SyncSubjectWorker.perform_async(payload['pull_request'])
+      SyncSubjectWorker.perform_async_if_configured(payload['pull_request'])
     when 'label'
-      SyncLabelWorker.perform_async(payload) if payload['action'] == 'edited'
+      SyncLabelWorker.perform_async_if_configured(payload) if payload['action'] == 'edited'
     when 'installation'
       case payload['action']
       when 'created'
-        SyncInstallationWorker.perform_async(payload)
+        SyncInstallationWorker.perform_async_if_configured(payload)
       when 'deleted'
         AppInstallation.find_by_github_id(payload['installation']['id']).try(:destroy)
       end
     when 'installation_repositories'
-      SyncInstallationRepositoriesWorker.perform_async(payload)
+      SyncInstallationRepositoriesWorker.perform_async_if_configured(payload)
     when 'github_app_authorization'
-      SyncGithubAppAuthorizationWorker.perform_async(payload['sender']['id'])
+      SyncGithubAppAuthorizationWorker.perform_async_if_configured(payload['sender']['id'])
     end
 
     head :no_content

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -40,7 +40,9 @@ class Subject < ApplicationRecord
 
   def sync_involved_users
     return unless Octobox.github_app?
-    user_ids.each { |user_id| SyncNotificationsWorker.perform_async(user_id) }
+    user_ids.each do |user_id|
+      SyncNotificationsWorker.perform_async_if_configured(user_id)
+    end
   end
 
   def self.sync(remote_subject)

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -54,9 +54,11 @@
               <%= octicon 'gist-secret', height: 16, class: 'text-muted' %>
               Admin
             <% end %>
-            <%= link_to admin_sidekiq_web_path, class: 'dropdown-item' do %>
-              <%= octicon 'graph', height: 16, class: 'text-muted' %>
-              Sidekiq
+            <% if Octobox.config.background_jobs_enabled? %>
+              <%= link_to admin_sidekiq_web_path, class: 'dropdown-item' do %>
+                <%= octicon 'graph', height: 16, class: 'text-muted' %>
+                Sidekiq
+              <% end %>
             <% end %>
           <% end %>
           <%= link_to "documentation", class: 'dropdown-item' do %>

--- a/app/workers/sync_all_user_notifications_worker.rb
+++ b/app/workers/sync_all_user_notifications_worker.rb
@@ -6,7 +6,7 @@ class SyncAllUserNotificationsWorker
 
   def perform
     User.find_each do |user|
-      SyncNotificationsWorker.perform_async(user.id)
+      SyncNotificationsWorker.perform_async_if_configured(user.id)
     end
   end
 end

--- a/config/initializers/custom_sidekiq_worker.rb
+++ b/config/initializers/custom_sidekiq_worker.rb
@@ -4,7 +4,12 @@ module Sidekiq::Worker
       if Octobox.config.background_jobs_enabled?
         perform_async(*args)
       else
-        perform(*args)
+        worker = new
+        if worker.method(:perform).arity != 0
+          worker.perform(*args)
+        else
+          worker.perform
+        end
       end
     end
   end

--- a/config/initializers/custom_sidekiq_worker.rb
+++ b/config/initializers/custom_sidekiq_worker.rb
@@ -1,0 +1,11 @@
+module Sidekiq::Worker
+  module ClassMethods
+    def perform_async_if_configured(*args)
+      if Octobox.config.background_jobs_enabled?
+        perform_async(*args)
+      else
+        perform(*args)
+      end
+    end
+  end
+end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,17 +1,26 @@
 # frozen_string_literal: true
 
-require 'sidekiq-scheduler'
-
-Sidekiq.configure_server do |config|
-  config.redis = { url: Octobox.config.redis_url }
-  if Octobox.config.sidekiq_schedule_enabled?
-    config.on(:startup) do
-      Sidekiq.schedule = YAML.load_file(Octobox.config.sidekiq_schedule_path)
-      Sidekiq::Scheduler.reload_schedule!
-    end
-  end
+if Octobox.config.sidekiq_schedule_enabled? && !Octobox.config.background_jobs_enabled?
+  raise ArgumentError, <<~EOF
+  You have enabled sidekiq schedule, but have not enabled background jobs.
+  Please set the `OCTOBOX_BACKGROUND_JOBS_ENABLED` env var, or unset `OCTOBOX_SIDEKIQ_SCHEDULE_ENABLED`
+  EOF
 end
 
-Sidekiq.configure_client do |config|
-  config.redis = { url: Octobox.config.redis_url }
+if Octobox.config.background_jobs_enabled?
+  require 'sidekiq-scheduler'
+
+  Sidekiq.configure_server do |config|
+    config.redis = { url: Octobox.config.redis_url }
+    if Octobox.config.sidekiq_schedule_enabled?
+      config.on(:startup) do
+        Sidekiq.schedule = YAML.load_file(Octobox.config.sidekiq_schedule_path)
+        Sidekiq::Scheduler.reload_schedule!
+      end
+    end
+  end
+
+  Sidekiq.configure_client do |config|
+    config.redis = { url: Octobox.config.redis_url }
+  end
 end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,12 +1,5 @@
 # frozen_string_literal: true
 
-if Octobox.config.sidekiq_schedule_enabled? && !Octobox.config.background_jobs_enabled?
-  raise ArgumentError, <<~EOF
-  You have enabled sidekiq schedule, but have not enabled background jobs.
-  Please set the `OCTOBOX_BACKGROUND_JOBS_ENABLED` env var, or unset `OCTOBOX_SIDEKIQ_SCHEDULE_ENABLED`
-  EOF
-end
-
 if Octobox.config.background_jobs_enabled?
   require 'sidekiq-scheduler'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,8 @@
 # frozen_string_literal: true
 
-if Octobox.config.background_jobs_enabled?
-  require 'sidekiq/web'
-  if Octobox.config.sidekiq_schedule_enabled?
-    require 'sidekiq-scheduler/web'
-  end
+require 'sidekiq/web'
+if Octobox.config.sidekiq_schedule_enabled?
+  require 'sidekiq-scheduler/web'
 end
 require 'admin_constraint'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
-require 'sidekiq/web'
-if Octobox.config.sidekiq_schedule_enabled?
-  require 'sidekiq-scheduler/web'
+if Octobox.config.background_jobs_enabled?
+  require 'sidekiq/web'
+  if Octobox.config.sidekiq_schedule_enabled?
+    require 'sidekiq-scheduler/web'
+  end
 end
 require 'admin_constraint'
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -285,6 +285,14 @@ GITHUB_DOMAIN=https://github.foobar.com
 
 And that's it :sparkles:
 
+## Background Jobs
+
+Octobox uses Sidekiq for background jobs. However, they are not enabled by default.
+
+To make use of background jobs, set the `OCTOBOX_BACKGROUND_JOBS_ENABLED` variable.
+
+If this is not set, all jobs will be run inline.
+
 ## Using Personal Access Tokens
 Octobox can optionally allow you to set a personal access token to use when querying for notifications.  This must be enabled
 at the server level.  In order to enable it, add the environment variable `PERSONAL_ACCESS_TOKENS_ENABLED` to the `.env` file / deployed environment.

--- a/lib/octobox/configurator.rb
+++ b/lib/octobox/configurator.rb
@@ -84,6 +84,11 @@ module Octobox
     end
     attr_writer :max_concurrency
 
+    def background_jobs_enabled?
+      @background_jobs_enabled || ENV['OCTOBOX_BACKGROUND_JOBS_ENABLED'].present?
+    end
+    attr_writer :background_jobs_enabled
+
     def sidekiq_schedule_enabled?
       @sidekiq_schedule_enabled || ENV['OCTOBOX_SIDEKIQ_SCHEDULE_ENABLED'].present?
     end

--- a/lib/octobox/configurator.rb
+++ b/lib/octobox/configurator.rb
@@ -85,7 +85,7 @@ module Octobox
     attr_writer :max_concurrency
 
     def background_jobs_enabled?
-      @background_jobs_enabled || ENV['OCTOBOX_BACKGROUND_JOBS_ENABLED'].present?
+      @background_jobs_enabled || sidekiq_schedule_enabled? || ENV['OCTOBOX_BACKGROUND_JOBS_ENABLED'].present?
     end
     attr_writer :background_jobs_enabled
 

--- a/test/support/sidekiq_helper.rb
+++ b/test/support/sidekiq_helper.rb
@@ -3,10 +3,19 @@ require 'sidekiq_unique_jobs/testing'
 
 Sidekiq::Testing.fake!
 Sidekiq::Logging.logger = nil
+Octobox.config.background_jobs_enabled = true
 
 module SidekiqMinitestSupport
   def after_teardown
     Sidekiq::Worker.clear_all
     super
+  end
+
+  def with_background_jobs_enabled(enabled: true)
+    original = Octobox.config.background_jobs_enabled?
+    Octobox.config.background_jobs_enabled = enabled
+    yield
+  ensure
+    Octobox.config.background_jobs_enabled = original
   end
 end

--- a/test/support/sidekiq_helper.rb
+++ b/test/support/sidekiq_helper.rb
@@ -1,4 +1,6 @@
 require 'sidekiq/testing'
+require 'sidekiq_unique_jobs/testing'
+
 Sidekiq::Testing.fake!
 Sidekiq::Logging.logger = nil
 

--- a/test/workers/custom_worker_test.rb
+++ b/test/workers/custom_worker_test.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class CustomWorkerTest < ActiveSupport::TestCase
+  test 'perform_async is only called from custom worker' do
+    ruby_files = Dir.glob(Rails.root.join('**', '*.rb'))
+    test_files = Dir.glob(Rails.root.join('test', '**', '*.rb'))
+    files_to_test = ruby_files - test_files
+    bad_files = files_to_test.select { |file| File.read(file) =~ /\.perform_async\(/ }
+    assert_empty bad_files, <<~EOF
+    Some files used `perform_async` instead of our custom `perform_async_if_configured`
+
+    Octobox does not assume that sidekiq is setup, so we use a custom `perform_async_if_configured`
+    that only performs the job in the background if sidekiq is configured. Otherwise, it performs it inline.
+
+    Please use `perform_async_if_configured` instead of `perform_async` in these files:
+
+    - #{bad_files.join("\n -")}
+    EOF
+  end
+
+  test 'perform_async_if_configured calls perform_async' do
+    Octobox.config.background_jobs_enabled = true
+    SyncAllUserNotificationsWorker.expects(:perform).never
+    SyncAllUserNotificationsWorker.perform_async_if_configured(['arg'])
+    assert_equal 1, SyncAllUserNotificationsWorker.jobs.size
+
+    args = SyncAllUserNotificationsWorker.jobs.first['args']
+    assert_equal 1, args.size
+    assert_equal ['arg'], args.first
+  end
+
+  test 'perform_async_if_configured calls perform' do
+    Octobox.config.background_jobs_enabled = false
+    SyncAllUserNotificationsWorker.expects(:perform).once.with(['arg'])
+    SyncAllUserNotificationsWorker.expects(:perform_async).never
+    SyncAllUserNotificationsWorker.perform_async_if_configured(['arg'])
+  end
+end

--- a/test/workers/custom_worker_test.rb
+++ b/test/workers/custom_worker_test.rb
@@ -6,8 +6,13 @@ class CustomWorkerTest < ActiveSupport::TestCase
   test 'perform_async is only called from custom worker' do
     ruby_files = Dir.glob(Rails.root.join('**', '*.rb'))
     test_files = Dir.glob(Rails.root.join('test', '**', '*.rb'))
-    files_to_test = ruby_files - test_files
-    bad_files = files_to_test.select { |file| File.read(file) =~ /\.perform_async\(/ }
+    vendor_files = Dir.glob(Rails.root.join('vendor', '**', '*.rb'))
+    files_to_test = ruby_files - test_files - vendor_files
+
+    bad_files = files_to_test.select do |file|
+      File.read(file).force_encoding('UTF-8') =~ /\.perform_async\(/
+    end
+
     assert_empty bad_files, <<~EOF
     Some files used `perform_async` instead of our custom `perform_async_if_configured`
 
@@ -21,20 +26,30 @@ class CustomWorkerTest < ActiveSupport::TestCase
   end
 
   test 'perform_async_if_configured calls perform_async' do
-    Octobox.config.background_jobs_enabled = true
-    SyncAllUserNotificationsWorker.expects(:perform).never
-    SyncAllUserNotificationsWorker.perform_async_if_configured(['arg'])
-    assert_equal 1, SyncAllUserNotificationsWorker.jobs.size
+    with_background_jobs_enabled(enabled: true) do
+      SyncAllUserNotificationsWorker.any_instance.expects(:perform).never
+      SyncAllUserNotificationsWorker.perform_async_if_configured(['arg'])
+      assert_equal 1, SyncAllUserNotificationsWorker.jobs.size
 
-    args = SyncAllUserNotificationsWorker.jobs.first['args']
-    assert_equal 1, args.size
-    assert_equal ['arg'], args.first
+      args = SyncAllUserNotificationsWorker.jobs.first['args']
+      assert_equal 1, args.size
+      assert_equal ['arg'], args.first
+    end
   end
 
-  test 'perform_async_if_configured calls perform' do
-    Octobox.config.background_jobs_enabled = false
-    SyncAllUserNotificationsWorker.expects(:perform).once.with(['arg'])
-    SyncAllUserNotificationsWorker.expects(:perform_async).never
-    SyncAllUserNotificationsWorker.perform_async_if_configured(['arg'])
+  test 'perform_async_if_configured calls perform with no args' do
+    with_background_jobs_enabled(enabled: false) do
+      SyncAllUserNotificationsWorker.any_instance.expects(:perform).once
+      SyncAllUserNotificationsWorker.expects(:perform_async).never
+      SyncAllUserNotificationsWorker.perform_async_if_configured(['arg'])
+    end
+  end
+
+  test 'perform_async_if_configured calls perform with args' do
+    with_background_jobs_enabled(enabled: false) do
+      SyncLabelWorker.any_instance.expects(:perform).once.with(['arg'])
+      SyncLabelWorker.expects(:perform_async).never
+      SyncLabelWorker.perform_async_if_configured(['arg'])
+    end
   end
 end


### PR DESCRIPTION
This allows sidekiq to be optionally enabled. Instead of using `perform_async`, we must use `perform_async_if_configured`. I've added a test to make sure no one accidentally uses the former.

This means octobox doesn't require a background job server, but you can use it.