### PR TITLE
Don't fire keyboard shortcuts when ctrl/cmd/alt/shift held down

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -180,7 +180,7 @@ function enableKeyboardShortcuts() {
 
   $(document).keydown(function(e) {
     // disable shortcuts for the seach box
-    if (e.target.id !== 'search-box') {
+    if (e.target.id !== 'search-box' && !e.ctrlKey && !e.altKey  && !e.shiftKey && !e.metaKey) {
       var shortcutFunction = shortcuts[e.which];
       if (shortcutFunction) { shortcutFunction(e) }
     }


### PR DESCRIPTION
Stops octobox from starting a sync when the page is refresh with cmd+r