### PR TITLE
Lazy load gemoji gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem 'sidekiq-unique-jobs'
 gem 'sidekiq-scheduler'
 gem 'rack-canonical-host'
 gem 'sidekiq-status'
-gem 'gemoji'
+gem 'gemoji', require: false
 gem 'bootsnap', require: false
 gem 'bugsnag'
 gem 'jwt'

--- a/app/helpers/emoji_helper.rb
+++ b/app/helpers/emoji_helper.rb
@@ -1,3 +1,5 @@
+require 'emoji'
+
 module EmojiHelper
   def emojify(content)
     html_escape_once(content).to_str.gsub(/:([\w+-]+):/) do |match|


### PR DESCRIPTION
Saves about ~5.8MB of memory for sidekiq workers that don't load the EmojiHelper class

Before:
```
Total allocated: 33849735 bytes (385351 objects)
Total retained:  6482043 bytes (68215 objects)

allocated memory by gem
-----------------------------------
  15543511  activesupport-5.2.1
   4510186  gemoji-3.0.0
   3783377  sass-3.5.7
   1559689  json
   1557725  addressable-2.5.2
    794028  skylight-core-3.0.0
    601901  sassc-1.12.1
    577579  bundler-1.16.3
    429503  ffi-1.9.25
    425090  pathname
    388269  net
    366196  activerecord-5.2.1
```
After:
```
Total allocated: 27965146 bytes (320436 objects)
Total retained:  5386864 bytes (47592 objects)

allocated memory by gem
-----------------------------------
  15499362  activesupport-5.2.1
   3783196  sass-3.5.7
   1557832  addressable-2.5.2
    793603  skylight-core-3.0.0
    601841  sassc-1.12.1
    564865  bundler-1.16.3
    429503  ffi-1.9.25
    425019  pathname
    388317  net
    366264  activerecord-5.2.1
```

Savings found using the wonderful [derailed_benchmarks](https://github.com/schneems/derailed_benchmarks), thanks @schneems!