### PR TITLE
Squash a sneaky n+1 query when running as a github app when calling web_url

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -274,7 +274,7 @@ class NotificationsController < ApplicationController
   end
 
   def notifications_for_presentation
-    eager_load_relation = display_subject? ? [{subject: :labels}] : nil
+    eager_load_relation = display_subject? ? [{subject: :labels}, :repository] : nil
     scope = current_user.notifications.includes(eager_load_relation)
 
     if params[:q].present?

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -125,7 +125,7 @@ class Notification < ApplicationRecord
   end
 
   def expanded_subject_url
-    return subject_url unless Octobox.config.subjects_enabled?
+    return subject_url unless display_subject?
     subject.try(:html_url) || subject_url # Use the sync'd HTML URL if possible, else the API one
   end
 


### PR DESCRIPTION
Fixes an n+1 sql query issue when running as a GitHub App, as seen in Skylight:

<img width="761" alt="screen shot 2018-09-15 at 16 03 25" src="https://user-images.githubusercontent.com/1060/45587678-f2d53e00-b900-11e8-8f4b-00d073d3691b.png">

Users who hadn't authorized the github app still didn't eager load subjects but called #subject on notifications resulting in excess sql queries.

Notification repositories are eager loaded as they are needed for the #display_subject? check 