### PR TITLE
Add user and org as aliases for owner search prefix

### DIFF
--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -98,11 +98,11 @@ class Search
   end
 
   def owner
-    parsed_query[:owner]
+    parsed_query[:owner].presence || parsed_query[:org].presence || parsed_query[:user]
   end
 
   def exclude_owner
-    parsed_query[:'-owner']
+    parsed_query[:'-owner'].presence || parsed_query[:'-org'].presence || parsed_query[:'-user']
   end
 
   def author

--- a/test/models/search_test.rb
+++ b/test/models/search_test.rb
@@ -1,7 +1,23 @@
 require 'test_helper'
 
 class SearchTest < ActiveSupport::TestCase
-  test 'parses search query' do
-    # TODO
+  test 'user acts as an alias for owner' do
+    search = Search.new(query: 'user:andrew', scope: Notification.all)
+    assert_equal search.send(:owner), ['andrew']
+  end
+
+  test 'org acts as an alias for owner' do
+    search = Search.new(query: 'org:octobox', scope: Notification.all)
+    assert_equal search.send(:owner), ['octobox']
+  end
+
+  test '-user acts as an alias for -owner' do
+    search = Search.new(query: '-user:andrew', scope: Notification.all)
+    assert_equal search.send(:exclude_owner), ['andrew']
+  end
+
+  test '-org acts as an alias for -owner' do
+    search = Search.new(query: '-org:octobox', scope: Notification.all)
+    assert_equal search.send(:exclude_owner), ['octobox']
   end
 end


### PR DESCRIPTION
Re https://github.com/octobox/octobox/issues/778#issuecomment-424093900

I've repeatedly mistaken done searches for `org:octobox` and `user:andrew` when the actual prefix is `owner`. I'm not going to document them but just make them work as expected for people who make the same mistake.