### PR TITLE
Suppress logger output for asset requests in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -30,6 +30,9 @@ Rails.application.configure do
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = 'http://assets.example.com'
 
+  # Suppress logger output for asset requests.
+  config.assets.quiet = true
+
   # Specifies the header that your server uses for sending files.
   # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX


### PR DESCRIPTION
Removes some noisy from the production logging