### PR TITLE
Allow configuration of app path for Github Enterprise installs

### DIFF
--- a/lib/octobox/configurator.rb
+++ b/lib/octobox/configurator.rb
@@ -131,7 +131,12 @@ module Octobox
     end
 
     def app_url
-      "#{github_domain}/apps/#{app_slug}"
+      "#{github_domain}/#{app_path}/#{app_slug}"
+    end
+
+    def app_path
+      env_value = ENV['GITHUB_APP_PATH'].blank? ? nil : ENV['GITHUB_APP_PATH']
+      @app_path || env_value || 'apps'
     end
 
     def app_slug


### PR DESCRIPTION
Fixes #1147 

`GITHUB_APP_PATH` can be set to override the `/app/` segment in `https://github.com/apps/octobox`