### PR TITLE
Fix adding repositories to installations when they already exist in the database

### DIFF
--- a/app/models/app_installation.rb
+++ b/app/models/app_installation.rb
@@ -10,14 +10,15 @@ class AppInstallation < ApplicationRecord
 
   def add_repositories(remote_repositories)
     remote_repositories.each do |remote_repository|
-      repository = repositories.find_or_create_by(github_id: remote_repository['id'])
+      repository = Repository.find_or_create_by(github_id: remote_repository['id'])
 
       repository.update_attributes({
         full_name: remote_repository['full_name'],
         private: remote_repository['private'],
         owner: remote_repository['full_name'].split('/').first,
         github_id: remote_repository['id'],
-        last_synced_at: Time.current
+        last_synced_at: Time.current,
+        app_installation_id: self.id
       })
 
       repository.notifications.includes(:user).find_each{|n| n.update_subject(true) }
@@ -50,6 +51,13 @@ class AppInstallation < ApplicationRecord
   def sync
     remote_installation = Octobox.github_app_client.installation(github_id, accept: 'application/vnd.github.machine-man-preview+json')
     update_attributes(AppInstallation.map_from_api(remote_installation))
+  end
+
+  def sync_repositories
+    access_token = Octobox.github_app_client.create_installation_access_token(self.github_id, accept: 'application/vnd.github.machine-man-preview+json')
+    client = Octokit::Client.new(access_token: access_token.token, auto_paginate: true)
+    remote_repositories = client.list_app_installation_repositories.repositories
+    add_repositories(remote_repositories)
   end
 
   def self.map_from_api(remote_installation)


### PR DESCRIPTION
Also adds a sync_repositories method to AppInstallation for creating/updating all installed repositories for an installation.

Related to https://github.com/octobox/octobox/issues/1071