### PR TITLE
Ignore the docs folder when generating docker images or heroku slugs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,7 @@ log
 tmp
 openshift/
 coverage/
+docs/
 .bundle
 .ruby-version
 

--- a/.slugignore
+++ b/.slugignore
@@ -5,6 +5,7 @@ log
 tmp
 openshift/
 coverage/
+docs/
 .bundle
 .ruby-version
 


### PR DESCRIPTION
Slightly reduce the size of those images