### PR TITLE
Send people to the GitHub Marketplace if MARKETPLACE_URL is present

### DIFF
--- a/lib/octobox/configurator.rb
+++ b/lib/octobox/configurator.rb
@@ -127,11 +127,19 @@ module Octobox
     attr_writer :source_repo
 
     def app_install_url
-      "#{app_url}/installations/new"
+      if marketplace_url.present?
+        marketplace_url
+      else
+        "#{app_url}/installations/new"
+      end
     end
 
     def app_url
-      "#{github_domain}/#{app_path}/#{app_slug}"
+      if marketplace_url.present?
+        marketplace_url
+      else
+        "#{github_domain}/#{app_path}/#{app_slug}"
+      end
     end
 
     def app_path


### PR DESCRIPTION
Getting ready to launch on the GitHub Marketplace tomorrow, this changes links to install the GitHub app to point to the marketplace page if it's present, which I'll add on Octobox once it's public. 🎉 