### PR TITLE
Ensure locked field is updated when existing subjects are updated

### DIFF
--- a/lib/octobox/notifications/sync_subject.rb
+++ b/lib/octobox/notifications/sync_subject.rb
@@ -32,6 +32,7 @@ module Octobox
             subject.assignees = ":#{Array(remote_subject.assignees.try(:map, &:login)).join(':')}:"
             subject.state = remote_subject.merged_at.present? ? SUBJECT_STATE_MERGED : remote_subject.state
             subject.sha = remote_subject.head&.sha
+            subject.locked = remote_subject.locked
             subject.save(touch: false) if subject.changed?
           end
         else


### PR DESCRIPTION
Previously we we're only setting the `locked` field when first creating the subject in the database, so we never updated the `locked` field once an existing subject became locked 🙈 