### PR TITLE
Bring back #891

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -82,7 +82,7 @@ class NotificationsController < ApplicationController
       @bot_notifications     = scope.reorder(nil).bot_author.count
       @assigned              = scope.reorder(nil).assigned(current_user.github_login).count
       @visiblity             = scope.reorder(nil).distinct.joins(:repository).group('repositories.private').count
-      @repositories          = Repository.where(full_name: scope.distinct.pluck(:repository_full_name)).select('full_name,private')
+      @repositories          = Repository.where(full_name: scope.reorder(nil).distinct.pluck(:repository_full_name)).select('full_name,private')
     end
 
     scope = current_notifications(scope)

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -70,7 +70,7 @@ class NotificationsController < ApplicationController
   #   }
   #
   def index
-    scope = notifications_for_presentation
+    scope = notifications_for_presentation.newest
     @types                 = scope.reorder(nil).distinct.group(:subject_type).count
     @unread_notifications  = scope.reorder(nil).distinct.group(:unread).count
     @reasons               = scope.reorder(nil).distinct.group(:reason).count
@@ -90,7 +90,7 @@ class NotificationsController < ApplicationController
 
     @total = scope.count
 
-    @notifications = scope.newest.page(page).per(per_page)
+    @notifications = scope.page(page).per(per_page)
     @cur_selected = [per_page, @total].min
   end
 

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -24,10 +24,49 @@ class Search
     res = res.bot_author unless bot_author.nil?
     res = res.unlabelled unless unlabelled.nil?
     res = res.is_private(is_private) unless is_private.nil?
+    res = apply_sort(res)
     res
   end
 
   private
+
+  def apply_sort(scope)
+    case sort_by
+    when 'subject'
+      scope.reorder("upper(notifications.subject_title) #{sort_order}")
+    when 'updated'
+      scope.reorder(updated_at: sort_order)
+    when 'read'
+      scope.reorder(last_read_at: sort_order)
+    else
+      scope.newest
+    end
+  end
+
+  def sort_by
+    parsed_query[:sort].first
+  end
+
+  def sort_order
+    order = parsed_query[:order].first
+    case order
+    when 'asc'
+      :asc
+    when 'desc'
+      :desc
+    else
+      default_sort_order
+    end
+  end
+
+  def default_sort_order
+    case sort_by
+    when 'subject'
+      :asc
+    else
+      :desc
+    end
+  end
 
   def repo
     parsed_query[:repo].first

--- a/app/views/shared/_search_prefixes.html.erb
+++ b/app/views/shared/_search_prefixes.html.erb
@@ -58,7 +58,18 @@
       </td>
       <td>Search unread notifications.  Also accepts false for the inverse.</td>
     </tr>
-
+    <tr>
+      <td>
+        <code>sort:updated</code>
+      </td>
+      <td>Sort notifications by <code>updated</code>, <code>read</code> or <code>subject</code>.</td>
+    </tr>
+    <tr>
+      <td>
+        <code>order:asc</code>
+      </td>
+      <td>Sort notifications in ascending (<code>asc</code>) or descending (<code>desc</code>) order. Use with <code>sort</code>.</td>
+    </tr>
     <% if display_subject? %>
       <tr>
         <td>


### PR DESCRIPTION
A quick merge+deploy of #891 broke master and https://octobox.io 

The issue was really a workflow one rather than a code one.

I merged #891 without rebasing it against master, so the tests appeared to be passing but only showed up broken once merged into master.

I'm going to enable some more branch protections on this repo to stop this happening in future.