### PR TITLE
Add feature list to homepage

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -146,15 +146,13 @@ document.addEventListener("turbolinks:load", function() {
       checkAll($(".js-select_all").prop('checked'))
     })
 
-    if(!('ontouchstart' in window))
-    {
-      $('[data-toggle="tooltip"]').tooltip()
-    }
+    enableTooltips();
 
-    updateFavicon()
+    updateFavicon();
   }
 });
 
+$(document).ready(enableTooltips);
 
 document.addEventListener("turbolinks:before-cache", function() {
   $('td.js-current').removeClass("current js-current");
@@ -163,6 +161,13 @@ document.addEventListener("turbolinks:before-cache", function() {
 $(document).on('click', '[data-toggle="offcanvas"]', function () {
   $('.flex-content').toggleClass('active')
 });
+
+function enableTooltips() {
+  if(!('ontouchstart' in window))
+  {
+    $('[data-toggle="tooltip"]').tooltip()
+  }
+}
 
 function enableKeyboardShortcuts() {
   // Add shortcut events only once

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -598,16 +598,18 @@ td.keys {
   }
 }
 
-.octicon-star {
-  fill: none;
-  stroke: #aaa;
-  cursor: pointer;
-  &:hover {
-    fill: #aaa;
-  }
-  &.star-active {
-    fill: #f0ad4e;
-    stroke: #f0ad4e;
+.flex-content{
+  .octicon-star {
+    fill: none;
+    stroke: #aaa;
+    cursor: pointer;
+    &:hover {
+      fill: #aaa;
+    }
+    &.star-active {
+      fill: #f0ad4e;
+      stroke: #f0ad4e;
+    }
   }
 }
 
@@ -702,4 +704,8 @@ td.keys {
 
 .flex-header .dropdown-menu{
   z-index: 2000;
+}
+
+.text-large{
+  font-size: 16px;
 }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -39,4 +39,10 @@ module ApplicationHelper
   def menu_separator(custom_class=nil)
     "<li class='divider #{custom_class}'></li>".html_safe
   end
+
+  def used_by_orgs
+    %w(kubernetes facebook nodejs angular Microsoft dotnet
+       elastic src-d alphagov vuejs rails algolia
+       shopify WordPress golang)
+  end
 end

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -53,7 +53,7 @@
                 </div>
                 <div class="media-body">
                   <h4>Starred notifications</h4>
-                  Let's be honest, you probably don't have a 'favourite' issue. Octobox lets you highlight important notifications with a star so you can come back and find them easily.
+                  Let's be honest, you probably don't have a 'favourite' issue but Octobox lets you highlight important notifications with a star so you can come back and find them easily.
                 </div>
               </div>
             </div>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -2,8 +2,11 @@
   <div class="container">
     <h1 class="text-center"><%= octobox_round(80) %> Octobox</h1>
     <p class="text-center">Untangle your GitHub Notifications</p>
-    <div class="text-center">
+    <div class="text-center ">
       <%= image_tag 'screenshot.png', class: 'screenshot', alt: 'Octobox Screenshot' %>
+      <div class="row justify-content-md-center">
+        <h4 class='mb-5 w-75  font-weight-light'>Octobox helps you manage your GitHub notifications efficiently so you can spend less time managing and more time getting things done.</h4>
+      </div>
       <p>
         <%= link_to login_path, class: 'btn btn-outline-dark btn-lg' do %>
           <%= octicon 'mark-github', height: 22 %>
@@ -22,14 +25,128 @@
       </p>
     </div>
 
-    <div class="row justify-content-center">
-      <div class="col-lg-8">
+    <div class="row mb-5 mt-5">
+      <div class="col-lg-6">
+        <div class="card shadow-sm mb-3">
+          <div class="card-content">
+            <div class="card-body">
+              <div class="media d-flex">
+                <div class="align-self-center mr-4">
+                  <%= octicon 'inbox', height: 50 %>
+                </div>
+                <div class="media-body">
+                  <h4>Don't lose track</h4>
+                  Octobox adds an extra "archived" state to each notification so you can mark it as "done". If anything happens on an archived thread, issue or PR, Octobox will move it back into your inbox.
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="col-lg-6">
+        <div class="card shadow-sm mb-3">
+          <div class="card-content">
+            <div class="card-body">
+              <div class="media d-flex">
+                <div class="align-self-center mr-4">
+                  <%= octicon 'star', height: 50 %>
+                </div>
+                <div class="media-body">
+                  <h4>Starred notifications</h4>
+                  Let's be honest, you probably don't have a 'favourite' issue. Octobox lets you highlight important notifications with a star so you can come back and find them easily.
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="col-lg-6">
+        <div class="card shadow-sm mb-3">
+          <div class="card-content">
+            <div class="card-body">
+              <div class="media d-flex">
+                <div class="align-self-center mr-4">
+                  <%= octicon 'settings', height: 50 %>
+                </div>
+                <div class="media-body">
+                  <h4>Filter all the things</h4>
+                  Filter notifications by notification type, action, state and reason and keep notifications from bots alongside your regular label, author and assignees.
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="col-lg-6">
+        <div class="card shadow-sm mb-3">
+          <div class="card-content">
+            <div class="card-body">
+              <div class="media d-flex">
+                <div class="align-self-center mr-4">
+                  <%= octicon 'search', height: 50 %>
+                </div>
+                <div class="media-body">
+                  <h4>Search with prefix filters</h4>
+                  No more Jedi mind tricks. Combine a wide range of powerful search filters help you get straight to the notification you're looking for and focus on just what you need.
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="col-lg-6">
+        <div class="card shadow-sm mb-3">
+          <div class="card-content">
+            <div class="card-body">
+              <div class="media d-flex">
+                <div class="align-self-center mr-4">
+                  <%= octicon 'keyboard', height: 50 %>
+                </div>
+                <div class="media-body">
+                  <h4>Built for keyboard warriors</h4>
+                  Navigate, triage and manage your notifications like a pro using Gmail-inspired keyboard shortcuts for every function, no mouse required.
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="col-lg-6">
+        <div class="card shadow-sm mb-3">
+          <div class="card-content">
+            <div class="card-body">
+              <div class="media d-flex">
+                <div class="align-self-center mr-4">
+                  <%= octicon 'mark-github', height: 50 %>
+                </div>
+                <div class="media-body">
+                  <h4>Open for everyone</h4>
+                  Octobox developers use Octobox to develop Octobox. 100% developed and managed in the open on GitHub under a FLOSS license.
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <h3>Used by developers from top organisations</h3>
+    <div class="row mb-5 mt-4">
+      <div class="col">
+        <% used_by_orgs.each do |org| %>
+          <%= image_tag "https://github.com/#{org}.png?w=120", width: 60, height: 60, class: 'inline-block mr-2 mb-3', title: org, data: {toggle: 'tooltip'} %>
+        <% end %>
+      </div>
+    </div>
+
+    <div class="row justify-content-center text-large">
+      <div class="col-lg-12">
         <h3>Why is this a thing?</h3>
         <p>
           Octobox helps you triage notifications efficiently so you can spend less time managing and more time getting things done.
         </p>
         <p>
-          If you manage more than one active project on GitHub, you probably find <a href="https://github.com/notifications">GitHub Notifications</a> pretty lacking. Notifications are marked as read and disappear from the list as soon as you load the page or view the email of the notification. This makes it very hard to keep on top of which notifications you still need to follow up on. Most open source maintainers and GitHub staff end up using a complex combination of filters and labels in Gmail to manage their notifications from their inbox. If, like me, you try to avoid email, then you might want something else.
+          If you manage more any active projects on GitHub, you probably find <a href="https://github.com/notifications">GitHub Notifications</a> pretty lacking. Notifications are marked as read and disappear from the list as soon as you load the page or view the email of the notification. This makes it very hard to keep on top of which notifications you still need to follow up on. Most open source maintainers and GitHub staff end up using a complex combination of filters and labels in Gmail to manage their notifications from their inbox. If, like me, you try to avoid email, then you might want something else.
         </p>
         <p>
           Octobox adds an extra "archived" state to each notification so you can mark it as "done". If new activity happens on the thread/issue/pr, the next time you sync the app the relevant item will be unarchived and moved back into your inbox.


### PR DESCRIPTION
Adds a similar feature list as https://github.com/octobox/octobox/pull/868 to the homepage, along with some big orgs that are known users of Octobox.

![screen shot 2018-09-04 at 11 05 30](https://user-images.githubusercontent.com/1060/45025518-9d14b200-b033-11e8-9738-468e320ef204.png)
