### PR TITLE
Marketplace support

### DIFF
--- a/app/controllers/hooks_controller.rb
+++ b/app/controllers/hooks_controller.rb
@@ -22,6 +22,8 @@ class HooksController < ApplicationController
       SyncInstallationRepositoriesWorker.perform_async_if_configured(payload)
     when 'github_app_authorization'
       SyncGithubAppAuthorizationWorker.perform_async_if_configured(payload['sender']['id'])
+    when 'marketplace_purchase'
+      MarketplacePurchaseWorker.perform_async_if_configured(payload)
     end
 
     head :no_content

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -274,7 +274,7 @@ class NotificationsController < ApplicationController
   end
 
   def notifications_for_presentation
-    eager_load_relation = display_subject? ? [{subject: :labels}, :repository] : nil
+    eager_load_relation = display_subject? ? [{subject: :labels}, {repository: {app_installation: {subscription_purchase: :subscription_plan}}}] : nil
     scope = current_user.notifications.includes(eager_load_relation)
 
     if params[:q].present?

--- a/app/models/app_installation.rb
+++ b/app/models/app_installation.rb
@@ -2,6 +2,7 @@ class AppInstallation < ApplicationRecord
   has_many :repositories, dependent: :destroy
   has_many :app_installation_permissions, dependent: :delete_all
   has_many :users, through: :app_installation_permissions
+  has_one :subscription_purchase, foreign_key: :account_id, primary_key: :account_id
 
   validates :github_id, presence: true, uniqueness: true
   validates :account_login, presence: true
@@ -39,5 +40,10 @@ class AppInstallation < ApplicationRecord
 
   def github_avatar_url
     "#{Octobox.config.github_domain}/#{account_login}.png"
+  end
+
+  def private_repositories_enabled?
+    return true unless Octobox.config.marketplace_url
+    subscription_purchase.try(:private_repositories_enabled?)
   end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -178,7 +178,7 @@ class Notification < ApplicationRecord
   end
 
   def github_app_installed?
-    Octobox.github_app? && user.github_app_authorized? && repository.try(:github_app_installed?)
+    Octobox.github_app? && user.github_app_authorized? && repository.try(:display_subject?)
   end
 
   def subjectable?

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -12,4 +12,13 @@ class Repository < ApplicationRecord
   def github_app_installed?
     app_installation_id.present?
   end
+
+  def display_subject?
+    github_app_installed? && required_plan_available?
+  end
+
+  def required_plan_available?
+    return true unless Octobox.config.marketplace_url
+    private? ? app_installation.private_repositories_enabled? : true
+  end
 end

--- a/app/models/subscription_plan.rb
+++ b/app/models/subscription_plan.rb
@@ -1,0 +1,42 @@
+class SubscriptionPlan < ApplicationRecord
+  has_many :subscription_purchases
+
+  validates :name, presence: true
+
+  scope :github, -> { where.not(github_id: nil) }
+
+  def private_repositories_enabled?
+    name.match?(/private/i)
+  end
+
+  def self.sync_plans
+    Octobox.github_app_client.list_plans.each do |remote_plan|
+      plan = find_or_initialize_by(github_id: remote_plan.id)
+      plan.update({
+        name:                   remote_plan.name,
+        description:            remote_plan.description,
+        monthly_price_in_cents: remote_plan.monthly_price_in_cents,
+        yearly_price_in_cents:  remote_plan.yearly_price_in_cents,
+        price_model:            remote_plan.price_model,
+        has_free_trial:         remote_plan.has_free_trial,
+        unit_name:              remote_plan.unit_name
+      })
+    end
+  end
+
+  def sync_purchases
+    Octobox.github_app_client.list_accounts_for_plan(self.github_id).each do |remote_purchase|
+      purchase = SubscriptionPurchase.find_or_initialize_by(account_id: remote_purchase.id)
+
+      purchase.update({
+        billing_cycle:      remote_purchase.marketplace_purchase.billing_cycle,
+        unit_count:         remote_purchase.marketplace_purchase.unit_count,
+        on_free_trial:      remote_purchase.marketplace_purchase.on_free_trial,
+        free_trial_ends_on: remote_purchase.marketplace_purchase.free_trial_ends_on,
+        updated_at:         remote_purchase.marketplace_purchase.updated_at,
+        next_billing_date:  remote_purchase.marketplace_purchase.next_billing_date,
+        subscription_plan_id: self.id
+      })
+    end
+  end
+end

--- a/app/models/subscription_purchase.rb
+++ b/app/models/subscription_purchase.rb
@@ -1,0 +1,17 @@
+class SubscriptionPurchase < ApplicationRecord
+  belongs_to :subscription_plan
+  belongs_to :app_installation, foreign_key: :account_id, primary_key: :account_id
+
+  validates :account_id, presence: true
+  validates :subscription_plan_id, presence: true
+
+  scope :active, -> { where('unit_count > 0') }
+
+  def active?
+    unit_count > 0
+  end
+
+  def private_repositories_enabled?
+    active? && subscription_plan.private_repositories_enabled?
+  end
+end

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -105,8 +105,28 @@
           </div>
         </div>
       </div>
+
+      <% if Octobox.config.marketplace_url.present? %>
+        <div class="col-md-3">
+          <div class="card shadow-sm  mb-3">
+            <div class="card-content">
+              <div class="card-body">
+                <div class="media d-flex">
+                  <div class="align-self-center">
+                    <%= octicon 'credit-card', height: 50 %>
+                  </div>
+                  <div class="media-body text-right">
+                    <h3>
+                      <%= number_to_human SubscriptionPurchase.active.count %>
+                    </h3>
+                    <span>Active Subscriptions</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      <% end %>
     <% end %>
-
-
   </div>
 </div>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -140,6 +140,9 @@
               <tr>
                 <th class='border-top-0'>Account</th>
                 <th class='border-top-0'>Repositories</th>
+                <% if Octobox.config.marketplace_url.present? %>
+                  <th class='border-top-0' colspan='2'>Billing</th>
+                <% end %>
                 <th class='border-top-0'>Settings</th>
               </tr>
             </thead>
@@ -153,8 +156,42 @@
                   </td>
                   <td class="align-middle">
                     <%= pluralize app_installation.repositories.github_app_installed.count, 'repository' %>
-                  </td>
-                  <td>
+                  </td >
+                  <% if Octobox.config.marketplace_url.present? %>
+                    <td class="align-middle">
+                      <% if app_installation.subscription_purchase %>
+                        <% if app_installation.subscription_purchase.active? %>
+                          <strong>
+                            <%= app_installation.subscription_purchase.subscription_plan.name %>
+                          </strong> -
+                          <% if app_installation.subscription_purchase.billing_cycle == 'monthly' %>
+                            <%= number_to_currency app_installation.subscription_purchase.subscription_plan.monthly_price_in_cents/100 %>
+                          <% else %>
+                            <%= number_to_currency app_installation.subscription_purchase.subscription_plan.yearly_price_in_cents/100 %>
+                          <% end %>
+                          <%= app_installation.subscription_purchase.billing_cycle %>
+
+                          <% if app_installation.subscription_purchase.on_free_trial? %>
+                            <i class='text-muted'>
+                              (Free Trail ends in <%= distance_of_time_in_words_to_now app_installation.subscription_purchase.free_trial_ends_on %>)
+                            </i>
+                          <% end %>
+                        <% else %>
+                          Cancelled Plan
+                        <% end %>
+                      <% else %>
+                        No Plan
+                      <% end %>
+                    </td>
+                    <td>
+                      <% if app_installation.subscription_purchase.try(:active?) %>
+                        <%= link_to 'Edit Plan', Octobox.config.marketplace_url, class: 'btn btn-primary btn-sm', target: '_blank', rel: 'noopener' %>
+                      <% else %>
+                        <%= link_to 'Start a Plan', Octobox.config.marketplace_url, class: 'btn btn-primary btn-sm', target: '_blank', rel: 'noopener' %>
+                      <% end %>
+                    </td>
+                  <% end %>
+                  <td class="align-middle">
                     <%= link_to 'Manage', app_installation.settings_url, class: 'btn btn-secondary btn-sm', target: '_blank', rel: 'noopener' %>
                   </td>
                 </tr>
@@ -171,7 +208,11 @@
           <li>Full support for private repositories</li>
           <li>Sync new and updated notifications automatically</li>
         </ul>
-        <%= link_to 'Install GitHub App', Octobox.config.app_install_url, class: 'btn btn-primary', target: '_blank', rel: 'noopener' %>
+        <% if Octobox.config.marketplace_url.present? %>
+          <%= link_to 'Install GitHub App', Octobox.config.marketplace_url, class: 'btn btn-primary', target: '_blank', rel: 'noopener' %>
+        <% else %>
+          <%= link_to 'Install GitHub App', Octobox.config.app_install_url, class: 'btn btn-primary', target: '_blank', rel: 'noopener' %>
+        <% end %>
       </div>
     </div>
   <% end %>

--- a/app/workers/marketplace_purchase_worker.rb
+++ b/app/workers/marketplace_purchase_worker.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class MarketplacePurchaseWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: :marketplace, unique: :until_and_while_executing
+
+  def perform(payload)
+    purchase = SubscriptionPurchase.find_or_initialize_by(account_id: payload['marketplace_purchase']['account']['id'])
+    plan = SubscriptionPlan.find_by_github_id(payload['marketplace_purchase']['plan']['id'])
+
+    purchase.update({
+      billing_cycle:      payload['marketplace_purchase']['billing_cycle'],
+      unit_count:         payload['marketplace_purchase']['unit_count'],
+      on_free_trial:      payload['marketplace_purchase']['on_free_trial'],
+      free_trial_ends_on: payload['marketplace_purchase']['free_trial_ends_on'],
+      updated_at:         payload['marketplace_purchase']['updated_at'] || Time.current,
+      next_billing_date:  payload['marketplace_purchase']['next_billing_date'],
+      subscription_plan_id: plan.id
+    })
+  end
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -2,4 +2,5 @@
 :concurrency: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 }.to_i %> # From lib/database_config.rb
 :queues:
   - [sync_notifications, 2]
+  - [marketplace, 2]
   - [sync_subjects, 1]

--- a/db/migrate/20180912120123_create_subscription_plans.rb
+++ b/db/migrate/20180912120123_create_subscription_plans.rb
@@ -1,0 +1,16 @@
+class CreateSubscriptionPlans < ActiveRecord::Migration[5.2]
+  def change
+    create_table :subscription_plans do |t|
+      t.integer :github_id
+      t.string :name
+      t.string :description
+      t.integer :monthly_price_in_cents
+      t.integer :yearly_price_in_cents
+      t.string :price_model
+      t.boolean :has_free_trial
+      t.string :unit_name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20180912125744_create_subscription_purchases.rb
+++ b/db/migrate/20180912125744_create_subscription_purchases.rb
@@ -1,0 +1,15 @@
+class CreateSubscriptionPurchases < ActiveRecord::Migration[5.2]
+  def change
+    create_table :subscription_purchases do |t|
+      t.integer :subscription_plan_id
+      t.integer :account_id
+      t.string :billing_cycle
+      t.integer :unit_count
+      t.boolean :on_free_trial
+      t.datetime :free_trial_ends_on
+      t.datetime :next_billing_date
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_13_142522) do
+ActiveRecord::Schema.define(version: 2018_09_17_090422) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -100,6 +100,31 @@ ActiveRecord::Schema.define(version: 2018_09_13_142522) do
     t.index ["url"], name: "index_subjects_on_url"
   end
 
+  create_table "subscription_plans", force: :cascade do |t|
+    t.integer "github_id"
+    t.string "name"
+    t.string "description"
+    t.integer "monthly_price_in_cents"
+    t.integer "yearly_price_in_cents"
+    t.string "price_model"
+    t.boolean "has_free_trial"
+    t.string "unit_name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "subscription_purchases", force: :cascade do |t|
+    t.integer "subscription_plan_id"
+    t.integer "account_id"
+    t.string "billing_cycle"
+    t.integer "unit_count"
+    t.boolean "on_free_trial"
+    t.datetime "free_trial_ends_on"
+    t.datetime "next_billing_date"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "users", id: :serial, force: :cascade do |t|
     t.integer "github_id", null: false
     t.string "github_login", null: false
@@ -108,13 +133,13 @@ ActiveRecord::Schema.define(version: 2018_09_13_142522) do
     t.datetime "last_synced_at"
     t.integer "refresh_interval", default: 0
     t.string "api_token"
-    t.string "sync_job_id"
     t.string "encrypted_access_token"
     t.string "encrypted_access_token_iv"
     t.string "encrypted_personal_access_token"
     t.string "encrypted_personal_access_token_iv"
     t.string "encrypted_app_token"
     t.string "encrypted_app_token_iv"
+    t.string "sync_job_id"
     t.string "theme", default: "light"
     t.index ["api_token"], name: "index_users_on_api_token", unique: true
     t.index ["github_id"], name: "index_users_on_github_id", unique: true

--- a/lib/tasks/marketplace.rake
+++ b/lib/tasks/marketplace.rake
@@ -1,0 +1,13 @@
+namespace :marketplace do
+  task sync_plans: :environment do
+    next unless Octobox.config.marketplace_url
+
+    SubscriptionPlan.sync_plans
+  end
+
+  task sync_subscriptions: :environment do
+    return unless Octobox.config.marketplace_url
+
+    SubscriptionPlan.github.find_each(&:sync_purchases)
+  end
+end


### PR DESCRIPTION
Adds support for making the Octobox.io Github app available on the [GitHub Marketplace](https://github.com/marketplace/), we're going through the approval process at the moment. 

From a functionality point of view on Octobox.io, this limits the display of extra subject data (i.e. state, author, assignee and labels) on notifications from private repositories unless they have a subscription setup in the marketplace for a plan with a name that contains the word `private`.

It shouldn't affect any other installations, other than adding a couple of empty database tables.

