### PR TITLE
Rubocop fixes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
 AllCops:
   DisabledByDefault: true
+  TargetRubyVersion: 2.5
 
 #################### Lint ################################
 
@@ -295,6 +296,10 @@ Performance/StringReplacement:
                   you are deleting characters.
   Reference: 'https://github.com/JuanitoFatas/fast-ruby#stringgsub-vs-stringtr-code'
   Enabled: true
+
+Performance:
+  enabled: true
+
 
 ##################### Rails ##################################
 

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -132,7 +132,7 @@ class Notification < ApplicationRecord
   def update_from_api_response(api_response, unarchive: false)
     attrs = Notification.attributes_from_api_response(api_response)
     self.attributes = attrs
-    archived = false if archived.nil? # fixup existing records where archived is nil
+    self.archived = false if archived.nil? # fixup existing records where archived is nil
     unarchive_if_updated if unarchive
     save(touch: false) if changed?
     update_subject

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -159,11 +159,11 @@ class Search
   end
 
   def reason
-    parsed_query[:reason].map{|r| r.downcase.gsub(' ', '_') }
+    parsed_query[:reason].map{|r| r.downcase.tr(' ', '_') }
   end
 
   def exclude_reason
-    parsed_query[:'-reason'].map{|r| r.downcase.gsub(' ', '_') }
+    parsed_query[:'-reason'].map{|r| r.downcase.tr(' ', '_') }
   end
 
   def state

--- a/bin/spring
+++ b/bin/spring
@@ -8,7 +8,7 @@ unless defined?(Spring)
   require 'bundler'
 
   lockfile = Bundler::LockfileParser.new(Bundler.default_lockfile.read)
-  if spring = lockfile.specs.detect { |spec| spec.name == "spring" }
+  if (spring = lockfile.specs.detect { |spec| spec.name == "spring" })
     Gem.use_paths Gem.dir, Bundler.bundle_path.to_s, *Gem.path
     gem 'spring', spring.version
     require 'spring/binstub'

--- a/config/initializers/simple_form_bootstrap.rb
+++ b/config/initializers/simple_form_bootstrap.rb
@@ -21,7 +21,7 @@ SimpleForm.setup do |config|
   config.boolean_label_class = 'form-check-label'
 
   # How the label text should be generated altogether with the required text.
-  config.label_text = lambda { |label, required, explicit_label| "#{label} #{required}" }
+  config.label_text = lambda { |label, required, _explicit_label| "#{label} #{required}" }
 
   # Define the way to render check boxes / radio buttons with labels.
   config.boolean_style = :inline

--- a/lib/page_limiting_octokit_client.rb
+++ b/lib/page_limiting_octokit_client.rb
@@ -1,5 +1,5 @@
 module PageLimitingOctokitClient
-  def paginate(url, options = {}, &block)
+  def paginate(url, options = {})
     under_max_results = -> (data, max_results) {
       ! max_results || ! data.respond_to?(:size) || data.size < max_results
     }

--- a/lib/search_parser.rb
+++ b/lib/search_parser.rb
@@ -12,7 +12,7 @@ class SearchParser
     @operators = {}
 
     offset = 0
-    while m = OPERATOR_EXPRESSION.match(query, offset)
+    while (m = OPERATOR_EXPRESSION.match(query, offset))
       key = m[1].downcase.to_sym
       value = m[2]
       value = value[1, value.length - 2] if ["'", '"'].include?(value[0])

--- a/lib/tasks/opencollective.rake
+++ b/lib/tasks/opencollective.rake
@@ -16,7 +16,7 @@ namespace :opencollective do
 
     # check for users who have made multiple donations in the last month that tipped
     tx_groups = txs.group_by{|item| item["github"].presence || item["organization"]}
-    subs = tx_groups.select do |name, transactions|
+    subs = tx_groups.select do |_name, transactions|
       transactions.sum{|item| item['lastTransactionAmount']} >= subs_cost_per_period
     end
 

--- a/test/controllers/notifications_controller_test.rb
+++ b/test/controllers/notifications_controller_test.rb
@@ -229,7 +229,7 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
     sign_in_as(@user)
     notification1 = create(:notification, user: @user, archived: false)
     notification2 = create(:notification, user: @user, archived: false)
-    notification3 = create(:notification, user: @user, archived: false)
+    create(:notification, user: @user, archived: false)
 
     Notification.expects(:mute).with([notification1, notification2])
 
@@ -254,7 +254,7 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
     sign_in_as(@user)
     notification1 = create(:notification, user: @user, archived: false)
     notification2 = create(:notification, user: @user, archived: false)
-    notification3 = create(:notification, user: @user, archived: false)
+    create(:notification, user: @user, archived: false)
 
     Notification.expects(:mark_read).with([notification1, notification2])
 
@@ -606,7 +606,7 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
   test 'search results can filter by inbox' do
     sign_in_as(@user)
     @user.notifications.delete_all
-    notification1 = create(:notification, user: @user, archived: true)
+    create(:notification, user: @user, archived: true)
     notification2 = create(:notification, user: @user, archived: false)
     get '/?q=inbox%3Atrue'
     assert_equal assigns(:notifications).length, 1
@@ -847,7 +847,7 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
     sign_in_as(@user)
 
     notification1 = create(:notification, user: @user, archived: true)
-    notification2 = create(:notification, user: @user, archived: true)
+    create(:notification, user: @user, archived: true)
     stub_request(:patch, /https:\/\/api.github.com\/notifications\/threads/)
 
     post '/notifications/archive_selected', params: { id: [notification1.id], value: false }, xhr: true
@@ -859,7 +859,7 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
 
   test 'shows saved searches in sidebar' do
     sign_in_as(@user)
-    pinned_search = create(:pinned_search, user: @user)
+    create(:pinned_search, user: @user)
     get '/'
     assert_response :success
     assert_template 'notifications/index'
@@ -868,7 +868,7 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
 
   test 'highlights active saved searches in sidebar' do
     sign_in_as(@user)
-    pinned_search = create(:pinned_search, user: @user)
+    create(:pinned_search, user: @user)
     get '/?q=inbox%3Atrue+owner%3Aoctobox'
     assert_response :success
     assert_template 'notifications/index'
@@ -877,7 +877,7 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
 
   test 'only shows new saved search link if filters are active' do
     sign_in_as(@user)
-    pinned_search = create(:pinned_search, user: @user)
+    create(:pinned_search, user: @user)
     get '/'
     assert_response :success
     assert_select '.new_pinned_search', {count: 0}
@@ -885,7 +885,7 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
 
   test 'shows new saved search link if not already saved' do
     sign_in_as(@user)
-    pinned_search = create(:pinned_search, user: @user)
+    create(:pinned_search, user: @user)
     get '/?q=foo'
     assert_response :success
     assert_select '.new_pinned_search', {count: 1}
@@ -893,7 +893,7 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
 
   test "doesn't show new saved search link if already saved" do
     sign_in_as(@user)
-    pinned_search = create(:pinned_search, user: @user)
+    create(:pinned_search, user: @user)
     get '/?q=inbox%3Atrue+owner%3Aoctobox'
     assert_response :success
     assert_select '.new_pinned_search', {count: 0}
@@ -901,7 +901,7 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
 
   test "doesn't show new saved search link if already saved with params" do
     sign_in_as(@user)
-    pinned_search = create(:pinned_search, user: @user)
+    create(:pinned_search, user: @user)
     get '/?owner=octobox'
     assert_response :success
     assert_select '.new_pinned_search', {count: 0}

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -38,7 +38,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
 
   test 'displays settings page with saved search' do
     sign_in_as(@user)
-    pinned_search = create(:pinned_search, user: @user)
+    create(:pinned_search, user: @user)
     get settings_path
     assert_template 'users/edit'
   end

--- a/test/lib/search_parser_test.rb
+++ b/test/lib/search_parser_test.rb
@@ -62,24 +62,18 @@ class SearchParserTest < ActiveSupport::TestCase
 
   test 'has multiple operators with "' do
     query = 'operator: "123 is lol" otheroperator: "12" operator: "other value"'
-    expectedvalue = '123 is lol'
-    othervalue = 'other value'
     search = SearchParser.new query
     assert_equal search[:operator], ['123 is lol', 'other value']
   end
    #
   test 'has multiple operators with \'' do
     query = 'operator: \'123 is lol\' otheroperator: \'12\' operator: \'other value\''
-    expectedvalue = '123 is lol'
-    othervalue = 'other value'
     search = SearchParser.new query
     assert_equal search[:operator], ['123 is lol', 'other value']
   end
 
   test 'has multiple operators with \' and "' do
     query = 'operator: \'123 is " lol\' otheroperator: \'12\' operator: "other \' value"'
-    expectedvalue = '123 is " lol'
-    othervalue = 'other \' value'
     search = SearchParser.new query
     assert_equal search[:operator], ["123 is \" lol", "other ' value"]
   end
@@ -100,6 +94,6 @@ class SearchParserTest < ActiveSupport::TestCase
   test 'allows - in prefix' do
     query = '-repo:octobox/octobox,foo/bar'
     search = SearchParser.new query
-    assert_equal search[:'-repo'], ['octobox/octobox','foo/bar'] 
+    assert_equal search[:'-repo'], ['octobox/octobox','foo/bar']
   end
 end

--- a/test/models/notification_test.rb
+++ b/test/models/notification_test.rb
@@ -157,7 +157,7 @@ class NotificationTest < ActiveSupport::TestCase
 
     api_response = notifications_from_fixture('morty_notifications.json').second
     notification_updated_at = Time.parse(api_response.updated_at)
-    user = create(:morty)
+    create(:morty)
     subject = create(:subject, url: url, updated_at: (notification_updated_at - 1.seconds))
     notification = create(:morty_updated, updated_at: (notification_updated_at - 1.minute), subject_url: url)
     notification.update_from_api_response(api_response, unarchive: true)
@@ -175,7 +175,7 @@ class NotificationTest < ActiveSupport::TestCase
 
     api_response = notifications_from_fixture('morty_notifications.json').second
     notification_updated_at = Time.parse(api_response.updated_at)
-    user = create(:morty)
+    create(:morty)
     subject = create(:subject, url: url, updated_at: (notification_updated_at - 5.seconds))
     notification = create(:morty_updated, updated_at: (notification_updated_at - 1.minute), subject_url: url)
     notification.update_from_api_response(api_response, unarchive: true)
@@ -228,7 +228,7 @@ class NotificationTest < ActiveSupport::TestCase
 
     api_response = notifications_from_fixture('morty_notifications.json').third
     notification_updated_at = Time.parse(api_response.updated_at)
-    user = create(:morty)
+    create(:morty)
     subject = create(:subject, state: 'open', url: url, updated_at: (notification_updated_at - 5.seconds))
     notification = create(:morty_updated, updated_at: (notification_updated_at - 1.minute), subject_url: url)
     notification.update_from_api_response(api_response, unarchive: true)

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -33,7 +33,7 @@ class RepositoryTest < ActiveSupport::TestCase
 
   test 'finds subjects by full_name' do
     subject = create(:subject, url: "https://api.github.com/repos/#{@repository.full_name}/issues/1", repository_full_name: @repository.full_name)
-    subject2 = create(:subject, url: "https://api.github.com/repos/foo/bar/issues/1", repository_full_name: 'foo/bar')
+    create(:subject, url: "https://api.github.com/repos/foo/bar/issues/1", repository_full_name: 'foo/bar')
     assert_equal @repository.subjects.length, 1
     assert_equal @repository.subjects.first, subject
   end


### PR DESCRIPTION
Tried running `rubocop --auto-correct` on the repo and this was the result, also added the `TargetRubyVersion` as recommended by @schneems in https://schneems.com/2018/10/09/pair-with-me-rubocop-cop-that-detects-duplicate-array-allocations/