### PR TITLE
Sync subject body for issues and pull requests

### DIFF
--- a/db/migrate/20181012130339_add_body_to_subjects.rb
+++ b/db/migrate/20181012130339_add_body_to_subjects.rb
@@ -1,0 +1,5 @@
+class AddBodyToSubjects < ActiveRecord::Migration[5.2]
+  def change
+    add_column :subjects, :body, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_05_090055) do
+ActiveRecord::Schema.define(version: 2018_10_12_130339) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -109,6 +109,7 @@ ActiveRecord::Schema.define(version: 2018_10_05_090055) do
     t.boolean "locked"
     t.string "sha"
     t.string "status"
+    t.text "body"
     t.index ["url"], name: "index_subjects_on_url"
   end
 

--- a/lib/octobox/notifications/sync_subject.rb
+++ b/lib/octobox/notifications/sync_subject.rb
@@ -32,6 +32,7 @@ module Octobox
             subject.assignees = ":#{Array(remote_subject.assignees.try(:map, &:login)).join(':')}:"
             subject.state = remote_subject.merged_at.present? ? SUBJECT_STATE_MERGED : remote_subject.state
             subject.sha = remote_subject.head&.sha
+            subject.body = remote_subject.body
             subject.save(touch: false) if subject.changed?
           end
         else
@@ -47,6 +48,7 @@ module Octobox
               updated_at: remote_subject.updated_at,
               assignees: ":#{Array(remote_subject.assignees.try(:map, &:login)).join(':')}:",
               locked: remote_subject.locked,
+              body: remote_subject.body,
               sha: remote_subject.head&.sha
             })
           when *SUBJECT_TYPE_COMMIT_RELEASE


### PR DESCRIPTION
Extracted as part of https://github.com/octobox/octobox/pull/709

Stores the issue/pr body, which shows up in the GitHub UI as the first comment.