### PR TITLE
Mute notifications on github in the background if sidekiq configured

### DIFF
--- a/app/workers/mute_notifications_worker.rb
+++ b/app/workers/mute_notifications_worker.rb
@@ -1,0 +1,9 @@
+class MuteNotificationsWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: :sync_notifications, unique: :until_and_while_executing
+
+  def perform(user_id, notification_ids)
+    user = User.find_by_id(user_id)
+    Notification.mute_on_github(user, notification_ids) if user
+  end
+end


### PR DESCRIPTION
Similar to https://github.com/octobox/octobox/pull/969, muting a whole load of notifications is now one of the slowest actions in the UI, because it makes http requests to the GitHub API that block the action.

This PR moves the muting on GitHub into sidekiq (where available) but keeps the database update synchronous so there isn't a lag in updating the UI.