### PR TITLE
Add Octobox.github_app_client for making API requests as the GitHub App

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,8 @@ gem 'sidekiq-status'
 gem 'gemoji'
 gem 'bootsnap', require: false
 gem 'bugsnag'
+gem 'openssl'
+gem 'jwt'
 
 # Supported databases
 gem 'mysql2', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,6 @@ gem 'sidekiq-status'
 gem 'gemoji'
 gem 'bootsnap', require: false
 gem 'bugsnag'
-gem 'openssl'
 gem 'jwt'
 
 # Supported databases

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -178,7 +178,6 @@ GEM
     omniauth-oauth2 (1.5.0)
       oauth2 (~> 1.1)
       omniauth (~> 1.2)
-    openssl (2.1.1)
     parallel (1.12.1)
     parser (2.5.1.2)
       ast (~> 2.4.0)
@@ -364,7 +363,6 @@ DEPENDENCIES
   octicons_helper
   octokit
   omniauth-github
-  openssl
   pg (= 1.1.3)
   pg_search
   puma

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -178,6 +178,7 @@ GEM
     omniauth-oauth2 (1.5.0)
       oauth2 (~> 1.1)
       omniauth (~> 1.2)
+    openssl (2.1.1)
     parallel (1.12.1)
     parser (2.5.1.2)
       ast (~> 2.4.0)
@@ -352,6 +353,7 @@ DEPENDENCIES
   git
   jbuilder
   jquery-rails
+  jwt
   kaminari
   listen
   local_time
@@ -362,6 +364,7 @@ DEPENDENCIES
   octicons_helper
   octokit
   omniauth-github
+  openssl
   pg (= 1.1.3)
   pg_search
   puma

--- a/lib/octobox.rb
+++ b/lib/octobox.rb
@@ -37,5 +37,25 @@ module Octobox
     def background_jobs_enabled?
       config.background_jobs_enabled
     end
+
+    def github_app_client
+      Octokit::Client.new(bearer_token: generate_jwt,
+                          auto_paginate: true,
+                          default_media_type: 'application/vnd.github.machine-man-preview+json')
+    end
+
+    private
+
+    def generate_jwt
+      private_key = OpenSSL::PKey::RSA.new(config.github_app_jwt)
+
+      payload = {
+        iat: Time.now.to_i,
+        exp: Time.now.to_i + (10 * 60),
+        iss: Rails.application.secrets.github_app_id
+      }
+
+      JWT.encode(payload, private_key, "RS256")
+    end
   end
 end

--- a/lib/octobox/configurator.rb
+++ b/lib/octobox/configurator.rb
@@ -151,6 +151,11 @@ module Octobox
     end
     attr_writer :open_in_same_tab
 
+    def github_app_jwt
+      @github_app_jwt || ENV['GITHUB_APP_JWT']
+    end
+    attr_writer :github_app_jwt
+
     private
 
     def env_boolean(env_var_name)


### PR DESCRIPTION
https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app

Useful for getting information on installations without an authenticated user, i.e. in background jobs