### PR TITLE
Avoid double sidebar separator when @states contains only a nil key

### DIFF
--- a/app/views/notifications/_sidebar.html.erb
+++ b/app/views/notifications/_sidebar.html.erb
@@ -51,7 +51,7 @@
 
       <% end %>
     <% end %>
-    <%= menu_separator unless @states.empty? %>
+    <%= menu_separator unless @states.keys.compact.empty? %>
 
     <% if @assigned > 0 %>
       <%= filter_link :assigned, current_user.github_login, @assigned do %>


### PR DESCRIPTION
Noticed this tiny bug that causes two separator lines to show in the sidebar when only showing commits in the inbox because `@states` => `{nil => 1}`

<img width="660" alt="screen shot 2018-09-04 at 19 11 40" src="https://user-images.githubusercontent.com/1060/45049929-ee469500-b077-11e8-8734-68aa3901eac6.png">
