### PR TITLE
Remove faraday probe as it's causing errors in sidekiq

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -83,5 +83,5 @@ Rails.application.configure do
 
   config.lograge.enabled = true
 
-  config.skylight.probes += %w(redis faraday) if ENV['SKYLIGHT_AUTHENTICATION'].present?
+  config.skylight.probes += %w(redis) if ENV['SKYLIGHT_AUTHENTICATION'].present?
 end


### PR DESCRIPTION
Doesn't like our custom octokit stack, throws `"Faraday::RackBuilder::StackLocked: can't modify middleware stack after making a request` errors