### PR TITLE
Ignore pending marketplace webhook actions for now

### DIFF
--- a/app/controllers/hooks_controller.rb
+++ b/app/controllers/hooks_controller.rb
@@ -23,7 +23,7 @@ class HooksController < ApplicationController
     when 'github_app_authorization'
       SyncGithubAppAuthorizationWorker.perform_async_if_configured(payload['sender']['id'])
     when 'marketplace_purchase'
-      MarketplacePurchaseWorker.perform_async_if_configured(payload)
+      MarketplacePurchaseWorker.perform_async_if_configured(payload)  if ['purchased', 'cancelled', 'changed'].include?(payload['action'])
     when 'status'
       SyncStatusWorker.perform_async_if_configured(payload['sha'], payload['name'])
     when 'repository'


### PR DESCRIPTION
Ignores the new pending_* action webhooks because we actively want to ignore them at the moment