### PR TITLE
Sync install permissions along with notifications

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -73,6 +73,7 @@ class User < ApplicationRecord
     return true if syncing?
     job_id = SyncNotificationsWorker.perform_async_if_configured(self.id)
     update(sync_job_id: job_id)
+    SyncInstallationPermissionsWorker.perform_async_if_configured(self.id) if github_app_authorized?
   end
 
   def sync_notifications_in_foreground


### PR DESCRIPTION
Only for GitHub App, required as there's no webhook event for access granted/removed to keep permissions up to date.