### PR TITLE
Refactor and improve test coverage on configurator class

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,7 +25,7 @@ class ApplicationController < ActionController::Base
   private
 
   def display_subject?
-    return true if Octobox.config.fetch_subject
+    return true if Octobox.fetch_subject?
     Octobox.config.github_app && current_user && current_user.app_token.present?
   end
 

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -201,7 +201,7 @@ class NotificationsController < ApplicationController
   #   HEAD 204
   #
   def sync
-    if Octobox.config.background_jobs_enabled? && params[:async]
+    if Octobox.background_jobs_enabled? && params[:async]
       current_user.sync_notifications
     else
       current_user.sync_notifications_in_foreground

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -21,7 +21,7 @@ module ApplicationHelper
   end
 
   def repo_scope_modal
-    content_tag :span, octicon('shield'), class: 'btn btn-sm btn-link repo-scope d-inline-block', title: 'Requires repo scope', data: {toggle:'modal', target:'#repo-scope'} unless Octobox.config.fetch_subject || Octobox.personal_access_tokens_enabled?
+    content_tag :span, octicon('shield'), class: 'btn btn-sm btn-link repo-scope d-inline-block', title: 'Requires repo scope', data: {toggle:'modal', target:'#repo-scope'} unless Octobox.fetch_subject? || Octobox.personal_access_tokens_enabled?
   end
 
   def octobox_icon(height=16)

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -155,7 +155,7 @@ class Notification < ApplicationRecord
   end
 
   def display_subject?
-    github_app_installed? || Octobox.config.fetch_subject
+    github_app_installed? || Octobox.fetch_subject?
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -58,7 +58,7 @@ class User < ApplicationRecord
   end
 
   def syncing?
-    return false unless Octobox.config.background_jobs_enabled? && sync_job_id
+    return false unless Octobox.background_jobs_enabled? && sync_job_id
     # We are syncing if we are queued or working, all other states mean we are not working
     [:queued, :working].include?(Sidekiq::Status.status(sync_job_id))
   end

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -9,7 +9,7 @@
     <%= link_to 'Source', Octobox.config.source_repo, target: '_blank', rel: "noopener" %>
     available under
     <%= link_to 'AGPL 3.0', "#{Octobox.config.source_repo}/blob/master/LICENSE.txt", target: '_blank', rel: "noopener" %>
-    <% if Octobox.config.octobox_io %>
+    <% if Octobox.octobox_io? %>
       &mdash; <a href='/terms' target="_blank" rel="noopener">Terms</a> &amp; <a href='/privacy' target="_blank" rel="noopener">Privacy Policy</a>
     <% end %>
   </p>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -54,7 +54,7 @@
               <%= octicon 'gist-secret', height: 16, class: 'text-muted' %>
               Admin
             <% end %>
-            <% if Octobox.config.background_jobs_enabled? %>
+            <% if Octobox.background_jobs_enabled? %>
               <%= link_to admin_sidekiq_web_path, class: 'dropdown-item' do %>
                 <%= octicon 'graph', height: 16, class: 'text-muted' %>
                 Sidekiq

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -37,7 +37,7 @@
           </label>
           <%= select_all_button(@cur_selected, @total) %>
           <% end %>
-          <%= link_to sync_notifications_path(filters.merge(async: Octobox.config.background_jobs_enabled?)), class: 'btn btn-sm btn-outline-secondary btn-outline-dark js-sync', 'data-toggle' => 'tooltip', 'data-placement' => 'bottom', 'data-turbolinks' => false, 'data-animation' => 'false', 'data-position' => 'bottom', 'title' => 'Sync', 'aria-label' => 'Sync', method: :post do %>
+          <%= link_to sync_notifications_path(filters.merge(async: Octobox.background_jobs_enabled?)), class: 'btn btn-sm btn-outline-secondary btn-outline-dark js-sync', 'data-toggle' => 'tooltip', 'data-placement' => 'bottom', 'data-turbolinks' => false, 'data-animation' => 'false', 'data-position' => 'bottom', 'title' => 'Sync', 'aria-label' => 'Sync', method: :post do %>
             <%= octicon 'sync', height: 16, class: "#{'spinning' if initial_sync? || current_user.syncing?}" %>
           <% end %>
           <%= archive_selected_button unless archive_selected? %>

--- a/app/views/pages/documentation.html.erb
+++ b/app/views/pages/documentation.html.erb
@@ -30,7 +30,7 @@
       </p>
       <h2 id='accessing'>Accessing Octobox</h2>
       <hr>
-      <% if Octobox.config.octobox_io %>
+      <% if Octobox.octobox_io? %>
         <p>
           This instance of Octobox is hosted by the Octobox.io team. To access Octobox.io you just need to sign in with your GitHub profile or install the GitHub app on the <%= link_to 'homepage', root_path %>.
         </p>
@@ -64,7 +64,7 @@
           Alternatively you can host your own instance of Octobox. See <a href='#https://github.com/octobox/octobox/blob/master/docs/INSTALLATION.md'>the installation guide</a> for instructions and details regarding deployment to Heroku, Docker, and more.
         </p>
       <% end %>
-      <% unless Octobox.config.octobox_io %>
+      <% unless Octobox.octobox_io? %>
         <p>
           By default Octobox uses GitHub's basic OAuth <code>'notifications'</code> scope to access your notifications. This provides Octobox with access to notifications from both public <i>and</i> private repositories, but it provides very little detail about those notifications.
         </p>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -12,7 +12,7 @@
           <%= octicon 'mark-github', height: 22 %>
           <span class='ml-1'>Sign in with GitHub</span>
         <% end %>
-        <% if Octobox.github_app? && !Octobox.config.octobox_io %>
+        <% if Octobox.github_app? && !Octobox.octobox_io? %>
           <%= link_to Octobox.config.app_install_url, class: 'btn btn-outline-dark btn-lg' do %>
             <%= octicon 'briefcase', height: 22 %>
             <span class='ml-1'>Install the GitHub App</span>

--- a/app/views/shared/_repo_scope_modal.html.erb
+++ b/app/views/shared/_repo_scope_modal.html.erb
@@ -1,4 +1,4 @@
-<% unless Octobox.config.fetch_subject || Octobox.personal_access_tokens_enabled? %>
+<% unless Octobox.fetch_subject? || Octobox.personal_access_tokens_enabled? %>
   <div id="repo-scope" class="modal" role="dialog">
     <div class="modal-dialog modal-sm" role="document">
       <div class="modal-content">
@@ -9,7 +9,7 @@
         <div class="modal-body">
           <p>
             This feature requires additional permissions.
-            <% if Octobox.config.octobox_io %>
+            <% if Octobox.octobox_io? %>
               We're working to enable them for Octobox.io soon.
             <% else %>
               See the <%= link_to 'documentation', documentation_path(anchor: 'accessing') %> for how to enable them.

--- a/config/initializers/custom_sidekiq_worker.rb
+++ b/config/initializers/custom_sidekiq_worker.rb
@@ -1,7 +1,7 @@
 module Sidekiq::Worker
   module ClassMethods
     def perform_async_if_configured(*args)
-      if Octobox.config.background_jobs_enabled?
+      if Octobox.background_jobs_enabled?
         perform_async(*args)
       else
         worker = new

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-if Octobox.config.background_jobs_enabled?
+if Octobox.background_jobs_enabled?
   require 'sidekiq-scheduler'
   require 'sidekiq-status'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,7 +49,7 @@ Rails.application.routes.draw do
 
   post '/hooks/github', to: 'hooks#create'
 
-  if Octobox.config.octobox_io
+  if Octobox.octobox_io?
     get '/privacy', to: 'pages#privacy'
     get '/terms', to: 'pages#terms'
   end

--- a/lib/octobox.rb
+++ b/lib/octobox.rb
@@ -11,7 +11,7 @@ module Octobox
     end
 
     def refresh_interval_enabled?
-      config.minimum_refresh_interval > 0
+      config.minimum_refresh_interval && config.minimum_refresh_interval > 0
     end
 
     def personal_access_tokens_enabled?

--- a/lib/octobox.rb
+++ b/lib/octobox.rb
@@ -25,5 +25,17 @@ module Octobox
     def github_app?
       config.github_app
     end
+
+    def octobox_io?
+      config.octobox_io
+    end
+
+    def fetch_subject?
+      config.fetch_subject
+    end
+
+    def background_jobs_enabled?
+      config.background_jobs_enabled
+    end
   end
 end

--- a/lib/octobox/configurator.rb
+++ b/lib/octobox/configurator.rb
@@ -44,7 +44,7 @@ module Octobox
     attr_writer :github_app
 
     def fetch_subject
-      @fetch_subject || (ENV['FETCH_SUBJECT'].try(:downcase) == "true")
+      @fetch_subject || env_boolean('FETCH_SUBJECT')
     end
     attr_writer :fetch_subject
 
@@ -53,44 +53,32 @@ module Octobox
     end
 
     def personal_access_tokens_enabled
-      @personal_access_tokens_enabled || ENV['PERSONAL_ACCESS_TOKENS_ENABLED'].present?
+      @personal_access_tokens_enabled || env_boolean('PERSONAL_ACCESS_TOKENS_ENABLED')
     end
     attr_writer :personal_access_tokens_enabled
 
     def minimum_refresh_interval
-      @minimum_refresh_interval || ENV['MINIMUM_REFRESH_INTERVAL'].to_i
+      @minimum_refresh_interval || env_integer('MINIMUM_REFRESH_INTERVAL')
     end
     attr_writer :minimum_refresh_interval
 
     def max_notifications_to_sync
-      if @max_notifications_to_sync
-        @max_notifications_to_sync
-      elsif ENV['MAX_NOTIFICATIONS_TO_SYNC'].present?
-        ENV['MAX_NOTIFICATIONS_TO_SYNC'].to_i
-      else
-        500
-      end
+      @max_notifications_to_sync || env_integer('MAX_NOTIFICATIONS_TO_SYNC', 500)
     end
     attr_writer :max_notifications_to_sync
 
     def max_concurrency
-      if @max_concurrency
-        @max_concurrency
-      elsif ENV['MAX_CONCURRENCY'].present?
-        ENV['MAX_CONCURRENCY'].to_i
-      else
-        10
-      end
+      @max_concurrency || env_integer('MAX_CONCURRENCY', 10)
     end
     attr_writer :max_concurrency
 
-    def background_jobs_enabled?
-      @background_jobs_enabled || sidekiq_schedule_enabled? || ENV['OCTOBOX_BACKGROUND_JOBS_ENABLED'].present?
+    def background_jobs_enabled
+      @background_jobs_enabled || sidekiq_schedule_enabled? || env_boolean('OCTOBOX_BACKGROUND_JOBS_ENABLED')
     end
     attr_writer :background_jobs_enabled
 
     def sidekiq_schedule_enabled?
-      @sidekiq_schedule_enabled || ENV['OCTOBOX_SIDEKIQ_SCHEDULE_ENABLED'].present?
+      @sidekiq_schedule_enabled || env_boolean('OCTOBOX_SIDEKIQ_SCHEDULE_ENABLED')
     end
     attr_writer :sidekiq_schedule_enabled
 
@@ -100,26 +88,23 @@ module Octobox
     attr_writer :sidekiq_schedule_path
 
     def restricted_access_enabled
-      @restricted_access_enabled || ENV['RESTRICTED_ACCESS_ENABLED'].present?
+      @restricted_access_enabled || env_boolean('RESTRICTED_ACCESS_ENABLED')
     end
     attr_writer :restricted_access_enabled
 
     def github_organization_id
-      id = @github_organization_id || ENV['GITHUB_ORGANIZATION_ID']
-      return id.to_i if id.present?
+      @github_organization_id || env_integer('GITHUB_ORGANIZATION_ID')
     end
     attr_writer :github_organization_id
 
     def github_team_id
-      id = @github_team_id || ENV['GITHUB_TEAM_ID']
-      return id.to_i if id.present?
+      @github_team_id || env_integer('GITHUB_TEAM_ID')
     end
     attr_writer :github_team_id
 
     def native_link
       ENV['OCTOBOX_NATIVE_LINK'] || nil
     end
-    attr_writer :native_link
 
     def source_repo
       env_value = ENV['SOURCE_REPO'].blank? ? nil : ENV['SOURCE_REPO']
@@ -130,20 +115,17 @@ module Octobox
     def app_install_url
       "#{app_url}/installations/new"
     end
-    attr_writer :app_install_url
 
     def app_url
       "#{github_domain}/apps/#{app_slug}"
     end
-    attr_writer :app_url
 
     def app_slug
       ENV['GITHUB_APP_SLUG']
     end
-    attr_writer :app_slug
 
     def octobox_io
-      @octobox_io || ENV['OCTOBOX_IO'].present?
+      @octobox_io || env_boolean('OCTOBOX_IO')
     end
     attr_writer :octobox_io
 
@@ -162,6 +144,16 @@ module Octobox
 
       return @admin_github_ids = [] unless admin_github_ids.present?
       @github_admin_ids = admin_github_ids.split(',')
+    end
+
+    private
+
+    def env_boolean(env_var_name)
+      ENV[env_var_name].try(:downcase) == 'true'
+    end
+
+    def env_integer(env_var_name, default = nil)
+      ENV[env_var_name].try(:to_i) || default
     end
   end
 end

--- a/lib/octobox/configurator.rb
+++ b/lib/octobox/configurator.rb
@@ -149,7 +149,7 @@ module Octobox
     private
 
     def env_boolean(env_var_name)
-      ENV[env_var_name].try(:downcase) == 'true'
+      %w(true 1).include?(ENV[env_var_name].try(:downcase))
     end
 
     def env_integer(env_var_name, default = nil)

--- a/test/lib/octobox/configurator_test.rb
+++ b/test/lib/octobox/configurator_test.rb
@@ -29,4 +29,114 @@ class ConfiguratorTest < ActiveSupport::TestCase
     stub_env_var('FETCH_SUBJECT', 'true')
     assert_equal true, Octobox.config.fetch_subject
   end
+
+  test "when ENV['PERSONAL_ACCESS_TOKENS_ENABLED'] is false, config.personal_access_tokens_enabled is false" do
+    stub_env_var('PERSONAL_ACCESS_TOKENS_ENABLED', 'false')
+    assert_equal false, Octobox.config.personal_access_tokens_enabled
+  end
+
+  test "when ENV['PERSONAL_ACCESS_TOKENS_ENABLED'] is nil, config.personal_access_tokens_enabled is false" do
+    stub_env_var('PERSONAL_ACCESS_TOKENS_ENABLED', '')
+    assert_equal false, Octobox.config.personal_access_tokens_enabled
+  end
+
+  test "when ENV['PERSONAL_ACCESS_TOKENS_ENABLED'] is true, config.personal_access_tokens_enabled is true" do
+    stub_env_var('PERSONAL_ACCESS_TOKENS_ENABLED', 'true')
+    assert_equal true, Octobox.config.personal_access_tokens_enabled
+  end
+
+  test "when ENV['OCTOBOX_SIDEKIQ_SCHEDULE_ENABLED'] is false, config.sidekiq_schedule_enabled? is false" do
+    stub_env_var('OCTOBOX_SIDEKIQ_SCHEDULE_ENABLED', 'false')
+    assert_equal false, Octobox.config.sidekiq_schedule_enabled?
+  end
+
+  test "when ENV['OCTOBOX_SIDEKIQ_SCHEDULE_ENABLED'] is nil, config.sidekiq_schedule_enabled? is false" do
+    stub_env_var('OCTOBOX_SIDEKIQ_SCHEDULE_ENABLED', '')
+    assert_equal false, Octobox.config.sidekiq_schedule_enabled?
+  end
+
+  test "when ENV['OCTOBOX_SIDEKIQ_SCHEDULE_ENABLED'] is true, config.sidekiq_schedule_enabled? is true" do
+    stub_env_var('OCTOBOX_SIDEKIQ_SCHEDULE_ENABLED', 'true')
+    assert_equal true, Octobox.config.sidekiq_schedule_enabled?
+  end
+
+  test "when ENV['RESTRICTED_ACCESS_ENABLED'] is false, config.restricted_access_enabled is false" do
+    stub_env_var('RESTRICTED_ACCESS_ENABLED', 'false')
+    assert_equal false, Octobox.config.restricted_access_enabled
+  end
+
+  test "when ENV['RESTRICTED_ACCESS_ENABLED'] is nil, config.restricted_access_enabled is false" do
+    stub_env_var('RESTRICTED_ACCESS_ENABLED', '')
+    assert_equal false, Octobox.config.restricted_access_enabled
+  end
+
+  test "when ENV['RESTRICTED_ACCESS_ENABLED'] is true, config.restricted_access_enabled is true" do
+    stub_env_var('RESTRICTED_ACCESS_ENABLED', 'true')
+    assert_equal true, Octobox.config.restricted_access_enabled
+  end
+
+  test "when ENV['OCTOBOX_IO'] is false, config.octobox_io is false" do
+    stub_env_var('OCTOBOX_IO', 'false')
+    assert_equal false, Octobox.config.octobox_io
+  end
+
+  test "when ENV['OCTOBOX_IO'] is nil, config.octobox_io is false" do
+    stub_env_var('OCTOBOX_IO', '')
+    assert_equal false, Octobox.config.octobox_io
+  end
+
+  test "when ENV['OCTOBOX_IO'] is true, config.octobox_io is true" do
+    stub_env_var('OCTOBOX_IO', 'true')
+    assert_equal true, Octobox.config.octobox_io
+  end
+
+  test 'max_notifications_to_sync default value' do
+    stub_env_var('MAX_NOTIFICATIONS_TO_SYNC', nil)
+    assert_equal 500, Octobox.config.max_notifications_to_sync
+  end
+
+  test 'max_notifications_to_sync configured by ENV var' do
+    stub_env_var('MAX_NOTIFICATIONS_TO_SYNC', 20)
+    assert_equal 20, Octobox.config.max_notifications_to_sync
+  end
+
+  test 'max_concurrency default value' do
+    stub_env_var('MAX_CONCURRENCY', nil)
+    assert_equal 10, Octobox.config.max_concurrency
+  end
+
+  test 'max_concurrency configured by ENV var' do
+    stub_env_var('MAX_CONCURRENCY', 20)
+    assert_equal 20, Octobox.config.max_concurrency
+  end
+
+  test 'minimum_refresh_interval default value' do
+    stub_env_var('MINIMUM_REFRESH_INTERVAL', nil)
+    assert_nil Octobox.config.minimum_refresh_interval
+  end
+
+  test 'minimum_refresh_interval configured by ENV var' do
+    stub_env_var('MINIMUM_REFRESH_INTERVAL', 20)
+    assert_equal 20, Octobox.config.minimum_refresh_interval
+  end
+
+  test 'github_organization_id default value' do
+    stub_env_var('GITHUB_ORGANIZATION_ID', nil)
+    assert_nil Octobox.config.github_organization_id
+  end
+
+  test 'github_organization_id configured by ENV var' do
+    stub_env_var('GITHUB_ORGANIZATION_ID', 20)
+    assert_equal 20, Octobox.config.github_organization_id
+  end
+
+  test 'github_team_id default value' do
+    stub_env_var('GITHUB_TEAM_ID', nil)
+    assert_nil Octobox.config.github_team_id
+  end
+
+  test 'github_team_id configured by ENV var' do
+    stub_env_var('GITHUB_TEAM_ID', 20)
+    assert_equal 20, Octobox.config.github_team_id
+  end
 end

--- a/test/lib/octobox/configurator_test.rb
+++ b/test/lib/octobox/configurator_test.rb
@@ -30,6 +30,16 @@ class ConfiguratorTest < ActiveSupport::TestCase
     assert_equal true, Octobox.config.fetch_subject
   end
 
+  test "when ENV['FETCH_SUBJECT'] is 1, config.fetch_subject is true" do
+    stub_env_var('FETCH_SUBJECT', '1')
+    assert_equal true, Octobox.config.fetch_subject
+  end
+
+  test "when ENV['FETCH_SUBJECT'] is 0, config.fetch_subject is false" do
+    stub_env_var('FETCH_SUBJECT', '0')
+    assert_equal false, Octobox.config.fetch_subject
+  end
+
   test "when ENV['PERSONAL_ACCESS_TOKENS_ENABLED'] is false, config.personal_access_tokens_enabled is false" do
     stub_env_var('PERSONAL_ACCESS_TOKENS_ENABLED', 'false')
     assert_equal false, Octobox.config.personal_access_tokens_enabled

--- a/test/support/sidekiq_helper.rb
+++ b/test/support/sidekiq_helper.rb
@@ -19,7 +19,7 @@ module SidekiqMinitestSupport
   end
 
   def with_background_jobs_enabled(enabled: true)
-    original = Octobox.config.background_jobs_enabled?
+    original = Octobox.background_jobs_enabled?
     Octobox.config.background_jobs_enabled = enabled
     yield
   ensure


### PR DESCRIPTION
What started out as a little refactor turned into a slightly bigger one as I remembered that we support [Adding a custom initializer](https://github.com/octobox/octobox/blob/master/docs/INSTALLATION.md#adding-a-custom-initializer):

```ruby
# config/initializers/custom.rb

Octobox.config do |c|
  c.personal_access_tokens_enabled = true
end
```

Although we don't currently have any tests for that or documentation about which config options can be overridden by that block.