### PR TITLE
Mark notifications as read on github in the background if sidekiq configured

### DIFF
--- a/app/workers/mark_read_worker.rb
+++ b/app/workers/mark_read_worker.rb
@@ -1,0 +1,9 @@
+class MarkReadWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: :sync_notifications, unique: :until_and_while_executing
+
+  def perform(user_id, notification_ids)
+    user = User.find_by_id(user_id)
+    Notification.mark_read_on_github(user, notification_ids) if user
+  end
+end


### PR DESCRIPTION
Marking a whole load of notifications as read is currently one of the slowest actions in the UI, because it makes http requests to the GitHub API that block the action.

This PR moves the marking on GitHub into sidekiq (where available) but keeps the database update synchronous so there isn't a lag in updating the UI.

If this works well we can also it do it for the mute action.