### PR TITLE
Revert "Ignore the docs folder when generating docker images or heroku slugs"

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,7 +5,6 @@ log
 tmp
 openshift/
 coverage/
-docs/
 .bundle
 .ruby-version
 

--- a/.slugignore
+++ b/.slugignore
@@ -5,7 +5,6 @@ log
 tmp
 openshift/
 coverage/
-docs/
 .bundle
 .ruby-version
 


### PR DESCRIPTION
Reverts octobox/octobox#916

Fixes #917