### PR TITLE
Add repository_full_name index on notifications table

### DIFF
--- a/db/migrate/20180910161047_add_repository_full_name_index_to_notifications.rb
+++ b/db/migrate/20180910161047_add_repository_full_name_index_to_notifications.rb
@@ -1,0 +1,5 @@
+class AddRepositoryFullNameIndexToNotifications < ActiveRecord::Migration[5.2]
+  def change
+    add_index :notifications, :repository_full_name
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_30_145149) do
+ActiveRecord::Schema.define(version: 2018_09_10_161047) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -59,6 +59,7 @@ ActiveRecord::Schema.define(version: 2018_08_30_145149) do
     t.boolean "starred", default: false
     t.string "repository_owner_name", default: ""
     t.string "latest_comment_url"
+    t.index ["repository_full_name"], name: "index_notifications_on_repository_full_name"
     t.index ["subject_url"], name: "index_notifications_on_subject_url"
     t.index ["user_id", "archived", "updated_at"], name: "index_notifications_on_user_id_and_archived_and_updated_at"
     t.index ["user_id", "github_id"], name: "index_notifications_on_user_id_and_github_id", unique: true


### PR DESCRIPTION
Speed up a number of 100ms+ database queries I noticed on Octobox.io around filtering notifications by `repository_full_name`.