### PR TITLE
Add a rake task to update old notifications with renamed repositories

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -410,4 +410,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.4
+   1.16.5

--- a/lib/tasks/tasks.rake
+++ b/lib/tasks/tasks.rake
@@ -29,4 +29,22 @@ namespace :tasks do
       duplicate_subjects[1..-1].each(&:destroy)
     end
   end
+
+  desc "Update repository names"
+  task update_repository_names: :environment do
+    Repository.all.find_each do |repository|
+      count = Notification.where(repository_id: repository.github_id).
+                           where.not(repository_full_name: repository.full_name).
+                           where.not(repository_owner_name: repository.owner).count
+      if count > 0
+        Notification.where(repository_id: repository.github_id).
+                     where.not(repository_full_name: repository.full_name).
+                     where.not(repository_owner_name: repository.owner).
+                     update_all({
+                      repository_full_name: repository.full_name,
+                      repository_owner_name:  repository.owner
+                    })
+      end
+    end
+  end
 end


### PR DESCRIPTION
Follow on from https://github.com/octobox/octobox/pull/978, adds a handy rake task to update any old notifications where the repository has since been renamed.