### PR TITLE
feature(docker): Adapt Docker image to run sidekiq when enabled

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,7 @@ RUN RAILS_ENV=development bin/rails api_docs:generate
 RUN chgrp -R 0 /usr/src/app \
  && chmod -R g=u /usr/src/app
 
+# Install Foreman
+RUN gem install foreman
+
 CMD ["bin/docker-start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,41 @@
 FROM ruby:2.5.1-alpine
-RUN apk add --update \
-  build-base \
-  netcat-openbsd \
-  git \
-  nodejs \
-  postgresql-dev \
-  mysql-dev \
-  tzdata \
-  curl-dev \
-  && rm -rf /var/cache/apk/*
-# throw errors if Gemfile has been modified since Gemfile.lock
-RUN bundle config --global frozen 1
-RUN mkdir -p /usr/src/app
+
+# Install and update all dependencies (os, ruby)
 WORKDIR /usr/src/app
 
+# =============================================
+# System layer
+
+# Will invalidate cache as soon a the Gemfile changes
 COPY Gemfile Gemfile.lock /usr/src/app/
-RUN bundle install --without test production --jobs 2
 
+# * Setup system
+# * Install Ruby dependencies
+RUN apk add --update \
+    build-base \
+    netcat-openbsd \
+    git \
+    nodejs \
+    postgresql-dev \
+    mysql-dev \
+    tzdata \
+    curl-dev \
+ && rm -rf /var/cache/apk/* \
+ && bundle config --global frozen 1 \
+ && bundle install --without test production --jobs 2 \
+ && gem install foreman
+
+# ========================================================
+# Application layer
+
+# Copy application code
 COPY . /usr/src/app
-# Generate API Docs
-RUN RAILS_ENV=development bin/rails api_docs:generate
 
-# Allow the image to run with an arbitrary uid, but gid set to 0 (the OpenShift case)
-RUN chgrp -R 0 /usr/src/app \
+# * Generate the docs
+# * Make files OpenShift conformant
+RUN RAILS_ENV=development bin/rails api_docs:generate \
+ && chgrp -R 0 /usr/src/app \
  && chmod -R g=u /usr/src/app
 
-# Install Foreman
-RUN gem install foreman
-
+# Startup
 CMD ["bin/docker-start"]

--- a/bin/docker-start
+++ b/bin/docker-start
@@ -10,7 +10,18 @@ done
 bundle exec rake db:migrate
 rm -rf tmp/pids
 
-if [ "${OCTOBOX_SIDEKIQ_SCHEDULE_ENABLED}" == "true" ]; then
+env_boolean() {
+  local env=$1
+  if [ "$env" == "true" ] || [ "$env" == "1" ]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+if env_boolean "${OCTOBOX_SIDEKIQ_SCHEDULE_ENABLED}" ||
+   env_boolean "${OCTOBOX_BACKGROUND_JOBS_ENABLED}";
+then
   exec foreman start -f config/Procfile.foreman -d .
 else
   exec rails s -b 0.0.0.0

--- a/bin/docker-start
+++ b/bin/docker-start
@@ -10,4 +10,8 @@ done
 bundle exec rake db:migrate
 rm -rf tmp/pids
 
-exec rails s -b 0.0.0.0
+if [ "${OCTOBOX_SIDEKIQ_SCHEDULE_ENABLED}" == "true" ]; then
+  exec foreman start -f config/Procfile.foreman -d .
+else
+  exec rails s -b 0.0.0.0
+fi

--- a/config/Procfile.foreman
+++ b/config/Procfile.foreman
@@ -1,0 +1,2 @@
+web: bundle exec puma -C config/puma.rb
+worker: bundle exec sidekiq -C config/sidekiq.yml


### PR DESCRIPTION
Modified Docker image to start check OCTOBOX_SIDEKIQ_SCHEDULE_ENABLED
and start foreman with rails+sidekiq if set. If not set, then
rails is start as usual.

This is alternative approach to #942 and implements a unified approach
for the Docker image.