### PR TITLE
Fix some cases of incorrect conversion from params to search query

### DIFF
--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -68,10 +68,17 @@ class Search
     @parsed_query[:archived] = ['true'] if params[:archive].present?
     @parsed_query[:inbox] = ['true'] if params[:archive].blank? && params[:starred].blank? && params[:q].blank?
 
-    [:repo, :reason, :type, :unread, :owner, :state, :author, :is_private, :assigned, :label].each do |filter|
+    [:reason, :type, :unread, :state, :is_private].each do |filter|
       next if params[filter].blank?
       @parsed_query[filter] = Array(params[filter]).map(&:underscore)
     end
+
+    [:repo, :owner, :author, :label].each do |filter|
+      next if params[filter].blank?
+      @parsed_query[filter] = Array(params[filter])
+    end
+
+    @parsed_query[:assignee] = Array(params[:assigned]) if params[:assigned].present?
   end
 
   def lock_conditionally(scope)

--- a/test/models/search_test.rb
+++ b/test/models/search_test.rb
@@ -20,4 +20,29 @@ class SearchTest < ActiveSupport::TestCase
     search = Search.new(query: '-org:octobox', scope: Notification.all)
     assert_equal search.send(:exclude_owner), ['octobox']
   end
+
+  test 'converts assigned params to assignee prefix' do
+    search = Search.new(query: 'inbox:true', scope: Notification.all, params: {assigned: 'andrew'})
+    assert_equal search.to_query, 'inbox:true assignee:andrew'
+  end
+
+  test 'converts repo params to repo prefix without changing it' do
+    search = Search.new(query: 'inbox:true', scope: Notification.all, params: {repo: 'CamelCase/RepoName'})
+    assert_equal search.to_query, 'inbox:true repo:CamelCase/RepoName'
+  end
+
+  test 'converts owner params to owner prefix without changing it' do
+    search = Search.new(query: 'inbox:true', scope: Notification.all, params: {owner: 'OwnerName'})
+    assert_equal search.to_query, 'inbox:true owner:OwnerName'
+  end
+
+  test 'converts author params to author prefix without changing it' do
+    search = Search.new(query: 'inbox:true', scope: Notification.all, params: {author: 'AuthorName'})
+    assert_equal search.to_query, 'inbox:true author:AuthorName'
+  end
+
+  test 'converts label params to label prefix without changing it' do
+    search = Search.new(query: 'inbox:true', scope: Notification.all, params: {label: 'LabelName'})
+    assert_equal search.to_query, 'inbox:true label:LabelName'
+  end
 end


### PR DESCRIPTION
- assigned should be converted to assignee
- repo, owner, author, label and assignee shouldn't be underscored

Related to #1071