### PR TITLE
Only attempt to update labels and state if subject has been saved

### DIFF
--- a/lib/octobox/notifications/sync_subject.rb
+++ b/lib/octobox/notifications/sync_subject.rb
@@ -72,8 +72,9 @@ module Octobox
           end
         end
 
-        update_labels(remote_subject)
+        return unless persisted?
 
+        update_labels(remote_subject)
         subject&.update_status
       end
 


### PR DESCRIPTION
Avoids ActiveRecord::RecordNotSaved errors when syncing labels on invalid subjects