### PR TITLE
Skip edit label webhooks when there are no changes

### DIFF
--- a/app/workers/sync_label_worker.rb
+++ b/app/workers/sync_label_worker.rb
@@ -7,6 +7,8 @@ class SyncLabelWorker
   def perform(payload)
     repository = Repository.find_by_github_id(payload['repository']['id'])
     return if repository.nil?
+    return if payload['changes']['name'].nil?
+
     subjects = repository.subjects.label(payload['changes']['name']['from'])
     subjects.each do |subject|
       n = subject.notifications.first


### PR DESCRIPTION
For some reason GitHub is sending pointless webhook events with `changes: {}`