### PR TITLE
fix Alignment issues with Octobox Selected Option for Sidebar

### DIFF
--- a/app/assets/stylesheets/_application.scss
+++ b/app/assets/stylesheets/_application.scss
@@ -377,17 +377,12 @@ td.keys {
     }
     &.filter {
       padding: 5px 15px;
-
       &.repo-label {
         padding-left: 42px;
-
-        .octicon {
-          margin-right: 5px;
-        }
       }
-
       .badge {
         top: 6px;
+        padding: 2px 6px;
       }
     }
   }


### PR DESCRIPTION
* Alignment of `X` octokit icon was not proper so fixed that. Checked on Chrome, Firefox, Safari