### PR TITLE
Add repo name as title attribute to filter items

### DIFF
--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -177,25 +177,25 @@ module NotificationsHelper
   end
 
   def filter_link(param, value, count)
-    sidebar_filter_link(params[param] == value.to_s, param, value, count) do
+    sidebar_filter_link(active: params[param] == value.to_s, param: param, value: value, count: count) do
       yield
     end
   end
 
   def org_filter_link(param, value)
-    sidebar_filter_link(params[param] == value.to_s, param, value, nil, :repo, 'owner-label') do
+    sidebar_filter_link(active: params[param] == value.to_s, param: param, value: value, except: :repo, link_class: 'owner-label') do
       yield
     end
   end
 
   def repo_filter_link(param, repo_name, count)
     active = params[param] == repo_name || params[:owner] == repo_name.split('/')[0]
-    sidebar_filter_link(active, param, repo_name, count, :owner, 'repo-label', nil, repo_name) do
+    sidebar_filter_link(active: active, param: param, value: repo_name, count: count, except: :owner, link_class: 'repo-label', title: repo_name) do
       yield
     end
   end
 
-  def sidebar_filter_link(active, param, value, count, except = nil, link_class = nil, path_params = nil, title = nil)
+  def sidebar_filter_link(active:, param:, value:, count: nil, except: nil, link_class: nil, path_params: nil, title: nil)
     content_tag :li, class: (active ? 'nav-item active' : 'nav-item'), title: title do
       active = (active && not_repo_in_active_org(param))
       path_params ||= filtered_params(param => (active ? nil : value)).except(except)
@@ -215,7 +215,7 @@ module NotificationsHelper
     link_value = reason_link_param_value(params[:reason], value, active)
     path_params = filtered_params(:reason => link_value)
 
-    sidebar_filter_link(active, :reason, link_value, count, nil, nil, path_params) do
+    sidebar_filter_link(active: active, param: :reason, value: link_value, count: count, path_params: path_params) do
       yield
     end
   end

--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -188,15 +188,15 @@ module NotificationsHelper
     end
   end
 
-  def repo_filter_link(param, value, count)
-    active = params[param] == value || params[:owner] == value.split('/')[0]
-    sidebar_filter_link(active, param, value, count, :owner, 'repo-label') do
+  def repo_filter_link(param, repo_name, count)
+    active = params[param] == repo_name || params[:owner] == repo_name.split('/')[0]
+    sidebar_filter_link(active, param, repo_name, count, :owner, 'repo-label', nil, repo_name) do
       yield
     end
   end
 
-  def sidebar_filter_link(active, param, value, count, except = nil, link_class = nil, path_params = nil)
-    content_tag :li, class: (active ? 'nav-item active' : 'nav-item') do
+  def sidebar_filter_link(active, param, value, count, except = nil, link_class = nil, path_params = nil, title = nil)
+    content_tag :li, class: (active ? 'nav-item active' : 'nav-item'), title: title do
       active = (active && not_repo_in_active_org(param))
       path_params ||= filtered_params(param => (active ? nil : value)).except(except)
       link_to root_path(path_params), class: (active ? "nav-link active filter #{link_class}" : "nav-link filter #{link_class}") do


### PR DESCRIPTION
Repository names in our case have a common prefix.
In the sidebar the repo names are `overflow:hidden` and I can only see the beginning of the names which are in a lot cases the same.

By providing the full repo name also as a title attribute we add a non-invasive way to get the info just by hovering with the cursor over the filter item.

I added a optional parameter to the `sidebar_filter_link` so it should not have any impact on existing code.
I would suggest to move to keyword args for helpers like this, since with a lot of optional params it becomes more ugly and error prone to call the method with sparsely filled parameters.

I did not find any tests for the notifications_helper and it was a tiny change so I did not add tests.
