### PR TITLE
Switch Safari mask icon to use no-background logo

### DIFF
--- a/app/views/layouts/_favicons.html.erb
+++ b/app/views/layouts/_favicons.html.erb
@@ -12,7 +12,7 @@
 <link rel="icon" type="image/png" sizes="96x96" href="/favicon-96x96.png">
 <link id="favicon" rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
 <link rel="manifest" href="/manifest.json">
-<link rel="mask-icon" href="<%= asset_path "infinitacle-round.svg" %>" color="black">
+<link rel="mask-icon" href="<%= asset_path "infinitacle.svg" %>" color="black">
 <meta name="msapplication-TileColor" content="#ffffff">
 <meta name="msapplication-TileImage" content="/ms-icon-144x144.png">
 <meta name="theme-color" content="#ffffff">


### PR DESCRIPTION
The round-background icon wasn't rendering correctly for some reason, and this brings the tab icon in line with the other favicons:

![screen shot 2018-09-26 at 11 06 14 am](https://user-images.githubusercontent.com/2745/46093325-ac8fa280-c17c-11e8-815a-0177bcbd4c02.png)

(before on the left, after on the right)

Fixes #1010 