### PR TITLE
Push subject syncing to sidekiq if background jobs enabled

### DIFF
--- a/app/workers/sync_installation_repositories_worker.rb
+++ b/app/workers/sync_installation_repositories_worker.rb
@@ -19,7 +19,7 @@ class SyncInstallationRepositoriesWorker
         app_installation_id: app_installation['id']
       })
 
-      repository.notifications.find_each{|n| n.send :update_subject, true }
+      repository.notifications.find_each{|n| n.update_subject(true) }
     end
 
     payload['repositories_removed'].each do |remote_repository|

--- a/app/workers/sync_installation_worker.rb
+++ b/app/workers/sync_installation_worker.rb
@@ -29,7 +29,7 @@ class SyncInstallationWorker
         app_installation_id: app_installation['id']
       })
 
-      repository.notifications.find_each{|n| n.send :update_subject, true }
+      repository.notifications.find_each{|n| n.update_subject(true) }
     end
   end
 end

--- a/app/workers/sync_label_worker.rb
+++ b/app/workers/sync_label_worker.rb
@@ -10,7 +10,7 @@ class SyncLabelWorker
     subjects = repository.subjects.label(payload['changes']['name']['from'])
     subjects.each do |subject|
       n = subject.notifications.first
-      n.try(:send, :update_subject, true)
+      n.try(:update_subject, true)
     end
   end
 end

--- a/app/workers/update_subject_worker.rb
+++ b/app/workers/update_subject_worker.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class UpdateSubjectWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: :sync_subjects, unique: :until_and_while_executing
+
+  def perform(notification_id, force = false)
+    Notification.find(notification_id).try(:update_subject_in_foreground, force)
+  end
+end

--- a/lib/tasks/tasks.rake
+++ b/lib/tasks/tasks.rake
@@ -12,7 +12,7 @@ namespace :tasks do
 
   desc "Sync subjects"
   task sync_subjects: :environment do
-    Notification.subjectable.find_each{|n| n.send(:update_subject, true); print '.' }
+    Notification.subjectable.find_each{|n| n.update_subject(true); print '.' }
   end
 
   desc "Sync repositories"

--- a/test/models/notification_test.rb
+++ b/test/models/notification_test.rb
@@ -130,6 +130,7 @@ class NotificationTest < ActiveSupport::TestCase
   end
 
   test 'update_from_api_response creates a subject when fetch_subject is enabled' do
+    stub_background_jobs_enabled(value: false)
     stub_fetch_subject_enabled
     stub_repository_request
     url = 'https://api.github.com/repos/octobox/octobox/issues/560'
@@ -163,6 +164,7 @@ class NotificationTest < ActiveSupport::TestCase
   end
 
   test 'update_from_api_response updates the subject if the subject was not recently updated' do
+    stub_background_jobs_enabled(value: false)
     stub_fetch_subject_enabled
     stub_repository_request
     url = 'https://api.github.com/repos/octobox/octobox/issues/560'
@@ -180,7 +182,8 @@ class NotificationTest < ActiveSupport::TestCase
   end
 
   test 'update_from_api_response updates the subject with no author available' do
-    Octobox.config.fetch_subject = true
+    stub_background_jobs_enabled(value: false)
+    stub_fetch_subject_enabled
     stub_repository_request
     url = 'https://api.github.com/repos/octobox/octobox/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e'
     response = { status: 200, body: file_fixture('commit_no_author.json'), headers: { 'Content-Type' => 'application/json' } }
@@ -192,12 +195,10 @@ class NotificationTest < ActiveSupport::TestCase
     assert_difference 'Subject.count' do
       notification.update_from_api_response(api_response, unarchive: true)
     end
-  ensure
-    Octobox.config.fetch_subject = false
   end
 
   test 'update_from_api_response updates the subject that returns a 40x error' do
-    Octobox.config.fetch_subject = true
+    stub_fetch_subject_enabled
     stub_repository_request
     url = 'https://api.github.com/repos/octobox/octobox/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e'
     response = { status: 401, headers: { 'Content-Type' => 'application/json' } }
@@ -209,11 +210,10 @@ class NotificationTest < ActiveSupport::TestCase
     assert_no_difference 'Subject.count' do
       notification.update_from_api_response(api_response, unarchive: true)
     end
-  ensure
-    Octobox.config.fetch_subject = false
   end
 
   test 'updated_from_api_response updates the existing subject if present' do
+    stub_background_jobs_enabled(value: false)
     stub_fetch_subject_enabled
     stub_repository_request
     url = 'https://api.github.com/repos/octobox/octobox/pulls/403'

--- a/test/support/stub_helper.rb
+++ b/test/support/stub_helper.rb
@@ -99,4 +99,8 @@ module StubHelper
   def stub_fetch_subject_enabled(value: true)
     Octobox.config.stubs(:fetch_subject).returns(value)
   end
+
+  def stub_background_jobs_enabled(value: true)
+    Octobox.config.stubs(:background_jobs_enabled).returns(value)
+  end
 end


### PR DESCRIPTION
Should speed up syncing when `FETCH_SUBJECT` enabled (or in GitHub App) and sidekiq enabled by parallelizing the `update_subject` calls, at least until https://github.com/octobox/octobox/issues/852 is in.

Need to fix up a few tests before merging.