### PR TITLE
Push notification changes directly to the browser

### DIFF
--- a/app/assets/javascripts/cable.js
+++ b/app/assets/javascripts/cable.js
@@ -1,0 +1,13 @@
+// Action Cable provides the framework to deal with WebSockets in Rails.
+// You can generate new channels where WebSocket features live using the `rails generate channel` command.
+//
+//= require action_cable
+//= require_self
+//= require_tree ./channels
+
+(function() {
+  this.App || (this.App = {});
+
+  App.cable = ActionCable.createConsumer();
+
+}).call(this);

--- a/app/assets/javascripts/channels/sync.js
+++ b/app/assets/javascripts/channels/sync.js
@@ -1,0 +1,16 @@
+$(document).on("turbolinks:load", function () {
+  if ($("meta[name='push_notifications']").length >0) {
+    App.sync = App.cable.subscriptions.create("NotificationsChannel", {
+      received: function(data) {
+        if($(data.id).length) {
+          var selected = $(data.id).has("input:checked");
+
+          $(data.id)[0].outerHTML = data.html;
+          if (selected.length) {
+            $(data.id).find("input[type=checkbox]").prop('checked', true);
+          }
+        }
+      }
+    });
+  }
+});

--- a/app/assets/stylesheets/_notifications.scss
+++ b/app/assets/stylesheets/_notifications.scss
@@ -12,6 +12,12 @@ $notification-items: (
 .table-notifications {
   td{
     padding: 0.6rem;
+    &.notification-archived, .notification-repo{
+      padding: 0;
+      svg, small{
+        margin: 0.6rem;
+      }
+    }
   }
   .active {
     font-weight: bold;

--- a/app/channels/application_cable/channel.rb
+++ b/app/channels/application_cable/channel.rb
@@ -1,0 +1,4 @@
+module ApplicationCable
+  class Channel < ActionCable::Channel::Base
+  end
+end

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,0 +1,19 @@
+module ApplicationCable
+  class Connection < ActionCable::Connection::Base
+    identified_by :current_user
+
+    def connect
+      self.current_user = find_verified_user
+    end
+
+    private
+
+    def find_verified_user
+      if current_user = User.find_by(id: cookies.permanent.signed[:user_id])
+        current_user
+      else
+        reject_unauthorized_connection
+      end
+    end
+  end
+end

--- a/app/channels/notifications_channel.rb
+++ b/app/channels/notifications_channel.rb
@@ -1,0 +1,9 @@
+class NotificationsChannel < ApplicationCable::Channel
+  def subscribed
+    stream_from "notifications:#{current_user.id}"
+  end
+
+  def unsubscribed
+    stop_all_streams
+  end
+end

--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -156,10 +156,15 @@ module NotificationsHelper
     notification_param_keys.all?{|param| params[param].blank? }
   end
 
-  def notification_icon(subject_type, state = nil)
-    state = nil unless display_subject?
+  def notification_icon(notification)
+    subject_type = notification.subject_type
+    state = notification.user.github_app_authorized? ? notification.state : nil
     return 'issue-closed' if subject_type == 'Issue' && state == 'closed'
     return 'git-merge' if subject_type == 'PullRequest' && state == 'merged'
+    subject_type_icon(subject_type)
+  end
+
+  def subject_type_icon(subject_type)
     SUBJECT_TYPES[subject_type]
   end
 

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -34,6 +34,8 @@ class Notification < ApplicationRecord
   validates :subject_url, presence: true
   validates :archived, inclusion: [true, false]
 
+  after_update :push_if_changed
+
   paginates_per 20
 
   class << self
@@ -171,5 +173,18 @@ class Notification < ApplicationRecord
 
   def display_thread?
     Octobox.include_comments? && subjectable? && subject.present? && user.display_comments?
+  end
+
+  def push_if_changed
+    push_to_channel if (saved_changes.keys & pushable_fields).any?
+  end
+
+  def pushable_fields
+    ['archived', 'reason', 'subject_title', 'subject_url', 'subject_type', 'unread']
+  end
+
+  def push_to_channel
+    string = ApplicationController.render(partial: 'notifications/notification', locals: { notification: self})
+    ActionCable.server.broadcast "notifications:#{user_id}", { id: "#notification-#{id}", html: string }
   end
 end

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -15,6 +15,7 @@ class Subject < ApplicationRecord
   validates :url, presence: true, uniqueness: true
 
   after_update :sync_involved_users
+  after_save :push_to_channels
 
   def update_labels(remote_labels)
     existing_labels = labels.to_a
@@ -37,6 +38,7 @@ class Subject < ApplicationRecord
     remote_label_ids = remote_labels.map{|l| l['id'] }
     deleted_labels = existing_labels.reject{|l| remote_label_ids.include?(l.github_id) }
     deleted_labels.each(&:destroy)
+    push_to_channels if existing_labels != labels.to_a
   end
 
   def sync_involved_users
@@ -116,12 +118,20 @@ class Subject < ApplicationRecord
       end
     end
   end
-  
+
   def notifiable_fields
     ['state', 'assignees', 'locked', 'sha', 'comment_count']
   end
 
+  def push_to_channels
+    notifications.find_each(&:push_to_channel) if (saved_changes.keys & pushable_fields).any?
+  end
+
   private
+
+  def pushable_fields
+    ['state', 'status', 'body']
+  end
 
   def assign_status(remote_status)
     if remote_status.state == 'pending'

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -38,6 +38,10 @@
 
     <meta name="twitter:card" content="summary">
     <meta name="twitter:creator" content="teabass">
+
+    <% if Octobox.config.push_notifications && logged_in? %>
+      <meta name="push_notifications" content="true">
+    <% end %>
   </head>
 
   <body>

--- a/app/views/notifications/_notification.html.erb
+++ b/app/views/notifications/_notification.html.erb
@@ -16,33 +16,31 @@
     <%= octicon 'star', height: 18, class: "toggle-star #{notification.starred ? 'star-active' : 'star-inactive'}", data: { id: notification.id, toggle: 'tooltip' }, title: notification.starred ? 'Remove star' : 'Star' %>
   </td>
 
-  <% if show_archive_icon? %>
-    <td class='notification-archived align-middle'>
-      <% if notification.archived? %>
-        <%= octicon 'archive', height: 16, data: { toggle: 'tooltip' }, title: 'Archived' %>
-      <% end %>
-    </td>
-  <% end %>
+  <td class='notification-archived align-middle'>
+    <% if notification.archived? %>
+      <%= octicon 'archive', height: 16, data: { toggle: 'tooltip' }, title: 'Archived' %>
+    <% end %>
+  </td>
 
   <td class='notification-icon align-middle <%= notification_icon_color(notification.state) if notification.display_subject? %>'>
     <% if Octobox.github_app? && notification.subjectable? %>
-      <% if notification.repository.try(:github_app_installed?) && !current_user.github_app_authorized? %>
-        <a tabindex="0" class="" role="button" data-toggle="popover" title="Login to the GitHub App" data-content="<%= render 'login_prompt' %>">
-          <%= octicon notification_icon(notification.subject_type, notification.state), :height => 16 %>
+      <% if notification.repository.try(:github_app_installed?) && !notification.user.github_app_authorized? %>
+        <a tabindex="0" class="" role="button" data-toggle="popover" title="Login to the GitHub App" data-content="<%= render 'notifications/login_prompt' %>">
+          <%= octicon notification_icon(notification), :height => 16 %>
         </a>
       <% elsif !notification.repository.try(:github_app_installed?) %>
-        <a tabindex="0" class="" role="button" data-toggle="popover" title="Get more info for this <%= notification_icon_title(notification.subject_type, notification.state) %>" data-content="<%= render 'app_prompt', notification: notification %>">
-          <%= octicon notification_icon(notification.subject_type, notification.state), :height => 16 %>
+        <a tabindex="0" class="" role="button" data-toggle="popover" title="Get more info for this <%= notification_icon_title(notification.subject_type, notification.state) %>" data-content="<%= render 'notifications/app_prompt', notification: notification %>">
+          <%= octicon notification_icon(notification), :height => 16 %>
         </a>
       <% elsif Octobox.octobox_io? && notification.upgrade_required? %>
-        <a tabindex="0" class="" role="button" data-toggle="popover" title="Subscribe Now" data-content="<%= render 'private_repos' %>">
-          <%= octicon notification_icon(notification.subject_type, notification.state), :height => 16 %>
+        <a tabindex="0" class="" role="button" data-toggle="popover" title="Subscribe Now" data-content="<%= render 'notifications/private_repos' %>">
+          <%= octicon notification_icon(notification), :height => 16 %>
         </a>
       <% else %>
-        <%= octicon notification_icon(notification.subject_type, notification.state), :height => 16, title: notification_icon_title(notification.subject_type, notification.state), data: {toggle: 'tooltip'} %>
+        <%= octicon notification_icon(notification), :height => 16, title: notification_icon_title(notification.subject_type, notification.state), data: {toggle: 'tooltip'} %>
       <% end %>
     <% else %>
-      <%= octicon notification_icon(notification.subject_type, notification.state), :height => 16, title: notification_icon_title(notification.subject_type, notification.state), data: {toggle: 'tooltip'} %>
+      <%= octicon notification_icon(notification), :height => 16, title: notification_icon_title(notification.subject_type, notification.state), data: {toggle: 'tooltip'} %>
     <% end %>
   </td>
   <td class='notification-subject'>
@@ -60,13 +58,14 @@
       <% end %>
     <% end %>
   </td>
-  <% unless params[:repo].present? %>
-    <td class='notification-repo'>
+
+  <td class='notification-repo'>
+    <% unless params[:repo].present? %>
       <small>
         <%= link_to notification.repository_full_name, root_path(filtered_params(repo: notification.repository_full_name)), class: 'text-muted' %>
       </small>
-    </td>
-  <% end %>
+    <% end %>
+  </td>
 
   <td class='notification-subject-author'>
     <% if notification.display_subject? %>

--- a/app/views/notifications/_sidebar.html.erb
+++ b/app/views/notifications/_sidebar.html.erb
@@ -106,10 +106,10 @@
   <ul class="nav nav-pills flex-column nav-filters">
     <% @types.sort_by{|type, count| type.downcase }.each do |type, count| %>
       <%= filter_link :type, type, count do %>
-        <% if notification_icon(type).nil? %>
+        <% if subject_type_icon(type).nil? %>
             <span class='sidebar-icon'></span>
         <% else %>
-            <%= octicon notification_icon(type), height: 16, class: 'sidebar-icon' %>
+            <%= octicon subject_type_icon(type), height: 16, class: 'sidebar-icon' %>
         <% end %>
         <%= type.underscore.gsub('repository', '').humanize %>
 

--- a/app/views/notifications/_thread.html.erb
+++ b/app/views/notifications/_thread.html.erb
@@ -29,7 +29,7 @@
 
   <h2>
     <button class='btn btn-sm <%= notification_button_color(@notification.state) if display_subject? %>'>
-      <%= octicon notification_icon(@notification.subject_type, @notification.state), :height => 16, title: notification_icon_title(@notification.subject_type, @notification.state), data: {toggle: 'tooltip'} %>
+      <%= octicon notification_icon(@notification), :height => 16, title: notification_icon_title(@notification.subject_type, @notification.state), data: {toggle: 'tooltip'} %>
       <%= notification_button_title(@notification.subject_type, @notification.state) %>
     </button>
     <%= @notification.subject_title %> &nbsp

--- a/config/application.rb
+++ b/config/application.rb
@@ -9,6 +9,7 @@ require "rails"
   action_view/railtie
   rails/test_unit/railtie
   sprockets/railtie
+  action_cable/engine
 ).each do |railtie|
   begin
     require railtie

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,0 +1,12 @@
+# Action Cable uses Redis by default to administer connections, channels,
+#  and sending/receiving messages over the WebSocket.
+
+production:
+  adapter: redis
+  url: <%=ENV['REDIS_URL']%>
+
+development:
+  adapter: redis
+
+test:
+  adapter: async

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,8 @@ Rails.application.routes.draw do
     get '/admin', to: 'admin#index', as: :admin
   end
 
+  mount ActionCable.server => '/cable'
+
   get :login,  to: 'sessions#new'
   get :logout, to: 'sessions#destroy'
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -31,6 +31,7 @@ in your GitHub settings for Octobox to work.
 * [Google Analytics](#google-analytics)
 * [Running Octobox as a GitHub App](#running-octobox-as-a-github-app)
 * [Open links in the same tab](#open-links-in-the-same-tab)
+* [Live updates](#live-updates)
 
 # Installation
 ## Database Selection
@@ -423,3 +424,9 @@ If you wish to run the GitHub app locally and still recieve webhook events, use 
 If you use Octobox inside of [Wavebox](https://wavebox.io/), [Franz](https://meetfranz.com/) or [Station](https://getstation.com/), you may find the default behaviour of opening notification links in new tabs annoying.
 
 You can set the `OPEN_IN_SAME_TAB` environment variable, which will force all notification links to open in the same tab rather than new ones.
+
+## Live updates
+
+Octobox has an experimental feature where it can live-update notifications when they change using websockets. Only notifications you are currently viewing will be updated, no rows will be added or removed dynamically.
+
+To enable this set the environment variable `PUSH_NOTIFICATIONS` to `true` and ensure you have redis configured for your instance.

--- a/lib/octobox/configurator.rb
+++ b/lib/octobox/configurator.rb
@@ -188,6 +188,11 @@ module Octobox
     end
     attr_writer :include_comments
 
+    def push_notifications
+      @push_notifications || ENV['PUSH_NOTIFICATIONS']
+    end
+    attr_writer :push_notifications
+
     private
 
     def env_boolean(env_var_name)


### PR DESCRIPTION
Now that we've got a lot of people running on the GitHub App, we can make use of the webhooks that we receive from GitHub, updating issues and pull request states, CI statuses, labels etc and update them live in the page as soon as we hear about them.

![untitled](https://user-images.githubusercontent.com/1060/46746686-789d9c80-cca7-11e8-90bd-d34c0f433852.gif)

This won't add or remove notifications from the page that a user is currently on, or update the sidebar, it just updates a row if something has changed, saving the user having to refresh the page to see if everything is up to date.

TODO:

- [x] Work out what's needed to deploy to heroku
- [x] Only push updates if the records have actually changed in a meaningful way
- [x] Make this opt-in for self-hosted installations
- [x] Documentation
- [x] If a row is selected, either make sure it remains selected after updating, or don't update it
- [x] Push updates when labels are added/removed/updated
