### PR TITLE
Add feature list to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,18 @@
-# [Octobox](https://octobox.io) &#128238;
+# [Octobox](https://octobox.io) &#128238; <small>Untangle your GitHub Notifications.<small>
 
-:postbox: Untangle your GitHub Notifications.
+Octobox helps you manage your GitHub notifications efficiently so you can spend less time managing and more time getting things done.
+
+- **Don't lose track** - Octobox adds an extra "archived" state to each notification so you can mark it as "done". If anything happens on an archived thread, issue or PR, Octobox will move it back into your inbox.
+
+- **Starred notifications** - Let's be honest, you probably don't have a 'favourite' issue. Octobox lets you highlight important notifications with a star so you can come back and find them easily.
+
+- **Filter all the things** - Filter notifications by notification type, action, state and reason and keep notifications from bots alongside your regular label, author and assignees.
+
+- **Search with prefix filters** - No more Jedi mind tricks. Combine a wide range of powerful search filters help you get straight to the notification you're looking for and focus on just what you need.
+
+- **Built for keyboard warriors** - Navigate, triage and manage your notifications like a pro using Gmail-inspired keyboard shortcuts for every function, no mouse required.
+
+- **Open for everyone** - Octobox developers use Octobox to develop Octobox. 100% developed and managed in the open on GitHub under a FLOSS license.
 
 ![Screenshot of  Octobox](app/assets/images/screenshot.png)
 
@@ -15,7 +27,7 @@
 
 ## Why is this a thing?
 
-If you manage more than one active project on GitHub, you probably find [GitHub Notifications](https://github.com/notifications) pretty lacking.
+If you manage any active projects on GitHub, you probably find [GitHub Notifications](https://github.com/notifications) pretty lacking.
 
 Notifications are marked as read and disappear from the list as soon as you load the page or view the email of the notification. This makes it very hard to keep on top of which notifications you still need to follow up on. Most open source maintainers and GitHub staff end up using a complex combination of filters and labels in Gmail to manage their notifications from their inbox. If, like me, you try to avoid email, then you might want something else.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Octobox helps you manage your GitHub notifications efficiently so you can spend 
 
 - **Don't lose track** - Octobox adds an extra "archived" state to each notification so you can mark it as "done". If anything happens on an archived thread, issue or PR, Octobox will move it back into your inbox.
 
-- **Starred notifications** - Let's be honest, you probably don't have a 'favourite' issue. Octobox lets you highlight important notifications with a star so you can come back and find them easily.
+- **Starred notifications** - Let's be honest, you probably don't have a 'favourite' issue but Octobox lets you highlight important notifications with a star so you can come back and find them easily.
 
 - **Filter all the things** - Filter notifications by notification type, action, state and reason and keep notifications from bots alongside your regular label, author and assignees.
 


### PR DESCRIPTION
Added a list of the high level features of Octobox to the start of the readme, see the full rendered page here: https://github.com/octobox/octobox/blob/readme-feature-list/README.md

![screen shot 2018-09-04 at 10 47 17](https://user-images.githubusercontent.com/1060/45024062-0c88a280-b030-11e8-8e61-1d21fcc96918.png)
