### PR TITLE
Prompt users to log into the GitHub App

### DIFF
--- a/app/views/notifications/_login_prompt.html.erb
+++ b/app/views/notifications/_login_prompt.html.erb
@@ -1,0 +1,5 @@
+<p>
+  The GitHub App is installed on this repository, authorize it to see state, labels, authors, assignees and CI status on this notification.
+</p>
+
+<a href='/auth/githubapp' class='btn btn-primary btn-sm'>Login to the GitHub App</a>

--- a/app/views/notifications/_notification.html.erb
+++ b/app/views/notifications/_notification.html.erb
@@ -26,7 +26,11 @@
 
   <td class='notification-icon align-middle <%= notification_icon_color(notification.state) if notification.display_subject? %>'>
     <% if Octobox.github_app? && notification.subjectable? %>
-      <% if !notification.repository.try(:github_app_installed?) %>
+      <% if notification.repository.try(:github_app_installed?) && !current_user.github_app_authorized? %>
+        <a tabindex="0" class="" role="button" data-toggle="popover" title="Login to the GitHub App" data-content="<%= render 'login_prompt' %>">
+          <%= octicon notification_icon(notification.subject_type, notification.state), :height => 16 %>
+        </a>
+      <% elsif !notification.repository.try(:github_app_installed?) %>
         <a tabindex="0" class="" role="button" data-toggle="popover" title="Get more info for this <%= notification_icon_title(notification.subject_type, notification.state) %>" data-content="<%= render 'app_prompt', notification: notification %>">
           <%= octicon notification_icon(notification.subject_type, notification.state), :height => 16 %>
         </a>


### PR DESCRIPTION
If users have notifications from repositories that have the app installed, we need them to log into the GitHub app so we can see if they can access that installation.

Very helpful for other team members who don't need to install the app but need to login to authorize it.