### PR TITLE
chore(docker, openshift): Add Docker build for octobox + sidekiq

### DIFF
--- a/Dockerfile-with-sidekiq
+++ b/Dockerfile-with-sidekiq
@@ -1,0 +1,31 @@
+FROM ruby:2.5.1-alpine
+RUN apk add --update \
+  build-base \
+  netcat-openbsd \
+  git \
+  nodejs \
+  postgresql-dev \
+  mysql-dev \
+  tzdata \
+  curl-dev \
+  && rm -rf /var/cache/apk/*
+# throw errors if Gemfile has been modified since Gemfile.lock
+RUN bundle config --global frozen 1
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+COPY Gemfile Gemfile.lock /usr/src/app/
+RUN bundle install --without test production --jobs 2
+
+COPY . /usr/src/app
+# Generate API Docs
+RUN RAILS_ENV=development bin/rails api_docs:generate
+
+# Allow the image to run with an arbitrary uid, but gid set to 0 (the OpenShift case)
+RUN chgrp -R 0 /usr/src/app \
+ && chmod -R g=u /usr/src/app
+
+# Install Foreman
+RUN gem install foreman
+
+CMD ["bin/docker-start-with-sidekiq"]

--- a/bin/docker-start-with-sidekiq
+++ b/bin/docker-start-with-sidekiq
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -e
+
+db_host=${OCTOBOX_DATABASE_HOST:-database.service.octobox.internal}
+while ! nc -z $db_host 5432; do
+  echo "Waiting for database to be available..."
+  sleep 1
+done
+
+bundle exec rake db:migrate
+rm -rf tmp/pids
+
+exec foreman start -f config/Procfile.foreman -d .


### PR DESCRIPTION
Added a new "Dockerfile-with-sidekiq" which uses foreman to run
two processes: rails with octobox and a sidekiq worker.
Althought this conflicts with the 'pid 1' paradigm to only run a single
process within an Docker container, it saves some resources when
compared when used in two separate containers.

This is especially useful in environments which enforce a minimum size
for heap memory like OpenShift Online, which in its "Starter tier" also
has only a limited budget for memory.

Procfile has been adapted to removed the DB migration as this already happens in the
docker-start script, and also given like this will terminate foreman
as soon as the migration has finished (foreman seems to stop all processes as soon
as one of the process has finished)

The adapted build itself is contained is in Dockerfile-with-sidekiq and bin/docker-start-with-sidekiq.

To proceed I see two options:

* Either add a Docker automated build for an image like 'octobox/octobox-with-sidekiq' pointing to Dockerfile-with-sidekiq
* Consolidate to a single Docker image. In that case I would recommend to adapt the startup script
to check the BACKGROUND_CHECK variables in the script and start sidekiq only if set.

If the second option is more appealing, I can work on this. Shouldn't be that hard.

For testing 'rhuss/octobox-with-sidekiq' has been pushed to Docker Hub. It works for my personal installation without issues.