### PR TITLE
 Fix sync_repositories method on AppInstallation 

### DIFF
--- a/app/models/app_installation.rb
+++ b/app/models/app_installation.rb
@@ -54,11 +54,14 @@ class AppInstallation < ApplicationRecord
   end
 
   def sync_repositories
-    installation_client(self.github_id)
-    remote_repositories = client.list_app_installation_repositories.repositories
+    remote_repositories = github_client.list_app_installation_repositories.repositories
     add_repositories(remote_repositories)
   rescue Octokit::ClientError
     nil
+  end
+
+  def github_client
+    Octobox.installation_client(self.github_id)
   end
 
   def self.map_from_api(remote_installation)

--- a/app/models/app_installation.rb
+++ b/app/models/app_installation.rb
@@ -21,7 +21,7 @@ class AppInstallation < ApplicationRecord
         app_installation_id: self.id
       })
 
-      repository.notifications.includes(:user).find_each{|n| n.update_subject(true) }
+      repository.notifications.includes(:user, :subject, :repository).find_each{|n| n.update_subject(true) }
     end
   end
 


### PR DESCRIPTION
I broke this in a refactor last week, but it's only used in the console at the moment so little harm done.