### PR TITLE
WIP: Add setting to disable github app reminders

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -105,6 +105,6 @@ class UsersController < ApplicationController
       params[:user][:personal_access_token] = nil
     end
 
-    params.require(:user).permit(:personal_access_token, :refresh_interval, :theme)
+    params.require(:user).permit(:personal_access_token, :refresh_interval, :theme, :show_app_banner)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,6 +36,10 @@ class User < ApplicationRecord
     encrypted_app_token.present?
   end
 
+  def should_show_app_tooltips?
+    show_app_banner
+  end
+
   def refresh_interval=(val)
     val = nil if 0 == val
     super(val)

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -37,7 +37,7 @@
   <div class="user-info collapse navbar-collapse justify-content-end" id="navbarNav">
     <ul class="navbar-nav">
       <li class="nav-item nav-link d-none d-md-block">
-        <% if Octobox.octobox_io? %>
+        <% if Octobox.octobox_io? && current_user.should_show_app_tooltips? %>
           <a href="<%= Octobox.config.app_url %>" class='btn btn-sm btn-outline-light'>
             <%= octicon 'briefcase', height: 16, class: 'mr-1' %>
             Install the GitHub App

--- a/app/views/notifications/_notification.html.erb
+++ b/app/views/notifications/_notification.html.erb
@@ -25,7 +25,7 @@
   <% end %>
 
   <td class='notification-icon align-middle <%= notification_icon_color(notification.state) if notification.display_subject? %>'>
-    <% if Octobox.github_app? && notification.subjectable? %>
+    <% if Octobox.github_app? && notification.subjectable? && current_user.should_show_app_tooltips? %>
       <% if notification.repository.try(:github_app_installed?) && !current_user.github_app_authorized? %>
         <a tabindex="0" class="" role="button" data-toggle="popover" title="Login to the GitHub App" data-content="<%= render 'login_prompt' %>">
           <%= octicon notification_icon(notification.subject_type, notification.state), :height => 16 %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -56,6 +56,27 @@
   </div>
 
   <%= form_for current_user do |f| %>
+    <% if Octobox.github_app? %>
+      <div class="card mb-3">
+        <h5 class="card-header">
+          GitHub App Reminders
+        </h5>
+        <div class="card-body">
+          <div class="form-group">
+            <div class="checkbox">
+              <label>
+                <%= f.check_box :show_app_banner, value: current_user[:show_app_banner] %>
+                Show reminders to install the GitHub app throughout Octobox
+              </label>
+            </div>
+
+            <%= submit_tag 'Save', class: 'btn btn-primary' %>
+            <%= link_to 'Cancel', root_path, class: 'btn btn-light' %>
+          </div>
+        </div>
+      </div>
+    <% end %>
+
     <% if Octobox.refresh_interval_enabled? || Octobox.personal_access_tokens_enabled? %>
       <% if Octobox.refresh_interval_enabled? %>
         <div class="card mb-3">

--- a/db/migrate/20181020075935_add_show_app_banner_flag_to_users.rb
+++ b/db/migrate/20181020075935_add_show_app_banner_flag_to_users.rb
@@ -1,0 +1,5 @@
+class AddShowAppBannerFlagToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :show_app_banner, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_18_095459) do
+ActiveRecord::Schema.define(version: 2018_10_20_075935) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -155,6 +155,7 @@ ActiveRecord::Schema.define(version: 2018_10_18_095459) do
     t.string "encrypted_app_token"
     t.string "encrypted_app_token_iv"
     t.string "theme", default: "light"
+    t.boolean "show_app_banner", default: true
     t.index ["api_token"], name: "index_users_on_api_token", unique: true
     t.index ["github_id"], name: "index_users_on_github_id", unique: true
   end


### PR DESCRIPTION
This adds a user configurable setting that permits disabling the GitHub
app installation banner on the navbar as well as the tooltips in the
notification index.

It makes the UI less cluttered for people who won't install the app.

While "feature complete," I've marked this PR as WIP because I want positive confirmation that this is the way to go. I don't want to write tests for something if I'm not following a convention and everything needs to be reworked in the future. Can I get some feedback on if this is the right way to go, and whether or not I should go ahead and add tests for it?