### PR TITLE
Gracefully handle jobs that have been enqueud after a notification was deleted

### DIFF
--- a/app/workers/update_repository_worker.rb
+++ b/app/workers/update_repository_worker.rb
@@ -5,6 +5,6 @@ class UpdateRepositoryWorker
   sidekiq_options queue: :sync_subjects, unique: :until_and_while_executing
 
   def perform(notification_id, force = false)
-    Notification.find(notification_id).try(:update_repository_in_foreground, force)
+    Notification.find_by_id(notification_id).try(:update_repository_in_foreground, force)
   end
 end


### PR DESCRIPTION
Someone signed up to Octobox.io and then deleted their account before all their notifications had been synced, causing some jobs to get stuck in a fail-retry loop.