### PR TITLE
Bg sync timeout

### DIFF
--- a/app/workers/sync_notifications_worker.rb
+++ b/app/workers/sync_notifications_worker.rb
@@ -1,20 +1,30 @@
 # frozen_string_literal: true
 
+require 'timeout'
+
 class SyncNotificationsWorker
   include Sidekiq::Worker
   include Sidekiq::Status::Worker
   sidekiq_options queue: :sync_notifications, unique: :until_executed
 
+  TIMEOUT = 30.minutes.to_i
+
   def perform(user_id)
     user = User.find_by(id: user_id)
     return unless user.present?
 
-    user.sync_notifications_in_foreground
-  rescue Octokit::Unauthorized, Octokit::Forbidden => exception
-    handle_exception(exception, user)
-  rescue Octokit::BadGateway, Octokit::ServerError, Octokit::ServiceUnavailable => exception
-    handle_exception(exception, user)
-  rescue Faraday::ClientError => exception
+    Timeout.timeout(TIMEOUT) do
+      begin
+        user.sync_notifications_in_foreground
+      rescue Octokit::Unauthorized, Octokit::Forbidden => exception
+        handle_exception(exception, user)
+      rescue Octokit::BadGateway, Octokit::ServerError, Octokit::ServiceUnavailable => exception
+        handle_exception(exception, user)
+      rescue Faraday::ClientError => exception
+        handle_exception(exception, user)
+      end
+    end
+  rescue Timeout::Error => exception
     handle_exception(exception, user)
   end
 


### PR DESCRIPTION
If a user syncs for a long time, or for some reason ends up hanging, you can cause the system to hang on many other users (resource contention).

For this reason, we've found a 30 minute timeout to be sufficient to catch these and force a retry