### PR TITLE
Allow more search prefixes to accept multiple arguements

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -57,7 +57,6 @@ class Notification < ApplicationRecord
   scope :is_private, ->(is_private = true) { joins(:repository).where('repositories.private = ?', is_private) }
 
   scope :state,      ->(state)  { joins(:subject).where('subjects.state = ?', state) }
-  scope :author,     ->(author) { joins(:subject).where(Subject.arel_table[:author].matches(author)) }
 
   scope :labelable,  -> { where(subject_type: ['Issue', 'PullRequest']) }
   scope :label,      ->(label_names) {

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -41,7 +41,12 @@ class Notification < ApplicationRecord
   scope :type,     ->(subject_type) { where(subject_type: subject_type) }
   scope :reason,   ->(reason)       { where(reason: reason) }
   scope :unread,   ->(unread)       { where(unread: unread) }
-  scope :owner,    ->(owner_name)   { where(arel_table[:repository_owner_name].matches(owner_name)) }
+  scope :owner,    ->(owner_names)   {
+    owner_names = [owner_names] if owner_names.is_a?(String)
+    where(
+      owner_names.map { |owner_name| arel_table[:repository_owner_name].matches(owner_name) }.reduce(:or)
+    )
+  }
   scope :author,   ->(author_name)  { joins(:subject).where(Subject.arel_table[:author].matches(author_name)) }
 
   scope :is_private, ->(is_private = true) { joins(:repository).where('repositories.private = ?', is_private) }

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -50,7 +50,7 @@ class Notification < ApplicationRecord
   scope :author, ->(author_names)  {
     author_names = [author_names] if author_names.is_a?(String)
     joins(:subject).where(
-      author_names.map { |owner_name| Subject.arel_table[:author].matches(author_name) }.reduce(:or)
+      author_names.map { |author_name| Subject.arel_table[:author].matches(author_name) }.reduce(:or)
     )
   }
 
@@ -60,7 +60,14 @@ class Notification < ApplicationRecord
   scope :author,     ->(author) { joins(:subject).where(Subject.arel_table[:author].matches(author)) }
 
   scope :labelable,  -> { where(subject_type: ['Issue', 'PullRequest']) }
-  scope :label,      ->(label_name) { joins(:labels).where(Label.arel_table[:name].matches(label_name))}
+  scope :label,      ->(label_names) {
+    label_names = [label_names] if label_names.is_a?(String)
+
+    joins(:labels).where(
+      label_names.map { |label_name| Label.arel_table[:name].matches(label_name) }.reduce(:or)
+    )
+
+  }
   scope :unlabelled, -> { labelable.with_subject.left_outer_joins(:labels).where(labels: {id: nil})}
 
   scope :assigned,   ->(assignee) { joins(:subject).where("subjects.assignees LIKE ?", "%:#{assignee}:%") }

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -47,7 +47,12 @@ class Notification < ApplicationRecord
       owner_names.map { |owner_name| arel_table[:repository_owner_name].matches(owner_name) }.reduce(:or)
     )
   }
-  scope :author,   ->(author_name)  { joins(:subject).where(Subject.arel_table[:author].matches(author_name)) }
+  scope :author, ->(author_names)  {
+    author_names = [author_names] if author_names.is_a?(String)
+    joins(:subject).where(
+      author_names.map { |owner_name| Subject.arel_table[:author].matches(author_name) }.reduce(:or)
+    )
+  }
 
   scope :is_private, ->(is_private = true) { joins(:repository).where('repositories.private = ?', is_private) }
 

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -90,7 +90,7 @@ class Search
   end
 
   def author
-    parsed_query[:author].first
+    parsed_query[:author]
   end
 
   def unread

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -114,7 +114,7 @@ class Search
   end
 
   def assignee
-    parsed_query[:assignee].first
+    parsed_query[:assignee]
   end
 
   def starred

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -86,7 +86,7 @@ class Search
   end
 
   def owner
-    parsed_query[:owner].first
+    parsed_query[:owner]
   end
 
   def author

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -110,7 +110,7 @@ class Search
   end
 
   def label
-    parsed_query[:label].first
+    parsed_query[:label]
   end
 
   def assignee

--- a/app/views/notifications/_search-help.html.erb
+++ b/app/views/notifications/_search-help.html.erb
@@ -11,6 +11,11 @@
           "<code>github enterprise type:issue owner:octobox reason:assign</code>"
         </p>
 
+        <p>
+          Many prefixes accept multiple arguments when separated by commas or passed twice, for example:
+          "<code>type:issue,release owner:octobox owner:24pullrequests</code>"
+        </p>
+
         </p>
         <h5>Supported prefixes</h5>
         <%= render 'shared/search_prefixes' %>

--- a/app/views/notifications/_search-help.html.erb
+++ b/app/views/notifications/_search-help.html.erb
@@ -8,12 +8,12 @@
       <div class="modal-body">
         <p>
           Examples of some common searches using supported prefixes. Combine them together and with free text searches, for example:
-          "<code>github enterprise type:issue owner:octobox reason:assign</code>"
+          "<code>github enterprise type:issue owner:octobox reason:assign</code>".
         </p>
 
         <p>
           Many prefixes accept multiple arguments when separated by commas or passed twice, for example:
-          "<code>type:issue,release owner:octobox owner:24pullrequests</code>"
+          "<code>type:issue,release owner:octobox owner:24pullrequests</code>".
         </p>
 
         </p>

--- a/test/controllers/notifications_controller_test.rb
+++ b/test/controllers/notifications_controller_test.rb
@@ -594,6 +594,26 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
     assert_equal assigns(:notifications).length, 2
   end
 
+  test 'search results can filter by assignee' do
+    sign_in_as(@user)
+    notification1 = create(:notification, user: @user)
+    notification2 = create(:notification, user: @user)
+    create(:subject, notifications: [notification1], assignees: ":andrew:")
+    create(:subject, notifications: [notification2], assignees: ":benjam:")
+    get '/?q=assignee%3Aandrew'
+    assert_equal assigns(:notifications).length, 1
+  end
+
+  test 'search results can filter by multiple assignees' do
+    sign_in_as(@user)
+    notification1 = create(:notification, user: @user)
+    notification2 = create(:notification, user: @user)
+    create(:subject, notifications: [notification1], assignees: ":andrew:")
+    create(:subject, notifications: [notification2], assignees: ":benjam:")
+    get '/?q=assignee%3Aandrew%2Cbenjam'
+    assert_equal assigns(:notifications).length, 2
+  end
+
   test 'search results can filter by locked:true' do
     sign_in_as(@user)
     notification1 = create(:notification, user: @user, subject_type: 'Issue')

--- a/test/controllers/notifications_controller_test.rb
+++ b/test/controllers/notifications_controller_test.rb
@@ -560,6 +560,16 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
     assert_equal assigns(:notifications).length, 1
   end
 
+  test 'search results can filter by multiple authors' do
+    sign_in_as(@user)
+    notification1 = create(:notification, user: @user, subject_type: 'Issue')
+    notification2 = create(:notification, user: @user, subject_type: 'PullRequest')
+    create(:subject, notifications: [notification1], author: 'andrew')
+    create(:subject, notifications: [notification2], author: 'benjam')
+    get '/?q=author%3Aandrew%2Cbenjam'
+    assert_equal assigns(:notifications).length, 2
+  end
+
   test 'search results can filter by locked:true' do
     sign_in_as(@user)
     notification1 = create(:notification, user: @user, subject_type: 'Issue')

--- a/test/controllers/notifications_controller_test.rb
+++ b/test/controllers/notifications_controller_test.rb
@@ -491,6 +491,15 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
     assert_equal assigns(:notifications).length, 1
   end
 
+  test 'search results can filter by multiple owners' do
+    sign_in_as(@user)
+    @user.notifications.delete_all
+    create(:notification, user: @user, repository_owner_name: 'andrew')
+    create(:notification, user: @user, repository_owner_name: 'octobox')
+    get '/?q=owner%3Aoctobox%2Candrew'
+    assert_equal assigns(:notifications).length, 2
+  end
+
   test 'search results can filter by type' do
     sign_in_as(@user)
     create(:notification, user: @user, subject_type: 'Issue')

--- a/test/controllers/notifications_controller_test.rb
+++ b/test/controllers/notifications_controller_test.rb
@@ -550,6 +550,16 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
     assert_equal assigns(:notifications).length, 1
   end
 
+  test 'search results can filter by author' do
+    sign_in_as(@user)
+    notification1 = create(:notification, user: @user, subject_type: 'Issue')
+    notification2 = create(:notification, user: @user, subject_type: 'PullRequest')
+    create(:subject, notifications: [notification1], author: 'andrew')
+    create(:subject, notifications: [notification2], author: 'benjam')
+    get '/?q=author%3Aandrew'
+    assert_equal assigns(:notifications).length, 1
+  end
+
   test 'search results can filter by locked:true' do
     sign_in_as(@user)
     notification1 = create(:notification, user: @user, subject_type: 'Issue')

--- a/test/controllers/notifications_controller_test.rb
+++ b/test/controllers/notifications_controller_test.rb
@@ -570,6 +570,30 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
     assert_equal assigns(:notifications).length, 2
   end
 
+  test 'search results can filter by label' do
+    sign_in_as(@user)
+    notification1 = create(:notification, user: @user)
+    notification2 = create(:notification, user: @user)
+    subject1 = create(:subject, notifications: [notification1])
+    subject2 = create(:subject, notifications: [notification2])
+    create(:label, subject: subject1, name: 'bug')
+    create(:label, subject: subject2, name: 'feature')
+    get '/?q=label%3Abug'
+    assert_equal assigns(:notifications).length, 1
+  end
+
+  test 'search results can filter by multiple labels' do
+    sign_in_as(@user)
+    notification1 = create(:notification, user: @user)
+    notification2 = create(:notification, user: @user)
+    subject1 = create(:subject, notifications: [notification1])
+    subject2 = create(:subject, notifications: [notification2])
+    create(:label, subject: subject1, name: 'bug')
+    create(:label, subject: subject2, name: 'feature')
+    get '/?q=label%3Abug%2Cfeature'
+    assert_equal assigns(:notifications).length, 2
+  end
+
   test 'search results can filter by locked:true' do
     sign_in_as(@user)
     notification1 = create(:notification, user: @user, subject_type: 'Issue')

--- a/test/factories/label.rb
+++ b/test/factories/label.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :label do
+    sequence(:github_id, 1000000) { |n| n }
+    name { 'bug' }
+    color { '#AAAAAA' }
+  end
+end


### PR DESCRIPTION
Replicating the enhancement from https://github.com/octobox/octobox/pull/921 for more fields:

- owner
- author
- label
- assignee

Also documents the feature in the search help box:

<img width="829" alt="screen shot 2018-09-17 at 12 05 16" src="https://user-images.githubusercontent.com/1060/45619668-094ed700-ba72-11e8-9508-f2a142350841.png">
