### PR TITLE
Don't show full list of repositories with app installed in settings

### DIFF
--- a/app/models/app_installation.rb
+++ b/app/models/app_installation.rb
@@ -36,4 +36,8 @@ class AppInstallation < ApplicationRecord
     org_segment = account_type == 'Organization' ? "/organizations/#{account_login}" : ''
     "#{Octobox.config.github_domain}#{org_segment}/settings/installations/#{github_id}"
   end
+
+  def github_avatar_url
+    "#{Octobox.config.github_domain}/#{account_login}.png"
+  end
 end

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -136,17 +136,12 @@
             <tbody>
               <% current_user.app_installations.each do |app_installation| %>
                 <tr>
-                  <td>
+                  <td class="align-middle">
+                    <%= image_tag app_installation.github_avatar_url+ "?size=50", width: 25, height: 25, class: 'pull-left mr-1' %>
                     <%= app_installation.account_login %>
                   </td>
-                  <td>
-                    <ul class='list-unstyled'>
-                      <% app_installation.repositories.github_app_installed.each do |repo| %>
-                        <li>
-                          <%= repo.full_name %>
-                        </li>
-                      <% end %>
-                    </ul>
+                  <td class="align-middle">
+                    <%= pluralize app_installation.repositories.github_app_installed.count + 1, 'repository' %>
                   </td>
                   <td>
                     <% unless app_installation.account_type == 'User' && app_installation.account_login != current_user.github_login %>


### PR DESCRIPTION
We still don't know which repos a user has access to, only that they have access to the installed apps, so just showing the count of repos now, also added the accounts avatar:

![screen shot 2018-09-11 at 17 46 44](https://user-images.githubusercontent.com/1060/45374749-f14b0380-b5ea-11e8-9eee-01f6dc282d28.png)
