### PR TITLE
Only trigger keyboard shortcuts if on the index page

### DIFF
--- a/app/assets/javascripts/octobox.js
+++ b/app/assets/javascripts/octobox.js
@@ -100,7 +100,7 @@ var Octobox = (function() {
 
     $(document).keydown(function(e) {
       // disable shortcuts for the seach box
-      if (e.target.id !== "search-box" && !e.ctrlKey && !e.shiftKey && !e.metaKey) {
+      if ($("#help-box").length && e.target.id !== "search-box" && !e.ctrlKey && !e.shiftKey && !e.metaKey) {
         var shortcutFunction = shortcuts[e.which];
         if (shortcutFunction) { shortcutFunction(e) }
       }


### PR DESCRIPTION
Keyboard shortcuts are persisted across turbolinks page loads, so going from the index page to the settings page keeps keyboard shortcuts active, which then interferes with forms and text fields.