### PR TITLE
Avoid calling sidekiq unless background jobs are enabled

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -58,7 +58,7 @@ class User < ApplicationRecord
   end
 
   def syncing?
-    return false unless sync_job_id
+    return false unless Octobox.config.background_jobs_enabled? && sync_job_id
     # We are syncing if we are queued or working, all other states mean we are not working
     [:queued, :working].include?(Sidekiq::Status.status(sync_job_id))
   end


### PR DESCRIPTION
Fixes #862 

`sync_job_id` gets set even if sidekiq isn't enabled, so before checking it's status, we need to make sure that sidekiq is actually configured.