### PR TITLE
Experiment with caching rvm directory on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,10 @@ script:
 
 bundler_args: --without development production --deployment --jobs=3 --retry=3
 
-cache: bundler
+cache:
+  bundler: true
+  directories:
+    - /home/travis/.rvm/
 
 env:
   matrix:


### PR DESCRIPTION
Possibly shaves ~16 seconds off the build time if it works.