### PR TITLE
Move add/remove AppInstallation repository logic from worker to class

### DIFF
--- a/app/models/app_installation.rb
+++ b/app/models/app_installation.rb
@@ -4,4 +4,29 @@ class AppInstallation < ApplicationRecord
   validates :github_id, presence: true, uniqueness: true
   validates :account_login, presence: true
   validates :account_id, presence: true
+
+  def add_repositories(remote_repositories)
+    remote_repositories.each do |remote_repository|
+      repository = repositories.find_or_create_by(github_id: remote_repository['id'])
+
+      repository.update_attributes({
+        full_name: remote_repository['full_name'],
+        private: remote_repository['private'],
+        owner: remote_repository['full_name'].split('/').first,
+        github_id: remote_repository['id'],
+        last_synced_at: Time.current
+      })
+
+      repository.notifications.includes(:user).find_each{|n| n.update_subject(true) }
+    end
+  end
+
+  def remove_repositories(remote_repositories)
+    remote_repositories.each do |remote_repository|
+      repository = repositories.find_by_github_id(remote_repository['id'])
+      next unless repository.present?
+      repository.subjects.each(&:destroy)
+      repository.destroy
+    end
+  end
 end

--- a/app/workers/sync_installation_repositories_worker.rb
+++ b/app/workers/sync_installation_repositories_worker.rb
@@ -7,26 +7,8 @@ class SyncInstallationRepositoriesWorker
   def perform(payload)
     app_installation = AppInstallation.find_by_github_id(payload['installation']['id'])
     return unless app_installation.present?
-    payload['repositories_added'].each do |remote_repository|
-      repository = app_installation.repositories.find_or_create_by(github_id: remote_repository['id'])
 
-      repository.update_attributes({
-        full_name: remote_repository['full_name'],
-        private: remote_repository['private'],
-        owner: remote_repository['full_name'].split('/').first,
-        github_id: remote_repository['id'],
-        last_synced_at: Time.current,
-        app_installation_id: app_installation['id']
-      })
-
-      repository.notifications.includes(:user).find_each{|n| n.update_subject(true) }
-    end
-
-    payload['repositories_removed'].each do |remote_repository|
-      repository = app_installation.repositories.find_by_github_id(remote_repository['id'])
-      next unless repository.present?
-      repository.subjects.each(&:destroy)
-      repository.destroy
-    end
+    app_installation.add_repositories(payload['repositories_added'])
+    app_installation.remove_repositories(payload['repositories_removed'])
   end
 end

--- a/app/workers/sync_installation_worker.rb
+++ b/app/workers/sync_installation_worker.rb
@@ -17,19 +17,6 @@ class SyncInstallationWorker
       permission_issues: payload['installation']['permissions']['issues']
     })
 
-    payload['repositories'].each do |remote_repository|
-      repository = Repository.find_or_create_by(github_id: remote_repository['id'])
-
-      repository.update_attributes({
-        full_name: remote_repository['full_name'],
-        private: remote_repository['private'],
-        owner: remote_repository['full_name'].split('/').first,
-        github_id: remote_repository['id'],
-        last_synced_at: Time.current,
-        app_installation_id: app_installation['id']
-      })
-
-      repository.notifications.includes(:user).find_each{|n| n.update_subject(true) }
-    end
+    app_installation.add_repositories(payload['repositories'])
   end
 end


### PR DESCRIPTION
Reduces some duplication between `SyncInstallationRepositoriesWorker` and `SyncInstallationWorker`