### PR TITLE
Add brakeman security scanner to development environment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,7 @@ group :development do
   gem 'rubocop', require: false
   gem 'spring'
   gem 'spring-watcher-listen'
+  gem 'brakeman'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,6 +57,7 @@ GEM
       autoprefixer-rails (>= 6.0.3)
       popper_js (>= 1.12.9, < 2)
       sass (>= 3.5.2)
+    brakeman (4.3.1)
     bugsnag (6.8.0)
       concurrent-ruby (~> 1.0)
     builder (3.2.3)
@@ -343,6 +344,7 @@ DEPENDENCIES
   attr_encrypted (~> 3.1.0)
   bootsnap
   bootstrap
+  brakeman
   bugsnag
   byebug
   codeclimate-test-reporter


### PR DESCRIPTION
Security scan can then easily be ran from the terminal with: `$ brakeman -o output.html`