### PR TITLE
Delay syncing involved users after webhook event by 1 minute

### DIFF
--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -43,7 +43,7 @@ class Subject < ApplicationRecord
 
   def sync_involved_users
     return unless Octobox.github_app?
-    involved_user_ids.each { |user_id| SyncNotificationsWorker.perform_async_if_configured(user_id) }
+    involved_user_ids.each { |user_id| SyncNotificationsWorker.perform_in(1.minute, user_id) }
   end
 
   def self.sync(remote_subject)


### PR DESCRIPTION
For very busy users we end syncing their account much more often that required, this adds a slight buffer to reduce excess syncing.

Only affects installations running as a GitHub App