### PR TITLE
Skip syncing users who don't have an access_token

### DIFF
--- a/app/workers/sync_notifications_worker.rb
+++ b/app/workers/sync_notifications_worker.rb
@@ -12,6 +12,7 @@ class SyncNotificationsWorker
   def perform(user_id)
     user = User.find_by(id: user_id)
     return unless user.present?
+    return unless user.effective_access_token.present?
 
     Timeout.timeout(TIMEOUT) do
       begin


### PR DESCRIPTION
Saves making API requests that will never succeed for users with no access_token as a result of https://github.com/octobox/octobox/pull/619