### PR TITLE
Use yard for generating api docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ public/assets
 public/docs
 .database
 config/sidekiq_custom_schedule.yml
+.yardoc

--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem 'bootsnap', require: false
 gem 'bugsnag'
 gem 'jwt'
 gem 'oj'
+gem 'yard'
 
 # Supported databases
 gem 'mysql2', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -371,6 +371,7 @@ GEM
     websocket-extensions (0.1.3)
     xpath (3.1.0)
       nokogiri (~> 1.8)
+    yard (0.9.16)
 
 PLATFORMS
   ruby
@@ -433,6 +434,7 @@ DEPENDENCIES
   uglifier
   web-console
   webmock
+  yard
 
 RUBY VERSION
    ruby 2.5.1p57

--- a/lib/tasks/docs.rake
+++ b/lib/tasks/docs.rake
@@ -1,14 +1,13 @@
 require 'rdoc/task'
 
 namespace :api_docs do
-  RDoc::Task.new :generate do |rdoc|
-    rdoc.main = "docs/API_README.md"
-    rdoc.rdoc_files.include(
+  YARD::Rake::YardocTask.new :generate do |doc|
+    doc.options = ["--readme", "docs/API_README.md",
+                   "--title", "Octobox API Documentation",
+                   "--output-dir", "public/docs"]
+    doc.files = [
       "app/controllers/notifications_controller.rb",
-      "app/controllers/users_controller.rb",
-      "docs/API_README.md",
-    )
-    rdoc.rdoc_dir = "public/docs"
-    rdoc.title = "Octobox API Documentation"
+      "app/controllers/users_controller.rb"
+    ]
   end
 end


### PR DESCRIPTION
rdoc wasn't playing nicely with heroku after https://github.com/octobox/octobox/pull/1001