### PR TITLE
fixes #973 Better handling of renamed/transferred repositories #973

### DIFF
--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -1,4 +1,7 @@
 class Repository < ApplicationRecord
+
+  include Octobox::Repository::UpdateNotificationRepositoryName
+
   has_many :notifications, foreign_key: :repository_full_name, primary_key: :full_name
   has_many :users, -> { distinct }, through: :notifications
   has_many :subjects, foreign_key: :repository_full_name, primary_key: :full_name

--- a/lib/octobox/repository/update_notification_repository_name.rb
+++ b/lib/octobox/repository/update_notification_repository_name.rb
@@ -1,0 +1,25 @@
+module Octobox
+  module Repository
+    module UpdateNotificationRepositoryName
+      extend ActiveSupport::Concern
+
+      included do
+        after_update :upate_full_name_and_owner, if: -> { saved_change_to_full_name? }
+      end
+
+      # update full_name and owner_name of notifications if Repository full_name is updated
+      def upate_full_name_and_owner
+        notifications = Notification.where(repository_id: self.github_id)
+
+        return if notifications.blank?
+        # bulk update notifications
+        # Note: This method constructs a single SQL UPDATE statement and sends it straight
+        # to the database so it will not update the timestamps
+        notifications.update_all({
+          repository_full_name: self.full_name,
+          repository_owner_name:  self.owner
+        })
+      end
+    end
+  end
+end

--- a/lib/octobox/repository/update_notification_repository_name.rb
+++ b/lib/octobox/repository/update_notification_repository_name.rb
@@ -4,18 +4,15 @@ module Octobox
       extend ActiveSupport::Concern
 
       included do
-        after_update :upate_full_name_and_owner, if: -> { saved_change_to_full_name? }
+        after_update :upate_full_name_and_owner, if: :saved_change_to_full_name?
       end
 
       # update full_name and owner_name of notifications if Repository full_name is updated
       def upate_full_name_and_owner
-        notifications = Notification.where(repository_id: self.github_id)
-
-        return if notifications.blank?
         # bulk update notifications
         # Note: This method constructs a single SQL UPDATE statement and sends it straight
         # to the database so it will not update the timestamps
-        notifications.update_all({
+        Notification.where(repository_id: self.github_id).update_all({
           repository_full_name: self.full_name,
           repository_owner_name:  self.owner
         })

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -37,4 +37,24 @@ class RepositoryTest < ActiveSupport::TestCase
     assert_equal @repository.subjects.length, 1
     assert_equal @repository.subjects.first, subject
   end
+
+  test 'updates full_name and ower_name of notifications of repository if full_name is updated' do
+    notification = create(
+      :notification,
+      repository_id: @repository.github_id,
+      repository_full_name: @repository.full_name,
+      repository_full_name: @repository.owner,
+      subject_url: "https://api.github.com/repos/#{@repository.full_name}/issues/1",
+      archived: false
+    )
+
+    @repository.full_name = "octobox_hq/octobox"
+    @repository.owner = "octobox_hq"
+    @repository.save
+
+    notification.reload
+
+    assert_equal notification.repository_owner_name, @repository.owner
+    assert_equal notification.repository_full_name, @repository.full_name
+  end
 end


### PR DESCRIPTION
* Create a module to handle Notifications update if any of the repository is rename/transferred
* Added `activerecord-import` gem for doing bulk update
* Bulk update is done in batch of 1000
* Added Test case 

Fixes #973 
