### PR TITLE
Excludable search prefixes

### DIFF
--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -11,13 +11,21 @@ class Search
     res = scope
     res = scope.search_by_subject_title(parsed_query.freetext) if parsed_query.freetext.present?
     res = res.repo(repo) if repo.present?
+    res = res.exclude_repo(exclude_repo) if exclude_repo.present?
     res = res.owner(owner) if owner.present?
+    res = res.exclude_owner(exclude_owner) if exclude_owner.present?
     res = res.type(type) if type.present?
+    res = res.exclude_type(exclude_type) if exclude_type.present?
     res = res.reason(reason) if reason.present?
+    res = res.exclude_reason(exclude_reason) if exclude_reason.present?
     res = res.label(label) if label.present?
+    res = res.exclude_label(exclude_label) if exclude_label.present?
     res = res.state(state) if state.present?
+    res = res.exclude_state(exclude_state) if exclude_state.present?
     res = res.author(author) if author.present?
+    res = res.exclude_author(exclude_author) if exclude_author.present?
     res = res.assigned(assignee) if assignee.present?
+    res = res.exclude_assigned(exclude_assignee) if exclude_assignee.present?
     res = res.starred(starred) unless starred.nil?
     res = res.archived(archived) unless archived.nil?
     res = res.archived(!inbox) unless inbox.nil?
@@ -85,12 +93,24 @@ class Search
     parsed_query[:repo]
   end
 
+  def exclude_repo
+    parsed_query[:'-repo']
+  end
+
   def owner
     parsed_query[:owner]
   end
 
+  def exclude_owner
+    parsed_query[:'-owner']
+  end
+
   def author
     parsed_query[:author]
+  end
+
+  def exclude_author
+    parsed_query[:'-author']
   end
 
   def unread
@@ -101,20 +121,40 @@ class Search
     parsed_query[:type].map(&:classify)
   end
 
+  def exclude_type
+    parsed_query[:'-type'].map(&:classify)
+  end
+
   def reason
     parsed_query[:reason].map{|r| r.downcase.gsub(' ', '_') }
+  end
+
+  def exclude_reason
+    parsed_query[:'-reason'].map{|r| r.downcase.gsub(' ', '_') }
   end
 
   def state
     parsed_query[:state].map(&:downcase)
   end
 
+  def exclude_state
+    parsed_query[:'-state'].map(&:downcase)
+  end
+
   def label
     parsed_query[:label]
   end
 
+  def exclude_label
+    parsed_query[:'-label']
+  end
+
   def assignee
     parsed_query[:assignee]
+  end
+
+  def exclude_assignee
+    parsed_query[:'-assignee']
   end
 
   def starred

--- a/lib/search_parser.rb
+++ b/lib/search_parser.rb
@@ -2,7 +2,7 @@
 # Simplified version of https://github.com/marcelocf/searrrch/blob/f2825e26/lib/searrrch.rb
 
 class SearchParser
-  OPERATOR_EXPRESSION = /(\w+):[\ 　]?([\w\p{Han}\p{Katakana}\p{Hiragana}\p{Hangul}ー\.\-,\/]+|(["'])(\\?.)*?\3)/
+  OPERATOR_EXPRESSION = /(\-?\w+):[\ 　]?([\w\p{Han}\p{Katakana}\p{Hiragana}\p{Hangul}ー\.\-,\/]+|(["'])(\\?.)*?\3)/
 
   attr_accessor :freetext
 

--- a/test/lib/search_parser_test.rb
+++ b/test/lib/search_parser_test.rb
@@ -96,4 +96,10 @@ class SearchParserTest < ActiveSupport::TestCase
     search = SearchParser.new query
     assert_equal search[:user_id], ['1','2','3','4']
   end
+
+  test 'allows - in prefix' do
+    query = '-repo:octobox/octobox,foo/bar'
+    search = SearchParser.new query
+    assert_equal search[:'-repo'], ['octobox/octobox','foo/bar'] 
+  end
 end

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -43,7 +43,7 @@ class RepositoryTest < ActiveSupport::TestCase
       :notification,
       repository_id: @repository.github_id,
       repository_full_name: @repository.full_name,
-      repository_full_name: @repository.owner,
+      repository_owner_name: @repository.owner,
       subject_url: "https://api.github.com/repos/#{@repository.full_name}/issues/1",
       archived: false
     )


### PR DESCRIPTION
Adds the following prefixes to exclude notifications that match the argument:

- [x] -repo
- [x] -owner
- [x] -type
- [x] -reason
- [x] -label
- [x] -state
- [x] -author
- [x] -assignee

Resolves #961 