### PR TITLE
Add redis and faraday probes to skylight config

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -82,4 +82,6 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   config.lograge.enabled = true
+
+  config.skylight.probes += %w(redis faraday) if ENV['SKYLIGHT_AUTHENTICATION'].present?
 end


### PR DESCRIPTION
So we can see more info on sidekiq and http calls in the skylight dashboard for https//octobox.io: https://oss.skylight.io/app/applications/eLvcBBdLmV6k