### PR TITLE
Only download status if there's a valid github client available

### DIFF
--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -105,6 +105,7 @@ class Subject < ApplicationRecord
   end
 
   def download_status
+    return unless github_client
     github_client.combined_status(repository_full_name, sha)
   rescue Octokit::ClientError
     nil


### PR DESCRIPTION
Avoids a `undefined method `combined_status' for nil:NilClass` error when syncing some subjects that don't have a user with a token available to sync the status.