### PR TITLE
Exit early from Notification#display_subject? if notification isn't subjectable

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -165,18 +165,16 @@ class Notification < ApplicationRecord
   end
 
   def display_subject?
-    Octobox.fetch_subject? || github_app_installed?
+    subjectable? && (Octobox.fetch_subject? || github_app_installed?)
   end
 
   def update_subject(force = false)
-    return unless subjectable?
     return unless display_subject?
 
     UpdateSubjectWorker.perform_async_if_configured(self.id, force)
   end
 
   def update_subject_in_foreground(force = false)
-    return unless subjectable?
     return unless display_subject?
     # skip syncing if the notification was updated around the same time as subject
     return if !force && subject != nil && updated_at - subject.updated_at < 2.seconds


### PR DESCRIPTION
Small speedup for subject related methods on any notifications that aren't in `['Issue', 'PullRequest', 'Commit', 'Release']