### PR TITLE
Persist per page in cookie

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -311,15 +311,20 @@ class NotificationsController < ApplicationController
   DEFAULT_PER_PAGE = 20
 
   def restrict_per_page
-    if params[:per_page]
-      per_page = Integer(params[:per_page]) rescue DEFAULT_PER_PAGE
-      per_page = DEFAULT_PER_PAGE if per_page < 1
-      raise ActiveRecord::RecordNotFound if per_page > 100
-      cookies[:per_page] = per_page
-    elsif cookies[:per_page]
-      Integer(cookies[:per_page]) rescue DEFAULT_PER_PAGE
-    else
-      DEFAULT_PER_PAGE
-    end
+    per_page = per_page_param || per_page_cookie || DEFAULT_PER_PAGE
+
+    return DEFAULT_PER_PAGE if per_page < 1
+    raise ActiveRecord::RecordNotFound if per_page > 100
+    cookies[:per_page] = per_page
+
+    per_page
+  end
+
+  def per_page_param
+    Integer(params[:per_page]) rescue nil
+  end
+
+  def per_page_cookie
+    Integer(cookies[:per_page]) rescue nil
   end
 end

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -308,16 +308,18 @@ class NotificationsController < ApplicationController
     @per_page ||= restrict_per_page
   end
 
+  DEFAULT_PER_PAGE = 20
+
   def restrict_per_page
     if params[:per_page]
-      per_page = params[:per_page].to_i rescue 20
-      per_page = 20 if per_page < 1
+      per_page = Integer(params[:per_page]) rescue DEFAULT_PER_PAGE
+      per_page = DEFAULT_PER_PAGE if per_page < 1
       raise ActiveRecord::RecordNotFound if per_page > 100
       cookies[:per_page] = per_page
     elsif cookies[:per_page]
-      cookies[:per_page].to_i
+      Integer(cookies[:per_page]) rescue DEFAULT_PER_PAGE
     else
-      20
+      DEFAULT_PER_PAGE
     end
   end
 end

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -309,9 +309,15 @@ class NotificationsController < ApplicationController
   end
 
   def restrict_per_page
-    per_page = params[:per_page].to_i rescue 20
-    per_page = 20 if per_page < 1
-    raise ActiveRecord::RecordNotFound if per_page > 100
-    per_page
+    if params[:per_page]
+      per_page = params[:per_page].to_i rescue 20
+      per_page = 20 if per_page < 1
+      raise ActiveRecord::RecordNotFound if per_page > 100
+      cookies[:per_page] = per_page
+    elsif cookies[:per_page]
+      cookies[:per_page].to_i
+    else
+      20
+    end
   end
 end

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -15,7 +15,7 @@
           <% if @notifications.to_a.any? %>
             <div class="per-page btn-group float-right d-none d-md-block" data-toggle="tooltip" data-placement="left" title="Notifications per page">
               <button type="button" class="btn btn-sm btn-outline-secondary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                <%= per_page = params[:per_page].presence || 20 %>
+                <%= per_page = @per_page || 20 %>
                 <span class="caret"></span>
               </button>
               <ul class="dropdown-menu dropdown-menu-right text-right">

--- a/test/controllers/notifications_controller_test.rb
+++ b/test/controllers/notifications_controller_test.rb
@@ -522,4 +522,17 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
     get '/?q=unread%3Afalse'
     assert_equal assigns(:notifications).length, 1
   end
+
+  test 'sets the per_page cookie' do
+    sign_in_as(@user)
+    get '/?per_page=100'
+    assert_equal '100', cookies[:per_page]
+  end
+
+  test 'uses the per_page cookie' do
+    sign_in_as(@user)
+    get '/?per_page=100'
+    get '/'
+    assert_equal assigns(:per_page), 100
+  end
 end


### PR DESCRIPTION
Stores the `per_page` value set with a param into a cookie of the same name.

Also fixes the template to use the per_page value calclated by the controller rather than just taking the param.

Fixes #779 
