### PR TITLE
Fix subjectable scope on Notifications

### DIFF
--- a/lib/octobox/notifications/inclusive_scope.rb
+++ b/lib/octobox/notifications/inclusive_scope.rb
@@ -15,7 +15,7 @@ module Octobox
         scope :status,   ->(status)       { joins(:subject).where(subjects: { status: status }) }
         scope :unassigned, -> { joins(:subject).where("subjects.assignees = '::'") }
         scope :locked,     -> { joins(:subject).where(subjects: { locked: true }) }
-        scope :subjectable,-> { where(subject_type: SUBJECTABLE_TYPES) }
+        scope :subjectable,-> { where(subject_type: Notification::SUBJECTABLE_TYPES) }
         scope :bot_author, -> { joins(:subject).where('subjects.author LIKE ? OR subjects.author LIKE ?', '%[bot]', '%-bot') }
         scope :labelable,  -> { where(subject_type: ['Issue', 'PullRequest']) }
         scope :is_private, ->(is_private = true) { joins(:repository).where('repositories.private = ?', is_private) }

--- a/test/models/notification_test.rb
+++ b/test/models/notification_test.rb
@@ -237,4 +237,12 @@ class NotificationTest < ActiveSupport::TestCase
     assert_equal 'merged', subject.state
     assert_equal 'failure', subject.status
   end
+
+  test 'subjectable scope returns only notifications that can have subjects' do
+    notification1 = create(:notification, subject_type: 'Issue')
+    notification2 = create(:notification, subject_type: 'RepositoryVulnerabilityAlert')
+
+    assert_equal Notification.subjectable.length, 1
+    assert_equal Notification.subjectable.first, notification1
+  end
 end


### PR DESCRIPTION
The scope was only used in a rake task and untested so it went unnoticed when was broken recently.