### PR TITLE
Add validation of unique urls in subjects table

### DIFF
--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -10,6 +10,8 @@ class Subject < ApplicationRecord
   scope :label, ->(label_name) { joins(:labels).where(Label.arel_table[:name].matches(label_name)) }
   scope :repository, ->(full_name) { where(arel_table[:url].matches("%/repos/#{full_name}/%")) }
 
+  validates :url, presence: true, uniqueness: true
+
   after_update :sync_involved_users
 
   def author_url

--- a/lib/tasks/tasks.rake
+++ b/lib/tasks/tasks.rake
@@ -19,4 +19,14 @@ namespace :tasks do
   task sync_repos: :environment do
     Notification.find_each{|n| n.update_repository(true); print '.' }
   end
+
+  desc "Clean up duplicate subjects"
+  task deduplicate_subjects: :environment do
+    duplicate_subject_urls = Subject.select(:url).group(:url).having("count(*) > 1").pluck(:url)
+
+    duplicate_subject_urls.each do |subject_url|
+      duplicate_subjects = Subject.where(url: subject_url).order('updated_at DESC')
+      duplicate_subjects[1..-1].each(&:destroy)
+    end
+  end
 end


### PR DESCRIPTION
Fixes #928, which was caused by multiple subjects with the same `url` existing in the database.

Doesn't add unique constraint to the database index because it will fail for any installation that has a duplicate in the subjects table.

Also adds a rake task to clear up duplicate subjects. 