### PR TITLE
Allow syncing of private repository subjects even if can't display them

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -145,7 +145,7 @@ class Notification < ApplicationRecord
   end
 
   def github_app_installed?
-    Octobox.github_app? && user.github_app_authorized? && repository.try(:display_subject?)
+    Octobox.github_app? && user.github_app_authorized? && repository.try(:github_app_installed?)
   end
 
   def subjectable?
@@ -153,7 +153,11 @@ class Notification < ApplicationRecord
   end
 
   def display_subject?
-    @display_subject ||= subjectable? && (Octobox.fetch_subject? || github_app_installed?)
+    @display_subject ||= subjectable? && (Octobox.fetch_subject? || (github_app_installed? && repository.display_subject?))
+  end
+
+  def download_subject?
+    @download_subject ||= subjectable? && (Octobox.fetch_subject? || github_app_installed?)
   end
 
   def upgrade_required?

--- a/lib/octobox/notifications/sync_subject.rb
+++ b/lib/octobox/notifications/sync_subject.rb
@@ -11,14 +11,14 @@ module Octobox
       SUBJECT_STATE_MERGED = 'merged'.freeze
 
       def update_subject(force = false)
-        return unless display_subject?
+        return unless download_subject?
         return if !force && subject != nil && updated_at - subject.updated_at < 2.seconds
 
         UpdateSubjectWorker.perform_async_if_configured(self.id, force)
       end
 
       def update_subject_in_foreground(force = false)
-        return unless display_subject?
+        return unless download_subject?
         # skip syncing if the notification was updated around the same time as subject
         return if !force && subject != nil && updated_at - subject.updated_at < 2.seconds
 


### PR DESCRIPTION
This means we can instantly enable private repository subject data as soon as a user upgrades rather than needing to resync.