### PR TITLE
Sync button shouldn't refresh page if sync is happening in background

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -137,9 +137,6 @@ document.addEventListener("turbolinks:load", function() {
       $(this).toggleClass("star-active star-inactive");
       $.post('/notifications/'+$(this).data('id')+'/star')
     });
-    $('a.js-sync').on('click', function() {
-      $('.js-sync .octicon').toggleClass('spinning')
-    });
     recoverPreviousCursorPosition();
 
     $('.js-select_all').change(function() {
@@ -160,6 +157,11 @@ document.addEventListener("turbolinks:before-cache", function() {
 
 $(document).on('click', '[data-toggle="offcanvas"]', function () {
   $('.flex-content').toggleClass('active')
+});
+
+$(document).on('click', 'a.js-sync', function(e) {
+  e.preventDefault(e);
+  sync()
 });
 
 function enableTooltips() {
@@ -300,8 +302,8 @@ function openCurrentLink(e) {
 }
 
 function refreshOnSync() {
-  if(!$(".sync .octicon").hasClass("spinning")){
-    $(".sync .octicon").addClass("spinning");
+  if(!$(".js-sync .octicon").hasClass("spinning")){
+    $(".js-sync .octicon").addClass("spinning");
   }
 
   jQuery.ajax({'url': "/notifications/syncing.json", data: {}, error: function(xhr, status) {
@@ -329,7 +331,11 @@ function notify(message, type) {
 }
 
 function sync() {
-  $("a.js-sync").click();
+  if($("a.js-sync.js-async").length) {
+    $.get('/notifications/sync.json?async=true', refreshOnSync);
+  } else {
+    Turbolinks.visit($("a.js-sync").attr('href'))
+  }
 }
 
 function autoSync() {

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -211,7 +211,7 @@ class NotificationsController < ApplicationController
       format.html do
         redirect_back fallback_location: root_path
       end
-      format.json { head :ok }
+      format.json { {} }
     end
   end
 

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -36,7 +36,7 @@
           </label>
           <%= select_all_button(@cur_selected, @total) %>
           <% end %>
-          <%= link_to sync_notifications_path(filters.merge(async: Octobox.background_jobs_enabled?)), class: 'btn btn-sm btn-outline-secondary btn-outline-dark js-sync', 'data-toggle' => 'tooltip', 'data-placement' => 'bottom', 'data-turbolinks' => false, 'data-animation' => 'false', 'data-position' => 'bottom', 'title' => 'Sync', 'aria-label' => 'Sync', method: :post do %>
+          <%= link_to sync_notifications_path(filters.merge(async: Octobox.background_jobs_enabled?)), class: "btn btn-sm btn-outline-secondary btn-outline-dark js-sync #{'js-async' if Octobox.background_jobs_enabled?}", 'data-toggle' => 'tooltip', 'data-placement' => 'bottom', 'data-turbolinks' => false, 'data-animation' => 'false', 'data-position' => 'bottom', 'title' => 'Sync', 'aria-label' => 'Sync' do %>
             <%= octicon 'sync', height: 16, class: "#{'spinning' if initial_sync? || current_user.syncing?}" %>
           <% end %>
           <%= archive_selected_button unless archive_selected? %>

--- a/test/controllers/notifications_controller_test.rb
+++ b/test/controllers/notifications_controller_test.rb
@@ -312,7 +312,7 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
     sign_in_as(@user)
 
     post "/notifications/sync.json"
-    assert_response :ok
+    assert_response :no_content
   end
 
   test 'get to syncs redirects' do


### PR DESCRIPTION
Follow on from https://github.com/octobox/octobox/pull/603, removes the need for an extra refresh of the page when starting the sync.