### PR TITLE
Remove async param from sync button

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -332,7 +332,7 @@ function notify(message, type) {
 
 function sync() {
   if($("a.js-sync.js-async").length) {
-    $.get('/notifications/sync.json?async=true', refreshOnSync);
+    $.get('/notifications/sync.json', refreshOnSync);
   } else {
     Turbolinks.visit($("a.js-sync").attr('href'))
   }

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -209,7 +209,7 @@ class NotificationsController < ApplicationController
   #   HEAD 204
   #
   def sync
-    if Octobox.background_jobs_enabled? && params[:async]
+    if Octobox.background_jobs_enabled?
       current_user.sync_notifications
     else
       current_user.sync_notifications_in_foreground

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -37,7 +37,7 @@
           </label>
           <%= select_all_button(@cur_selected, @total) %>
           <% end %>
-          <%= link_to sync_notifications_path(filters.merge(async: Octobox.background_jobs_enabled?)), class: "btn btn-sm btn-outline-dark js-sync #{'js-async' if Octobox.background_jobs_enabled?}", 'data-toggle' => 'tooltip', 'data-placement' => 'bottom', 'data-turbolinks' => false, 'data-animation' => 'false', 'data-position' => 'bottom', 'title' => 'Sync', 'aria-label' => 'Sync' do %>
+          <%= link_to sync_notifications_path(filters), class: "btn btn-sm btn-outline-dark js-sync #{'js-async' if Octobox.background_jobs_enabled?}", 'data-toggle' => 'tooltip', 'data-placement' => 'bottom', 'data-turbolinks' => false, 'data-animation' => 'false', 'data-position' => 'bottom', 'title' => 'Sync', 'aria-label' => 'Sync' do %>
             <%= octicon 'sync', height: 16, class: "#{'spinning' if initial_sync? || current_user.syncing?}" %>
           <% end %>
           <%= archive_selected_button unless archive_selected? %>


### PR DESCRIPTION
We only ever passed the `async` param when `Octobox.background_jobs_enabled?` was true, so it was kind of redundant. 

There's more than can be refactored in the `sync` controller action but that broke a number of test around error responses from back before we had sidekiq syncing so I'll save that for another day.
