### PR TITLE
Reorder Notification#display_subject? conditions

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -147,7 +147,7 @@ class Notification < ApplicationRecord
   end
 
   def github_app_installed?
-    user.app_token.present? && repository.try(:github_app_installed?)
+    Octobox.github_app? && user.app_token.present? && repository.try(:github_app_installed?)
   end
 
   def subjectable?
@@ -155,7 +155,7 @@ class Notification < ApplicationRecord
   end
 
   def display_subject?
-    github_app_installed? || Octobox.fetch_subject?
+    Octobox.fetch_subject? || github_app_installed?
   end
 
   def update_subject(force = false)


### PR DESCRIPTION
Returns quicker from `display_subject?` for installations with FETCH_SUBJECT enabled and returns quicker from `github_app_installed?` for installations without FETCH_SUBJECT or setup as a GitHub app by checking ENV vars before going to database.