### PR TITLE
Gracefully handle subject syncing jobs where the notification has been deleted

### DIFF
--- a/app/workers/update_subject_worker.rb
+++ b/app/workers/update_subject_worker.rb
@@ -5,6 +5,6 @@ class UpdateSubjectWorker
   sidekiq_options queue: :sync_subjects, unique: :until_and_while_executing
 
   def perform(notification_id, force = false)
-    Notification.find(notification_id).try(:update_subject_in_foreground, force)
+    Notification.find_by_id(notification_id).try(:update_subject_in_foreground, force)
   end
 end


### PR DESCRIPTION
Usually occurs when someone deletes their account whilst there are still jobs in the queue.