### PR TITLE
Show first few lines of issue/pr body as title on notification links

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -51,6 +51,11 @@ class Notification < ApplicationRecord
     end
   end
 
+  def title
+    body = subject.try(:body)
+    body.split("\n")[0..3].join if body
+  end
+
   def state
     return unless display_subject?
     subject.try(:state)

--- a/app/views/notifications/_notification.html.erb
+++ b/app/views/notifications/_notification.html.erb
@@ -46,7 +46,7 @@
     <% end %>
   </td>
   <td class='notification-subject'>
-    <%= link_to notification.subject_title, notification.web_url, target: (Octobox.config.open_in_same_tab ? nil : '_blank'), rel: "noopener", class: 'link', onclick: "Octobox.markRead(#{notification.id})" %>
+    <%= link_to notification.subject_title, notification.web_url, target: (Octobox.config.open_in_same_tab ? nil : '_blank'), rel: "noopener", class: 'link', onclick: "Octobox.markRead(#{notification.id})", title: notification.title %>
 
     <% if notification.display_subject? %>
       <% if notification.subject %>


### PR DESCRIPTION
Follow up from https://github.com/octobox/octobox/pull/1094

Adds a handy hover title on notification links when the body is present for quick access:

![screen shot 2018-10-12 at 16 20 40](https://user-images.githubusercontent.com/1060/46879606-62761480-ce3e-11e8-9adc-dc330a302496.png)
