### PR TITLE
Add multiple templates for different kinds of issues

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,1 @@
+## 👉 [Please follow one of these issue templates](https://github.com/octobox/octobox/issues/new/choose) 👈

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,3 +1,8 @@
+---
+name: 🐛 Bug Report
+about: Create a report to help us improve Octobox
+---
+
 <!--- Provide a general summary of the issue in the Title above -->
 
 Are you experiencing this issue in octobox.io or your own instance?
@@ -21,4 +26,4 @@ Are you experiencing this issue in octobox.io or your own instance?
  * Add, commit, push your changes
  * Submit a pull request and add this in comments - `Addresses #<put issue number here>`
  * Ask for a review in comments section of pull request
- * Celebrate your contribution to this project 🎉 
+ * Celebrate your contribution to this project 🎉

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,26 @@
+---
+name: 🐣 Feature Request
+about: Propose a non-trivial change or new feature for Octobox
+---
+
+## 💥 Proposal
+
+### What feature you'd like to see
+(A clear and concise description of what the proposal is.)
+
+## Motivation
+(Please outline the motivation for the proposal. It's interesting knowing what people are working on and also could help community members make suggestions for work-arounds until the feature is built)
+
+## Pitch
+
+(Please explain why this feature should be implemented and how it would be used.)
+
+<!--
+  What happens if you skip this step?
+
+  Someone will read your feature proposal and maybe will be able to help you,
+  but it’s unlikely that it will get much attention from the team. Eventually,
+  the issue will likely get closed in favor of issues that have better explanations
+
+  Thanks for helping us help you!
+-->

--- a/.github/ISSUE_TEMPLATE/support.md
+++ b/.github/ISSUE_TEMPLATE/support.md
@@ -1,0 +1,25 @@
+---
+name: ❓ Questions/Help
+about: As a support question
+---
+
+<!-- Having trouble installing? Be sure to check out the installation docs! https://github.com/octobox/octobox/blob/master/docs/INSTALLATION.md -->
+
+### Summary of Problem
+
+(Please answer all 3)
+
+- What are you trying to do?
+- What happens?
+- What should have happened?
+
+### Steps to Reproduce the Issue
+
+(help octobox maintainers reproduce your issue to make it easier to fix)
+
+### Versions, Operating System and Hardware
+
+- Which version/commit of Octobox are you using?
+- Which browser are you accessing Octobo with?
+- Windows? Linux? Mac?
+- How are you deploying Octobox (Docker, Heroku, Openshift, etc)


### PR DESCRIPTION
Based on https://help.github.com/articles/about-issue-and-pull-request-templates/, results in an extra multi-choice step in the issue reporting process that looks something like this:

![new-issue-page-with-multiple-templates](https://user-images.githubusercontent.com/1060/46282669-0374ed80-c56a-11e8-98fe-2de05dece4c6.png)

Also moves the templates out of the docs folder and into the `.github` folder to effectively hide the mechanics of these templates.