### PR TITLE
Only speculatively sync users who've not been synced within the last minute

### DIFF
--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -78,7 +78,9 @@ class Subject < ApplicationRecord
   end
 
   def involved_user_ids
-    (user_ids + Array(repository.try(:user_ids))).uniq
+    ids = users.pluck(:id)
+    ids += repository.users.not_recently_synced.pluck(:id) if repository.present?
+    ids.uniq
   end
 
   def author_url_path

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,6 +29,8 @@ class User < ApplicationRecord
   }
   validate :personal_access_token_validator
 
+  scope :not_recently_synced, -> { where('last_synced_at < ?', 1.minute.ago) }
+
   def admin?
     Octobox.config.github_admin_ids.include?(github_id.to_s)
   end


### PR DESCRIPTION
Avoids excess syncing jobs being generated for GitHub Apps