### PR TITLE
Always sync repositories if subjects_enabled?

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -224,13 +224,13 @@ class Notification < ApplicationRecord
   end
 
   def update_repository(force = false)
-    return unless display_subject?
+    return unless Octobox.config.subjects_enabled?
 
     UpdateRepositoryWorker.perform_async_if_configured(self.id, force)
   end
 
   def update_repository_in_foreground(force = false)
-    return unless display_subject?
+    return unless Octobox.config.subjects_enabled?
     return if repository != nil && updated_at - repository.updated_at < 2.seconds
 
     remote_repository = download_repository


### PR DESCRIPTION
The current behaviour doesn’t download repositories for notifications that aren’t `subjectable` or if the repo doesn’t have the app installed, instead we always want to try and download repos to show if it’s public/private. 