### PR TITLE
Visual fixes

### DIFF
--- a/app/assets/stylesheets/_application.scss
+++ b/app/assets/stylesheets/_application.scss
@@ -75,9 +75,11 @@
   }
 }
 
-.list-group-flush .list-group-item{
-  padding: 0rem;
-  border: 0;
+.pricing.card{
+  .list-group-flush .list-group-item{
+    padding: 0rem;
+    border: 0;
+  }
 }
 
 .select-all {

--- a/app/assets/stylesheets/_layout.scss
+++ b/app/assets/stylesheets/_layout.scss
@@ -81,6 +81,10 @@ body {
   max-width: 48rem;
 }
 
+.pricing.card{
+  margin: 1rem;
+}
+
 .footer {
   text-align: center;
   color: $text-muted;
@@ -90,6 +94,13 @@ body {
 }
 
 @mixin responsive{
+
+  .container{
+    padding: 0 1rem;
+    overflow-y: scroll;
+    -webkit-overflow-scrolling: touch;
+  }
+
   .flex-main{
     height: 100%;
     overflow-y: scroll;
@@ -108,11 +119,6 @@ body {
     }
   }
 
-  .text-content{
-    padding: 0 15px;
-    
-  }
-
   .flex-sidebar {
     position: absolute;
     // enable momentum scrolling on mobile safari
@@ -122,6 +128,10 @@ body {
     top: 0;
     width: $sidebar-width;
     left: -$sidebar-width;
+  }
+
+  .pricing.card{
+    margin: 1rem 0;
   }
 }
 

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,4 +1,4 @@
-<div class="footer text-muted small mt-3">
+<div class="footer text-muted small pt-3">
   <p>
     © 2018 <a href='https://github.com/andrew' >Andrew Nesbitt</a>,
     <%= link_to 'et al', "#{Octobox.config.source_repo}/graphs/contributors", target: '_blank', rel: "noopener" %>

--- a/app/views/pages/_github.html.erb
+++ b/app/views/pages/_github.html.erb
@@ -1,4 +1,4 @@
-<div class="pricing card mx-3 shadow p-3 mb-5 bg-white rounded text-muted">
+<div class="pricing card shadow p-3 bg-white rounded text-muted">
   <%= render('pages/ribbon')%>
   <div class="card-body">
   	<p class='text-muted'>GitHub Marketplace - coming soon</p>

--- a/app/views/pages/_opencollective.html.erb
+++ b/app/views/pages/_opencollective.html.erb
@@ -1,4 +1,4 @@
-<div class="pricing card mx-3 shadow p-3 mb-5 bg-white rounded">
+<div class="pricing card shadow p-3 bg-white rounded">
   <%= render('pages/ribbon') %>
   <div class="card-body">
   	<p class='text-muted'>Open Collective</p>

--- a/app/views/pages/documentation.html.erb
+++ b/app/views/pages/documentation.html.erb
@@ -1,4 +1,5 @@
 <div class='flex-content'>
+
   <div class="flex-sidebar">
     <div id='sidebar' class="list-group list-group-flush flex-column pt-5">
       <a class='list-group-item list-group-item-action' href='#documentation'>Documentation</a>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,11 +1,11 @@
 <div class="container readable">
 
-  <h1 class="text-center mt-5"><%= octobox_round(80) %> <span class='align-middle'>Octobox</span></h1>
+  <h1 class="text-center pt-5"><%= octobox_round(80) %> <span class='align-middle'>Octobox</span></h1>
   <h3 class='text-center pt-3'>Untangle your GitHub Notifications</h3>
   <h5 class='text-center font-weight-light'>
       <%= number_to_human Notification.count %> notifications managed, and counting &#8230
   </h5>
-  <div class='container readable text-center'>
+  <div class='text-center'>
     <%= image_tag 'screenshot.png', class: 'screenshot mt-3', alt: 'Octobox Screenshot' %>
     <p>
       <%= link_to login_path, class: 'btn btn-outline-dark btn-lg' do %>
@@ -21,130 +21,123 @@
     </p>
   </div>
 
-  <div class="container readable my-5">
-    <h3 id='features'>Features</h3>
-    <h5 class='mb-5 text-muted font-weight-light'>Octobox helps you manage your GitHub notifications efficiently so you can spend less time managing and more time getting things done:</h4>
-     <div class="card shadow-sm mb-3">
-      <div class="card-body">
-        <div class="media">
-          <div class="align-self-center mr-4">
-            <%= octicon 'inbox', height: 50 %>
-          </div>
-          <div class="media-body">
-            <h5>Don't lose track</h5>
-            Octobox adds an extra "archived" state to each notification so you can mark it as "done". If anything happens on an archived thread, issue or PR, Octobox will move it back into your inbox.
-          </div>
+  
+  <h3 id='features' class='pt-5'>Features</h3>
+  <h5 class='mb-5 text-muted font-weight-light'>Octobox helps you manage your GitHub notifications efficiently so you can spend less time managing and more time getting things done:</h4>
+   <div class="card shadow-sm mb-3">
+    <div class="card-body">
+      <div class="media">
+        <div class="align-self-center mr-4">
+          <%= octicon 'inbox', height: 50 %>
+        </div>
+        <div class="media-body">
+          <h5>Don't lose track</h5>
+          Octobox adds an extra "archived" state to each notification so you can mark it as "done". If anything happens on an archived thread, issue or PR, Octobox will move it back into your inbox.
         </div>
       </div>
     </div>
-    <div class="card shadow-sm mb-3">
-      <div class="card-body">
-        <div class="media">
-          <div class="align-self-center mr-4">
-            <%= octicon 'star', height: 50 %>
-          </div>
-          <div class="media-body">
-            <h5>Starred notifications</h5>
-            Let's be honest, you probably don't have a 'favourite' issue but Octobox lets you highlight important notifications with a star so you can come back and find them easily.
-          </div>
+  </div>
+  <div class="card shadow-sm mb-3">
+    <div class="card-body">
+      <div class="media">
+        <div class="align-self-center mr-4">
+          <%= octicon 'star', height: 50 %>
+        </div>
+        <div class="media-body">
+          <h5>Starred notifications</h5>
+          Let's be honest, you probably don't have a 'favourite' issue but Octobox lets you highlight important notifications with a star so you can come back and find them easily.
         </div>
       </div>
     </div>
-    <div class="card shadow-sm mb-3">
-      <div class="card-body">
-        <div class="media">
-          <div class="align-self-center mr-4">
-            <%= octicon 'settings', height: 50 %>
-          </div>
-          <div class="media-body">
-            <h5>Filter all the things</h5>
-            Filter notifications by repository, organisation, type, action, state, CI status and reason and keep notifications from bots alongside your regular labels, author and assignees.
-          </div>
+  </div>
+  <div class="card shadow-sm mb-3">
+    <div class="card-body">
+      <div class="media">
+        <div class="align-self-center mr-4">
+          <%= octicon 'settings', height: 50 %>
+        </div>
+        <div class="media-body">
+          <h5>Filter all the things</h5>
+          Filter notifications by repository, organisation, type, action, state, CI status and reason and keep notifications from bots alongside your regular labels, author and assignees.
         </div>
       </div>
     </div>
-    <div class="card shadow-sm mb-3">
-      <div class="card-body">
-        <div class="media">
-          <div class="align-self-center mr-4">
-            <%= octicon 'search', height: 50 %>
-          </div>
-          <div class="media-body">
-            <h5>Search with prefix filters</h5>
-            No more Jedi mind tricks. Combine a wide range of powerful search filters help you get straight to the notification you're looking for and focus on just what you need.
-          </div>
+  </div>
+  <div class="card shadow-sm mb-3">
+    <div class="card-body">
+      <div class="media">
+        <div class="align-self-center mr-4">
+          <%= octicon 'search', height: 50 %>
+        </div>
+        <div class="media-body">
+          <h5>Search with prefix filters</h5>
+          No more Jedi mind tricks. Combine a wide range of powerful search filters help you get straight to the notification you're looking for and focus on just what you need.
         </div>
       </div>
     </div>
-    <div class="card shadow-sm mb-3">
-      <div class="card-body">
-        <div class="media">
-          <div class="align-self-center mr-4">
-            <%= octicon 'keyboard', height: 50 %>
-          </div>
-          <div class="media-body">
-            <h5>Built for keyboard warriors</h5>
-            Navigate, triage and manage your notifications like a pro using Gmail-inspired keyboard shortcuts for every function, no mouse required.
-          </div>
+  </div>
+  <div class="card shadow-sm mb-3">
+    <div class="card-body">
+      <div class="media">
+        <div class="align-self-center mr-4">
+          <%= octicon 'keyboard', height: 50 %>
+        </div>
+        <div class="media-body">
+          <h5>Built for keyboard warriors</h5>
+          Navigate, triage and manage your notifications like a pro using Gmail-inspired keyboard shortcuts for every function, no mouse required.
         </div>
       </div>
     </div>
-    <div class="card shadow-sm mb-3">
-      <div class="card-body">
-        <div class="media">
-          <div class="align-self-center mr-4">
-            <%= octicon 'mark-github', height: 50 %>
-          </div>
-          <div class="media-body">
-            <h5>Open for everyone</h5>
-            Octobox developers use Octobox to develop Octobox. 100% developed and managed in the open on GitHub under a FLOSS license.
-          </div>
+  </div>
+  <div class="card shadow-sm mb-3">
+    <div class="card-body">
+      <div class="media">
+        <div class="align-self-center mr-4">
+          <%= octicon 'mark-github', height: 50 %>
+        </div>
+        <div class="media-body">
+          <h5>Open for everyone</h5>
+          Octobox developers use Octobox to develop Octobox. 100% developed and managed in the open on GitHub under a FLOSS license.
         </div>
       </div>
     </div>
   </div>
 
   <% if Octobox.octobox_io? %>
-    <div class="container readable mb-5">
+    <h3 id='pricing' class='pt-5'>Pricing</h3>
+    <p class='pt-3 text-large'>Octobox is <b>free for open source</b> projects. To add private repository access to your personal or organisation's account:</p>
+    <div class='d-flex flex-column flex-lg-row pt-3 justify-content-center'>
+      <%= render('pages/opencollective')%>
+      <%= render('pages/github')%>
+    </div>
+    <p class='text-large'>Wondering why there are two options? <a href='/pricing#why'>Read more about our pricing strategy</a>.</p>
 
-      <h3 id='pricing' class='pt-4'>Pricing</h3>
-      <p class='pt-3 text-large'>Octobox is <b>free for open source</b> projects. To add private repository access to your personal or organisation's account:</p>
-      <div class='d-flex flex-column flex-lg-row pt-3 justify-content-center'>
-        <%= render('pages/opencollective')%>
-        <%= render('pages/github')%>
+    <h3 id='users' class='pt-4'>Used by developers from</h3>
+    <div class="row mt-4">
+      <div class="col">
+        <% used_by_orgs.each do |org| %>
+          <%= image_tag "https://github.com/#{org}.png?w=120", width: 60, height: 60, class: 'inline-block mr-2 mb-3', title: org, data: {toggle: 'tooltip'} %>
+        <% end %>
       </div>
-      <p class='text-large'>Wondering why there are two options? <a href='/pricing#why'>Read more about our pricing strategy</a>.</p>
-
-      <h3 id='users' class='pt-4'>Used by developers from</h3>
-      <div class="row mt-4">
-        <div class="col">
-          <% used_by_orgs.each do |org| %>
-            <%= image_tag "https://github.com/#{org}.png?w=120", width: 60, height: 60, class: 'inline-block mr-2 mb-3', title: org, data: {toggle: 'tooltip'} %>
-          <% end %>
-        </div>
-      </div>
-
     </div>
   <% end %>
 
-  <div class="container readable text-large mb-5">
 
-    <h3 id='run-your-own' class='pt-4'>Run your own Octobox</h3>
 
-    <p>The Octobox team hosts a shared instance of Octobox at <a href="https://octobox.io/">octobox.io</a>, but perhaps you're looking to host your own or get yourself set up to contribute to Octobox? Fantastic! There are a number of install options available to you, check out the <a href="https://github.com/octobox/octobox/blob/master/docs/INSTALLATION.md">installation guide</a>.</p>
+  <h3 id='run-your-own' class='pt-5'>Run your own Octobox</h3>
 
-    <h3 id='contribute' class='pt-4'>Contribute</h3>
+  <p>The Octobox team hosts a shared instance of Octobox at <a href="https://octobox.io/">octobox.io</a>, but perhaps you're looking to host your own or get yourself set up to contribute to Octobox? Fantastic! There are a number of install options available to you, check out the <a href="https://github.com/octobox/octobox/blob/master/docs/INSTALLATION.md">installation guide</a>.</p>
 
-    <p>Octobox is open source and the source code is hosted at <a href="https://github.com/octobox/octobox">GitHub</a>. If you have an idea for a feature or enhancement, open an <a href="https://github.com/octobox/octobox/issues/new">issue</a> or a pull request.</p>
+  <h3 id='contribute' class='pt-4'>Contribute</h3>
 
-    <p>If you want to contribute you'll find we're a welcoming bunch. If you don't know where to start, take a look at the issues tagged as <a href="https://github.com/octobox/octobox/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22">"Help Wanted"</a>.</p>
+  <p>Octobox is open source and the source code is hosted at <a href="https://github.com/octobox/octobox">GitHub</a>. If you have an idea for a feature or enhancement, open an <a href="https://github.com/octobox/octobox/issues/new">issue</a> or a pull request.</p>
 
-    <p>You can also help triage issues. This can include reproducing bug reports, or asking for vital information such as version numbers or reproduction instructions. If you would like to start triaging issues, one easy way to get started is to <a href="https://www.codetriage.com/octobox/octobox">subscribe to Octobox on CodeTriage</a>.</p>
+  <p>If you want to contribute you'll find we're a welcoming bunch. If you don't know where to start, take a look at the issues tagged as <a href="https://github.com/octobox/octobox/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22">"Help Wanted"</a>.</p>
 
-    <p>Finally, if you would like to become a maintainer, we will consider adding you if you contribute frequently to the project. Feel free to ask.</p>
+  <p>You can also help triage issues. This can include reproducing bug reports, or asking for vital information such as version numbers or reproduction instructions. If you would like to start triaging issues, one easy way to get started is to <a href="https://www.codetriage.com/octobox/octobox">subscribe to Octobox on CodeTriage</a>.</p>
 
-  </div>
+  <p class='mb-5'>Finally, if you would like to become a maintainer, we will consider adding you if you contribute frequently to the project. Feel free to ask.</p>
+
+  <%= render 'layouts/footer'%>
 </div>
-
-<%= render 'layouts/footer'%>
 <script async defer src="https://buttons.github.io/buttons.js"></script>

--- a/app/views/pages/pricing.html.erb
+++ b/app/views/pages/pricing.html.erb
@@ -1,37 +1,39 @@
-<div class='container readable mt-5'>
-	<h1 class="text-center"><%= octobox_round(80) %> Octobox</h1>
-	<h3 class='pt-3 text-center'>One product, two ways to pay</h3>
-    <p class='pt-3 text-large'>Octobox is <b>free for open source</b> projects. To add private repository access to your personal or organisation's account:</p>
-	
-    <div class='d-flex flex-column flex-lg-row pt-3 justify-content-center'>
-		<%= render('opencollective')%>
-		<%= render('github')%>
-	</div>
-	
-	<h2 id='why' class='text-center mb-5 pt-3'>What... Why?</h2>
+<div class='flex-content justify-content-center'>
+  <div class='flex-main readable pt-5'>
+  	<h1 class="text-center"><%= octobox_round(80) %> Octobox</h1>
+  	<h3 class='pt-3 text-center'>One product, two ways to pay</h3>
+      <p class='pt-3 text-large'>Octobox is <b>free for open source</b> projects. To add private repository access to your personal or organisation's account:</p>
+  	
+      <div class='d-flex flex-column flex-lg-row pt-3 justify-content-center'>
+  		<%= render('opencollective')%>
+  		<%= render('github')%>
+  	</div>
+  	
+  	<h2 id='why' class='text-center mb-5 pt-3'>What... Why?</h2>
 
-	<h5>An experiment in open source sustainability</h5>
+  	<h5>An experiment in open source sustainability</h5>
 
-    <p>Like many open source projects Octobox currently relies on volunteers and donations to cover the cost of maintaining the Octobox project. This is <a href='https://www.fordfoundation.org/about/library/reports-and-studies/roads-and-bridges-the-unseen-labor-behind-our-digital-infrastructure/'>not sustainable</a>.
+      <p>Like many open source projects Octobox currently relies on volunteers and donations to cover the cost of maintaining the Octobox project. This is <a href='https://www.fordfoundation.org/about/library/reports-and-studies/roads-and-bridges-the-unseen-labor-behind-our-digital-infrastructure/'>not sustainable</a>.
 
-    <p>Octobox is primarily maintained by Andrew Nesbitt and Benjamin Nickolls. We believe that many of the issues around the sustainability of open source software <i>can</i> be solved by the community itself. We also believe in leading by example, testing our assumptions and backing up our decisions with data.</p>
+      <p>Octobox is primarily maintained by Andrew Nesbitt and Benjamin Nickolls. We believe that many of the issues around the sustainability of open source software <i>can</i> be solved by the community itself. We also believe in leading by example, testing our assumptions and backing up our decisions with data.</p>
 
-    <p>Octobox has a small community of <a href='https://github.com/orgs/octobox/people'>maintainers</a>, <a href='https://github.com/octobox/octobox/graphs/contributors'>contributors</a>, <a href='https://opencollective.com/octobox/#contributors'>supporters and sponsors</a>. Our first priority is to begin building a sustainable income, for ourselves and our community. Our second is to demonstrate that our approach is repeatable and scalable, proving that we can solve this problem <i>together</i>. Our pricing model is our first experiment.
+      <p>Octobox has a small community of <a href='https://github.com/orgs/octobox/people'>maintainers</a>, <a href='https://github.com/octobox/octobox/graphs/contributors'>contributors</a>, <a href='https://opencollective.com/octobox/#contributors'>supporters and sponsors</a>. Our first priority is to begin building a sustainable income, for ourselves and our community. Our second is to demonstrate that our approach is repeatable and scalable, proving that we can solve this problem <i>together</i>. Our pricing model is our first experiment.
 
-    <h5 class='pt-3'>Do you prefer supporting a commercial provider, or the community itself?</h5>
-    <p>Octobox.io operated by Octobox Ltd. a company registered in the UK by Andrew Nesbitt and Benjamin Nickolls. The company is primarily designed to offer limited liability to the operators of Octobox.io and to renumerate directors and staff as employees or contractors.</p>
+      <h5 class='pt-3'>Do you prefer supporting a commercial provider, or the community itself?</h5>
+      <p>Octobox.io operated by Octobox Ltd. a company registered in the UK by Andrew Nesbitt and Benjamin Nickolls. The company is primarily designed to offer limited liability to the operators of Octobox.io and to renumerate directors and staff as employees or contractors.</p>
 
-    <p>The Octobox project will continue to collect donations via Open Collective and operate a transparent ledger of income and outgoings for the project — including, for the time being, the costs of hosting Octobox.io. When it is able the project will pay maintainers for their time including time spent operating Octobox.io, which will be directed through Octobox Ltd.</p>
+      <p>The Octobox project will continue to collect donations via Open Collective and operate a transparent ledger of income and outgoings for the project — including, for the time being, the costs of hosting Octobox.io. When it is able the project will pay maintainers for their time including time spent operating Octobox.io, which will be directed through Octobox Ltd.</p>
 
-    <p>Octobox Ltd. will provide private repository access to those who donate an equivalent sum (or more) to the community as pay directly through alternate channels. In addition the company will pledge at least 15% of its revenues for use by the community to further the open source project, forever.</p>
+      <p>Octobox Ltd. will provide private repository access to those who donate an equivalent sum (or more) to the community as pay directly through alternate channels. In addition the company will pledge at least 15% of its revenues for use by the community to further the open source project, forever.</p>
 
-    <h5 class='pt-3'>Why does this matter?</h5>
+      <h5 class='pt-3'>Why does this matter?</h5>
 
-    <p>Most open source projects struggle to navigate the legislative, legal and social issues around sustianing their projects. By diving straight into the deep end and documenting our experiences we hope to provide a blueprint for others to follow.</p>
+      <p>Most open source projects struggle to navigate the legislative, legal and social issues around sustianing their projects. By diving straight into the deep end and documenting our experiences we hope to provide a blueprint for others to follow.</p>
 
-    <p>By asking you to make the choice with how you pay we will demonstrate whether donation-based, community-first sustainabiliy strategies work over more classical, commercial-lead approaches.</p>
+      <p>By asking you to make the choice with how you pay we will demonstrate whether donation-based, community-first sustainabiliy strategies work over more classical, commercial-lead approaches.</p>
 
-    <p>Thanks for taking the time to read this. If anything is unclear or you have concerns about this please <a href='https://github.com/octobox/octobox/issues/new'>raise an issue</a> or <a href='mailto: hello@octobox.io'>get in touch</a>.</p>
+      <p>Thanks for taking the time to read this. If anything is unclear or you have concerns about this please <a href='https://github.com/octobox/octobox/issues/new'>raise an issue</a> or <a href='mailto: hello@octobox.io'>get in touch</a>.</p>
+
+      <%= render 'layouts/footer'%>
+  </div>
 </div>
-
-<%= render 'layouts/footer'%>

--- a/app/views/pages/pricing.html.erb
+++ b/app/views/pages/pricing.html.erb
@@ -1,39 +1,38 @@
-<div class='flex-content justify-content-center'>
-  <div class='flex-main readable pt-5'>
-  	<h1 class="text-center"><%= octobox_round(80) %> Octobox</h1>
-  	<h3 class='pt-3 text-center'>One product, two ways to pay</h3>
-      <p class='pt-3 text-large'>Octobox is <b>free for open source</b> projects. To add private repository access to your personal or organisation's account:</p>
-  	
-      <div class='d-flex flex-column flex-lg-row pt-3 justify-content-center'>
-  		<%= render('opencollective')%>
-  		<%= render('github')%>
-  	</div>
-  	
-  	<h2 id='why' class='text-center mb-5 pt-3'>What... Why?</h2>
+<div class='container readable pt-5'>
 
-  	<h5>An experiment in open source sustainability</h5>
+	<h1 class="text-center"><%= octobox_round(80) %> Octobox</h1>
+	<h3 class='pt-3 text-center'>One product, two ways to pay</h3>
+    <p class='pt-3 text-large'>Octobox is <b>free for open source</b> projects. To add private repository access to your personal or organisation's account:</p>
+	
+    <div class='d-flex flex-column flex-lg-row pt-3 justify-content-center'>
+		<%= render('opencollective')%>
+		<%= render('github')%>
+	</div>
+	
+	<h2 id='why' class='text-center mb-5 pt-3'>What... Why?</h2>
 
-      <p>Like many open source projects Octobox currently relies on volunteers and donations to cover the cost of maintaining the Octobox project. This is <a href='https://www.fordfoundation.org/about/library/reports-and-studies/roads-and-bridges-the-unseen-labor-behind-our-digital-infrastructure/'>not sustainable</a>.
+	<h5>An experiment in open source sustainability</h5>
 
-      <p>Octobox is primarily maintained by Andrew Nesbitt and Benjamin Nickolls. We believe that many of the issues around the sustainability of open source software <i>can</i> be solved by the community itself. We also believe in leading by example, testing our assumptions and backing up our decisions with data.</p>
+  <p>Like many open source projects Octobox currently relies on volunteers and donations to cover the cost of maintaining the Octobox project. This is <a href='https://www.fordfoundation.org/about/library/reports-and-studies/roads-and-bridges-the-unseen-labor-behind-our-digital-infrastructure/'>not sustainable</a>.</p>
 
-      <p>Octobox has a small community of <a href='https://github.com/orgs/octobox/people'>maintainers</a>, <a href='https://github.com/octobox/octobox/graphs/contributors'>contributors</a>, <a href='https://opencollective.com/octobox/#contributors'>supporters and sponsors</a>. Our first priority is to begin building a sustainable income, for ourselves and our community. Our second is to demonstrate that our approach is repeatable and scalable, proving that we can solve this problem <i>together</i>. Our pricing model is our first experiment.
+  <p>Octobox is primarily maintained by Andrew Nesbitt and Benjamin Nickolls. We believe that many of the issues around the sustainability of open source software <i>can</i> be solved by the community itself. We also believe in leading by example, testing our assumptions and backing up our decisions with data.</p>
 
-      <h5 class='pt-3'>Do you prefer supporting a commercial provider, or the community itself?</h5>
-      <p>Octobox.io operated by Octobox Ltd. a company registered in the UK by Andrew Nesbitt and Benjamin Nickolls. The company is primarily designed to offer limited liability to the operators of Octobox.io and to renumerate directors and staff as employees or contractors.</p>
+  <p>Octobox has a small community of <a href='https://github.com/orgs/octobox/people'>maintainers</a>, <a href='https://github.com/octobox/octobox/graphs/contributors'>contributors</a>, <a href='https://opencollective.com/octobox/#contributors'>supporters and sponsors</a>. Our first priority is to begin building a sustainable income, for ourselves and our community. Our second is to demonstrate that our approach is repeatable and scalable, proving that we can solve this problem <i>together</i>. Our pricing model is our first experiment.</p>
 
-      <p>The Octobox project will continue to collect donations via Open Collective and operate a transparent ledger of income and outgoings for the project — including, for the time being, the costs of hosting Octobox.io. When it is able the project will pay maintainers for their time including time spent operating Octobox.io, which will be directed through Octobox Ltd.</p>
+  <h5 class='pt-3'>Do you prefer supporting a commercial provider, or the community itself?</h5>
+  <p>Octobox.io operated by Octobox Ltd. a company registered in the UK by Andrew Nesbitt and Benjamin Nickolls. The company is primarily designed to offer limited liability to the operators of Octobox.io and to renumerate directors and staff as employees or contractors.</p>
 
-      <p>Octobox Ltd. will provide private repository access to those who donate an equivalent sum (or more) to the community as pay directly through alternate channels. In addition the company will pledge at least 15% of its revenues for use by the community to further the open source project, forever.</p>
+  <p>The Octobox project will continue to collect donations via Open Collective and operate a transparent ledger of income and outgoings for the project — including, for the time being, the costs of hosting Octobox.io. When it is able the project will pay maintainers for their time including time spent operating Octobox.io, which will be directed through Octobox Ltd.</p>
 
-      <h5 class='pt-3'>Why does this matter?</h5>
+  <p>Octobox Ltd. will provide private repository access to those who donate an equivalent sum (or more) to the community as pay directly through alternate channels. In addition the company will pledge at least 15% of its revenues for use by the community to further the open source project, forever.</p>
 
-      <p>Most open source projects struggle to navigate the legislative, legal and social issues around sustianing their projects. By diving straight into the deep end and documenting our experiences we hope to provide a blueprint for others to follow.</p>
+  <h5 class='pt-3'>Why does this matter?</h5>
 
-      <p>By asking you to make the choice with how you pay we will demonstrate whether donation-based, community-first sustainabiliy strategies work over more classical, commercial-lead approaches.</p>
+  <p>Most open source projects struggle to navigate the legislative, legal and social issues around sustianing their projects. By diving straight into the deep end and documenting our experiences we hope to provide a blueprint for others to follow.</p>
 
-      <p>Thanks for taking the time to read this. If anything is unclear or you have concerns about this please <a href='https://github.com/octobox/octobox/issues/new'>raise an issue</a> or <a href='mailto: hello@octobox.io'>get in touch</a>.</p>
+  <p>By asking you to make the choice with how you pay we will demonstrate whether donation-based, community-first sustainabiliy strategies work over more classical, commercial-lead approaches.</p>
 
-      <%= render 'layouts/footer'%>
-  </div>
+  <p>Thanks for taking the time to read this. If anything is unclear or you have concerns about this please <a href='https://github.com/octobox/octobox/issues/new'>raise an issue</a> or <a href='mailto: hello@octobox.io'>get in touch</a>.</p>
+
+  <%= render 'layouts/footer'%>
 </div>

--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -1,5 +1,4 @@
-<div class="flex-content justify-content-center">
-  <div class='flex-main readable pt-5'>
+<div class="container readable pt-5">
     <div class='d-flex align-items-end justify-content-between'>
       <h1>Privacy Policy</h1>
       <%= link_to octobox_round(80), root_path  %>

--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -1,105 +1,107 @@
-<div class="container readable mt-5">
-  <div class='d-flex align-items-end justify-content-between'>
-    <h1>Privacy Policy</h1>
-    <%= link_to octobox_round(80), root_path  %>
+<div class="flex-content justify-content-center">
+  <div class='flex-main readable pt-5'>
+    <div class='d-flex align-items-end justify-content-between'>
+      <h1>Privacy Policy</h1>
+      <%= link_to octobox_round(80), root_path  %>
+    </div>
+    <hr>
+
+    <h2>We Care About Your Privacy</h2>
+    <p>
+      No, really, we actually do. But as a young, growing service provider it is necessary for Octobox.io to store some data. If we do so it will be for one of two reasons:
+    </p>
+    <ul>
+      <li>To enable you to use the service effectively.</li>
+      <li>To enable us to improve the services you can use.</li>
+    </ul>
+
+    <h3>Data We Collect</h3>
+    <p>
+      We collect the e-mail addresses of those who sign up with Octobox.io, aggregate information on what pages users access or visit, and information volunteered by the consumer.
+    </p>
+    <p>
+      We collect information about your GitHub notifications including some basic data about notifications from private repositories. If you install the GitHub App we collect more detailed data about these notifications including but not limitted to authors, labels, comments and status. If you enable private repository access then we collect this data for your private repositories too.
+    </p>
+
+    <h3>Transmitting Your Data</h4>
+    <p>
+      Transmitting information over the Internet is generally not completely secure, and we can’t guarantee the security of your data.
+    </p>
+
+    <h3>Processing And Storing Your Data</h4>
+    <p>
+      Your data is processed by servers in France and Ireland. Your data is stored on our servers in France, once it is stored we have processes in place to secure it.
+    </p>
+
+    <h3>Sharing Your Data</h4>
+    <p>
+      The information we collect is not shared with or sold to other organizations, except to provide products or services you have requested, with your permission, or under the following circumstances:
+    </p>
+    <ul>
+      <li>
+        It is necessary to share information in order to investigate, prevent, or take action regarding illegal activities, suspected fraud, situations involving potential threats to the physical safety of any person, violations of Terms of Service, or as otherwise required by law.
+      </li>
+      <li>
+        We transfer information about you if the assets of Octobox.io are acquired by or merged with another organisation. In this event, Octobox.io will notify you before information about you is transferred and becomes subject to a different privacy policy.
+      </li>
+    </ul>
+    <p>
+      Other than the above declarations we won’t share your information with any other organisations for marketing, market research or commercial purposes, and we don’t pass on your details to other websites.
+    </p>
+
+
+    <h2>Services We Use</h2>
+    <p>
+      Like many other websites, we sometimes use cookies, Google Analytics and Bugnag to help us make our websites better.
+    </p>
+    <p>
+      These tools are very common and widely used by other sites, but they do have privacy implications. When you visit sites that use these tools, you are potentially telling companies such as Google that you visited, as well as some information about how your web browser is configured. If you don’t want to share your browsing activities on sites with other companies, you can install opt-out browser plugins. You might find this article useful: <a href="http://www.guardian.co.uk/technology/askjack/2011/jun/17/ask-jack-internet-privacy-web-browsers-cookies">The Guardian – How to Keep Your Privacy Online</a>.
+    </p>
+
+    <h3>Cookies</h3>
+    <p>
+      Cookies are small amounts of text stored on your computer's web browser that can be written by websites and read by websites. They can also be shared between websites. We use cookies to store some information about your current session, this enables us to do things like keep you logged into the website between pages. Cookies are also used by third-party providers like Google:
+    </p>
+
+    <h3>Analytics</h3>
+    <p>
+      We use Google Analytics to collect information about how people use this site. Google Analytics stores information such as what pages you visit, how long you are on the site, how you got here, what you click on, and information about your web browser. Your computer's IP address is masked (only a portion is stored) and personal information is only reported in aggregate. We do not allow Google to use or share our analytics data for any purpose besides providing us with analytics information.
+    </p>
+
+    <h4>Google’s Official Statement About Analytics Data</h4>
+    <p>
+      This website uses Google Analytics, a web analytics service provided by Google, Inc. (“Google”). Google Analytics uses “cookies”, which are text files placed on your computer, to help the website analyze how users use the site. The information generated by the cookie about your use of the website (including your IP address) will be transmitted to and stored by Google on servers in the United States . Google will use this information for the purpose of evaluating your use of the website, compiling reports on website activity for website operators and providing other services relating to website activity and Internet usage. Google may also transfer this information to third parties where required to do so by law, or where such third parties process the information on Google’s behalf. Google will not associate your IP address with any other data held by Google. You may refuse the use of cookies by selecting the appropriate settings on your browser, however please note that if you do this you may not be able to use the full functionality of this website. By using this website, you consent to the processing of data about you by Google in the manner and for the purposes set out above.
+    </p>
+
+    <h4>Opting Out Of Analytics</h4>
+    <p>
+      If you are unhappy with the idea of sharing the fact you visited our sites (and any other sites) with Google, you can install the <a href="http://tools.google.com/dlpage/gaoptout"> official browser plugin for blocking Google Analytics</a>
+    </p>
+
+    <h3>Logging</h3>
+    <p>
+      We use logs to collect information about the state of the service in order to address bugs and improve the site. These logs may include details about your behavior at the time of an error, including your session information and your computer's IP address.
+    </p>
+    <h4>Bugsnag's DPA</h4>
+    <p>
+      We use Bugsnag to compile and analyse errors. These details are held by Busnag and may include your IP address. Bugsnag's data protection statement includes the following text:
+    </p>
+    <p>
+      "a) Cross-Border Transfers of Personal Data. Customer authorizes Bugsnag and its Third Parties to transfer Customer Personal Data across international borders, including from the European Economic Area to the United States. Any cross-border transfer of Customer Personal Data must be supported by an approved adequacy mechanism. b) Privacy Shield Certification. Bugsnag is currently Privacy Shield certified, will maintain its Privacy Shield certification during the term of the Agreement and will Process the Customer Personal Data in accordance with at least the same level of protection as required under the applicable Privacy Shield principles. Bugsnag will provide written notification to Customer before it withdraws from or otherwise no longer maintains a current certification to the Privacy Shield. Bugsnag shall promptly notify Customer if it can no longer meet its obligations under this Section."
+    </p>
+    <p>
+      You can read Bugnag's data protection addendum statement in full <a href='https://docs.bugsnag.com/legal/dpa/' target='_blank' rel="noopener"> on their website</a>
+    </p>
+    <h2>Your Rights</h4>
+    <p>
+      You can find out what information we hold about you, and ask us not to use any of the information we collect. Email <a href='mailto:privacy@octobox.io'>privacy@octobox.io</a> to request either of these.
+    </p>
+
+    <h2>Changes To This Privacy Policy</h2>
+    <p>
+      From time to time we may modify or update our privacy policy. We will do so by updating this page.
+    </p>
+
+    <%= render 'layouts/footer'%>
   </div>
-  <hr>
-
-  <h2>We Care About Your Privacy</h2>
-  <p>
-    No, really, we actually do. But as a young, growing service provider it is necessary for Octobox.io to store some data. If we do so it will be for one of two reasons:
-  </p>
-  <ul>
-    <li>To enable you to use the service effectively.</li>
-    <li>To enable us to improve the services you can use.</li>
-  </ul>
-
-  <h3>Data We Collect</h3>
-  <p>
-    We collect the e-mail addresses of those who sign up with Octobox.io, aggregate information on what pages users access or visit, and information volunteered by the consumer.
-  </p>
-  <p>
-    We collect information about your GitHub notifications including some basic data about notifications from private repositories. If you install the GitHub App we collect more detailed data about these notifications including but not limitted to authors, labels, comments and status. If you enable private repository access then we collect this data for your private repositories too.
-  </p>
-
-  <h3>Transmitting Your Data</h4>
-  <p>
-    Transmitting information over the Internet is generally not completely secure, and we can’t guarantee the security of your data.
-  </p>
-
-  <h3>Processing And Storing Your Data</h4>
-  <p>
-    Your data is processed by servers in France and Ireland. Your data is stored on our servers in France, once it is stored we have processes in place to secure it.
-  </p>
-
-  <h3>Sharing Your Data</h4>
-  <p>
-    The information we collect is not shared with or sold to other organizations, except to provide products or services you have requested, with your permission, or under the following circumstances:
-  </p>
-  <ul>
-    <li>
-      It is necessary to share information in order to investigate, prevent, or take action regarding illegal activities, suspected fraud, situations involving potential threats to the physical safety of any person, violations of Terms of Service, or as otherwise required by law.
-    </li>
-    <li>
-      We transfer information about you if the assets of Octobox.io are acquired by or merged with another organisation. In this event, Octobox.io will notify you before information about you is transferred and becomes subject to a different privacy policy.
-    </li>
-  </ul>
-  <p>
-    Other than the above declarations we won’t share your information with any other organisations for marketing, market research or commercial purposes, and we don’t pass on your details to other websites.
-  </p>
-
-
-  <h2>Services We Use</h2>
-  <p>
-    Like many other websites, we sometimes use cookies, Google Analytics and Bugnag to help us make our websites better.
-  </p>
-  <p>
-    These tools are very common and widely used by other sites, but they do have privacy implications. When you visit sites that use these tools, you are potentially telling companies such as Google that you visited, as well as some information about how your web browser is configured. If you don’t want to share your browsing activities on sites with other companies, you can install opt-out browser plugins. You might find this article useful: <a href="http://www.guardian.co.uk/technology/askjack/2011/jun/17/ask-jack-internet-privacy-web-browsers-cookies">The Guardian – How to Keep Your Privacy Online</a>.
-  </p>
-
-  <h3>Cookies</h3>
-  <p>
-    Cookies are small amounts of text stored on your computer's web browser that can be written by websites and read by websites. They can also be shared between websites. We use cookies to store some information about your current session, this enables us to do things like keep you logged into the website between pages. Cookies are also used by third-party providers like Google:
-  </p>
-
-  <h3>Analytics</h3>
-  <p>
-    We use Google Analytics to collect information about how people use this site. Google Analytics stores information such as what pages you visit, how long you are on the site, how you got here, what you click on, and information about your web browser. Your computer's IP address is masked (only a portion is stored) and personal information is only reported in aggregate. We do not allow Google to use or share our analytics data for any purpose besides providing us with analytics information.
-  </p>
-
-  <h4>Google’s Official Statement About Analytics Data</h4>
-  <p>
-    This website uses Google Analytics, a web analytics service provided by Google, Inc. (“Google”). Google Analytics uses “cookies”, which are text files placed on your computer, to help the website analyze how users use the site. The information generated by the cookie about your use of the website (including your IP address) will be transmitted to and stored by Google on servers in the United States . Google will use this information for the purpose of evaluating your use of the website, compiling reports on website activity for website operators and providing other services relating to website activity and Internet usage. Google may also transfer this information to third parties where required to do so by law, or where such third parties process the information on Google’s behalf. Google will not associate your IP address with any other data held by Google. You may refuse the use of cookies by selecting the appropriate settings on your browser, however please note that if you do this you may not be able to use the full functionality of this website. By using this website, you consent to the processing of data about you by Google in the manner and for the purposes set out above.
-  </p>
-
-  <h4>Opting Out Of Analytics</h4>
-  <p>
-    If you are unhappy with the idea of sharing the fact you visited our sites (and any other sites) with Google, you can install the <a href="http://tools.google.com/dlpage/gaoptout"> official browser plugin for blocking Google Analytics</a>
-  </p>
-
-  <h3>Logging</h3>
-  <p>
-    We use logs to collect information about the state of the service in order to address bugs and improve the site. These logs may include details about your behavior at the time of an error, including your session information and your computer's IP address.
-  </p>
-  <h4>Bugsnag's DPA</h4>
-  <p>
-    We use Bugsnag to compile and analyse errors. These details are held by Busnag and may include your IP address. Bugsnag's data protection statement includes the following text:
-  </p>
-  <p>
-    "a) Cross-Border Transfers of Personal Data. Customer authorizes Bugsnag and its Third Parties to transfer Customer Personal Data across international borders, including from the European Economic Area to the United States. Any cross-border transfer of Customer Personal Data must be supported by an approved adequacy mechanism. b) Privacy Shield Certification. Bugsnag is currently Privacy Shield certified, will maintain its Privacy Shield certification during the term of the Agreement and will Process the Customer Personal Data in accordance with at least the same level of protection as required under the applicable Privacy Shield principles. Bugsnag will provide written notification to Customer before it withdraws from or otherwise no longer maintains a current certification to the Privacy Shield. Bugsnag shall promptly notify Customer if it can no longer meet its obligations under this Section."
-  </p>
-  <p>
-    You can read Bugnag's data protection addendum statement in full <a href='https://docs.bugsnag.com/legal/dpa/' target='_blank' rel="noopener"> on their website</a>
-  </p>
-  <h2>Your Rights</h4>
-  <p>
-    You can find out what information we hold about you, and ask us not to use any of the information we collect. Email <a href='mailto:privacy@octobox.io'>privacy@octobox.io</a> to request either of these.
-  </p>
-
-  <h2>Changes To This Privacy Policy</h4>
-  <p>
-    From time to time we may modify or update our privacy policy. We will do so by updating this page.
-  </p>
 </div>
-
-<%= render 'layouts/footer'%>

--- a/app/views/pages/terms.html.erb
+++ b/app/views/pages/terms.html.erb
@@ -1,107 +1,105 @@
-<div class="flex-content justify-content-center">
-  <div class="flex-main readable pt-5">
-    <div class='d-flex align-items-end justify-content-between'>
-      <h1>Terms and Conditions</h1>
-      <%= link_to octobox_round(80), root_path  %>
-    </div>
-    <hr>
-    <p>
-      Thank you for using Octobox.io!
-    </p>
-    <p>
-      Octobox.io is owned and operated operated by Octobox Ltd. ("Octobox.io"), company number 11469796 registered in England and Wales.
-    </p>
-    <h4 id='acceptance'>Acceptance (How To Accept These Things)</h4>
-    <p>
-      By using the Octobox.io web site ("Service") you are agreeing to the terms and conditions ("Terms of Service") presented below.
-    </p>
-
-    <h4 id='account'>Account Terms</h4>
-      You may not enter into this agreement if you are not of legal age to do so, you are legally prohibited from doing so or you are not a human.
-    </p>
-    <p>
-      If you are using the Service on behalf of a legal entity you are representing that you have authority to bind that entity to these terms. By accepting these terms you are doing so on behalf of that entity and all references to 'you' and 'your' refer to that entity from here on.
-    </p>
-
-    <h4 id='termination'>Cancellation and Termination (How To Cancel This Agreement)</h4>
-    <p>
-      You may stop using the Service without notice. If you do not use the Service for thirty (30) calendar days we will consider your agreement under these terms terminated. You may also give prior notice of termination by emailing <%= mail_to 'support@octobox.io', 'support@octobox.io', subject: 'Termination of agreement' %>.
-    </p>
-
-    <h4 id='modifications'>Modifications (Things We May Change)</h4>
-    <p>
-      Octobox.io reserves the right at any time and from time to time to modify or discontinue, temporarily or permanently, the Service (or any part thereof) with or without notice.
-    </p>
-    <p>
-      Octobox.io reserves the right to update and change the Terms of Service from time to time without notice. Any new features that augment or enhance the current Service, including the release of new tools and resources, shall be subject to the Terms of Service. Continued use of the Service after any such changes shall constitute your consent to such changes.
-    </p>
-    <p>
-      As the Service grows we may add to or otherwise modify the Service. If we do so we will update the documentation. Occasionally we may need to make changes that require you to modify your usage.
-    </p>
-    <p>
-      Octobox.io shall not be liable to you or to any third party for any modification, price change, suspension or discontinuance of the Service.
-    </p>
-
-    <h4 id='copyrights'>Copyrights and Content Ownership</h4>
-    <p>
-      We claim no intellectual property rights over the material you provide to the Service.
-    </p>
-    <p>
-      The name and logos for Octobox.io are property of Octobox.io. All rights reserved. You may not use the Octobox.io name without written permission from Octobox.io.
-    </p>
-
-    <h4 id='agreements'>Agreements (Things You Agree To)</h4>
-    <ul>
-      <li>Your use of the Service is at your sole risk. The Service is provided on an “as is” and “as available” basis.</li>
-      <li>You understand that Octobox.io uses third party vendors and hosting partners to provide the necessary hardware, software, networking, storage, and related technology required to run the Service.</li>
-      <li>You agree to the terms of our <a href='/privacy'>Privacy Policy</a>.</li>
-      <li>If you are conducting security research you also agree to the terms of our <a href='https://github.com/octobox/octobox/blob/master/docs/RESPONSIBLE_DISCLOSURE_POLICY.md'>responsible disclosure policy</a>.</li>
-    </ul>
-
-    <h4 id='provisions'>Provisions (Things You Must Do)</h4>
-    <ul>
-      <li>You must Comply with the terms of service.</li>
-    </ul>
-
-    <h4 id='restrictions'>Restrictions (Things You Must Not Do)</h4>
-    <ul>
-      <li>You must not perform any action with the intent to introduce errors within or otherwise disrupt or interfere with the provision of the service.</li>
-      <li>You must not make representations regarding ownership, partnership, sponsorship or any other type of endorsement between you and Octobox.io.</li>
-      <li>You may not use the Service for any illegal or unauthorized purpose. </li>
-      <li>You must not, in the use of the Service, violate any laws in your jurisdiction (including but not limited to copyright laws).</li>
-    </ul>
-
-    <h4 id='limitations'>Limitations (Things We Cannot Promise)</h4>
-    <p>
-      Octobox.io does not warrant that (i) the Service will meet your specific requirements, (ii) the Service will be uninterrupted, timely, secure, or error-free, (iii) the results that may be obtained from the use of the Service will be accurate or reliable, (iv) the quality of any products, services, information, or other material purchased or obtained by you through the Service will meet your expectations, and (v) any errors in the Service will be corrected.
-    </p>
-    <p>
-      You expressly understand and agree that  Octobox.io shall not be liable for any direct, indirect, incidental, special, consequential or exemplary damages, including but not limited to, damages for loss of profits, goodwill, use, data or other intangible losses (even if Octobox.io has been advised of the possibility of such damages), resulting from: (i) the use or the inability to use the Service; (ii) the cost of procurement of substitute goods and services resulting from any goods, data, information or services purchased or obtained or messages received or transactions entered into through or from the Service; (iii) unauthorized access to or alteration of your transmissions or data; (iv) statements or conduct of any third party on the Service; (v) or any other matter relating to the Service.
-    </p>
-    <p>
-      Data provided by Octobox.io is gathered from third party sources. Therefore we cannot and do not warrant that it is accurate or up to date and we accept no liability for any errors.
-    </p>
-    <p>
-      The failure of Octobox.io to exercise or enforce any right or provision of the Terms of Service shall not constitute a waiver of such right or provision. The Terms of Service constitutes the entire agreement between you and Octobox.io and govern your use of the Service, superceding any prior agreements between you and Octobox.io (including, but not limited to, any prior versions of the Terms of Service).
-    </p>
-
-    <h4 id='bugs'>Bugs, Errors and Issues</h4>
-    <p>
-      If you find a bug or error in the operation or content of the service please file an issue in our <a href='https://github.com/octobox/octobox/issues/new'>bug tracker</a>.
-    </p>
-
-    <h4 id='support'>Support</h4>
-    <p>
-      Octobox.io is a small community of people supporting the service. We do not offer formal support processes. If you require mroe formal support arrangements please <a href='mailto:support@octobox.io'>email us</a> otherwise you can try:
-    </p>
-    <ul>
-      <li>Filing an issue in our <a href='https://github.com/octobox/octobox/issues/new'>bug tracker</a> following the template provided.</li>
-      <li>Asking for help in our <a href='https://gitter.im/octobox/octobox'>public chat room</a>.</li>
-      <li>Email us at <%= mail_to 'support@octobox.io' %>.</li>
-      <li>Tweet us at <%= link_to '@octoboxio', 'https://twitter.com/octoboxio' %>.</li>
-    </ul>
-    <hr>
-
-    <%= render 'layouts/footer'%>
+<div class="container readable pt-5">
+  <div class='d-flex align-items-end justify-content-between'>
+    <h1>Terms and Conditions</h1>
+    <%= link_to octobox_round(80), root_path  %>
   </div>
+  <hr>
+  <p>
+    Thank you for using Octobox.io!
+  </p>
+  <p>
+    Octobox.io is owned and operated operated by Octobox Ltd. ("Octobox.io"), company number 11469796 registered in England and Wales.
+  </p>
+  <h4 id='acceptance'>Acceptance (How To Accept These Things)</h4>
+  <p>
+    By using the Octobox.io web site ("Service") you are agreeing to the terms and conditions ("Terms of Service") presented below.
+  </p>
+
+  <h4 id='account'>Account Terms</h4>
+    You may not enter into this agreement if you are not of legal age to do so, you are legally prohibited from doing so or you are not a human.
+  </p>
+  <p>
+    If you are using the Service on behalf of a legal entity you are representing that you have authority to bind that entity to these terms. By accepting these terms you are doing so on behalf of that entity and all references to 'you' and 'your' refer to that entity from here on.
+  </p>
+
+  <h4 id='termination'>Cancellation and Termination (How To Cancel This Agreement)</h4>
+  <p>
+    You may stop using the Service without notice. If you do not use the Service for thirty (30) calendar days we will consider your agreement under these terms terminated. You may also give prior notice of termination by emailing <%= mail_to 'support@octobox.io', 'support@octobox.io', subject: 'Termination of agreement' %>.
+  </p>
+
+  <h4 id='modifications'>Modifications (Things We May Change)</h4>
+  <p>
+    Octobox.io reserves the right at any time and from time to time to modify or discontinue, temporarily or permanently, the Service (or any part thereof) with or without notice.
+  </p>
+  <p>
+    Octobox.io reserves the right to update and change the Terms of Service from time to time without notice. Any new features that augment or enhance the current Service, including the release of new tools and resources, shall be subject to the Terms of Service. Continued use of the Service after any such changes shall constitute your consent to such changes.
+  </p>
+  <p>
+    As the Service grows we may add to or otherwise modify the Service. If we do so we will update the documentation. Occasionally we may need to make changes that require you to modify your usage.
+  </p>
+  <p>
+    Octobox.io shall not be liable to you or to any third party for any modification, price change, suspension or discontinuance of the Service.
+  </p>
+
+  <h4 id='copyrights'>Copyrights and Content Ownership</h4>
+  <p>
+    We claim no intellectual property rights over the material you provide to the Service.
+  </p>
+  <p>
+    The name and logos for Octobox.io are property of Octobox.io. All rights reserved. You may not use the Octobox.io name without written permission from Octobox.io.
+  </p>
+
+  <h4 id='agreements'>Agreements (Things You Agree To)</h4>
+  <ul>
+    <li>Your use of the Service is at your sole risk. The Service is provided on an “as is” and “as available” basis.</li>
+    <li>You understand that Octobox.io uses third party vendors and hosting partners to provide the necessary hardware, software, networking, storage, and related technology required to run the Service.</li>
+    <li>You agree to the terms of our <a href='/privacy'>Privacy Policy</a>.</li>
+    <li>If you are conducting security research you also agree to the terms of our <a href='https://github.com/octobox/octobox/blob/master/docs/RESPONSIBLE_DISCLOSURE_POLICY.md'>responsible disclosure policy</a>.</li>
+  </ul>
+
+  <h4 id='provisions'>Provisions (Things You Must Do)</h4>
+  <ul>
+    <li>You must Comply with the terms of service.</li>
+  </ul>
+
+  <h4 id='restrictions'>Restrictions (Things You Must Not Do)</h4>
+  <ul>
+    <li>You must not perform any action with the intent to introduce errors within or otherwise disrupt or interfere with the provision of the service.</li>
+    <li>You must not make representations regarding ownership, partnership, sponsorship or any other type of endorsement between you and Octobox.io.</li>
+    <li>You may not use the Service for any illegal or unauthorized purpose. </li>
+    <li>You must not, in the use of the Service, violate any laws in your jurisdiction (including but not limited to copyright laws).</li>
+  </ul>
+
+  <h4 id='limitations'>Limitations (Things We Cannot Promise)</h4>
+  <p>
+    Octobox.io does not warrant that (i) the Service will meet your specific requirements, (ii) the Service will be uninterrupted, timely, secure, or error-free, (iii) the results that may be obtained from the use of the Service will be accurate or reliable, (iv) the quality of any products, services, information, or other material purchased or obtained by you through the Service will meet your expectations, and (v) any errors in the Service will be corrected.
+  </p>
+  <p>
+    You expressly understand and agree that  Octobox.io shall not be liable for any direct, indirect, incidental, special, consequential or exemplary damages, including but not limited to, damages for loss of profits, goodwill, use, data or other intangible losses (even if Octobox.io has been advised of the possibility of such damages), resulting from: (i) the use or the inability to use the Service; (ii) the cost of procurement of substitute goods and services resulting from any goods, data, information or services purchased or obtained or messages received or transactions entered into through or from the Service; (iii) unauthorized access to or alteration of your transmissions or data; (iv) statements or conduct of any third party on the Service; (v) or any other matter relating to the Service.
+  </p>
+  <p>
+    Data provided by Octobox.io is gathered from third party sources. Therefore we cannot and do not warrant that it is accurate or up to date and we accept no liability for any errors.
+  </p>
+  <p>
+    The failure of Octobox.io to exercise or enforce any right or provision of the Terms of Service shall not constitute a waiver of such right or provision. The Terms of Service constitutes the entire agreement between you and Octobox.io and govern your use of the Service, superceding any prior agreements between you and Octobox.io (including, but not limited to, any prior versions of the Terms of Service).
+  </p>
+
+  <h4 id='bugs'>Bugs, Errors and Issues</h4>
+  <p>
+    If you find a bug or error in the operation or content of the service please file an issue in our <a href='https://github.com/octobox/octobox/issues/new'>bug tracker</a>.
+  </p>
+
+  <h4 id='support'>Support</h4>
+  <p>
+    Octobox.io is a small community of people supporting the service. We do not offer formal support processes. If you require mroe formal support arrangements please <a href='mailto:support@octobox.io'>email us</a> otherwise you can try:
+  </p>
+  <ul>
+    <li>Filing an issue in our <a href='https://github.com/octobox/octobox/issues/new'>bug tracker</a> following the template provided.</li>
+    <li>Asking for help in our <a href='https://gitter.im/octobox/octobox'>public chat room</a>.</li>
+    <li>Email us at <%= mail_to 'support@octobox.io' %>.</li>
+    <li>Tweet us at <%= link_to '@octoboxio', 'https://twitter.com/octoboxio' %>.</li>
+  </ul>
+  <hr>
+
+  <%= render 'layouts/footer'%>
 </div>

--- a/app/views/pages/terms.html.erb
+++ b/app/views/pages/terms.html.erb
@@ -1,109 +1,107 @@
-<div class="container readable mt-5">
-  <div class="row">
-    <div class="col-md-12">
-      <div class='d-flex align-items-end justify-content-between'>
-        <h1>Terms and Conditions</h1>
-        <%= link_to octobox_round(80), root_path  %>
-      </div>
-      <hr>
-      <p>
-        Thank you for using Octobox.io!
-      </p>
-      <p>
-        Octobox.io is owned and operated operated by Octobox Ltd. ("Octobox.io"), company number 11469796 registered in England and Wales.
-      </p>
-      <h4 id='acceptance'>Acceptance (How To Accept These Things)</h4>
-      <p>
-        By using the Octobox.io web site ("Service") you are agreeing to the terms and conditions ("Terms of Service") presented below.
-      </p>
-
-      <h4 id='account'>Account Terms</h4>
-        You may not enter into this agreement if you are not of legal age to do so, you are legally prohibited from doing so or you are not a human.
-      </p>
-      <p>
-        If you are using the Service on behalf of a legal entity you are representing that you have authority to bind that entity to these terms. By accepting these terms you are doing so on behalf of that entity and all references to 'you' and 'your' refer to that entity from here on.
-      </p>
-
-      <h4 id='termination'>Cancellation and Termination (How To Cancel This Agreement)</h4>
-      <p>
-        You may stop using the Service without notice. If you do not use the Service for thirty (30) calendar days we will consider your agreement under these terms terminated. You may also give prior notice of termination by emailing <%= mail_to 'support@octobox.io', 'support@octobox.io', subject: 'Termination of agreement' %>.
-      </p>
-
-      <h4 id='modifications'>Modifications (Things We May Change)</h4>
-      <p>
-        Octobox.io reserves the right at any time and from time to time to modify or discontinue, temporarily or permanently, the Service (or any part thereof) with or without notice.
-      </p>
-      <p>
-        Octobox.io reserves the right to update and change the Terms of Service from time to time without notice. Any new features that augment or enhance the current Service, including the release of new tools and resources, shall be subject to the Terms of Service. Continued use of the Service after any such changes shall constitute your consent to such changes.
-      </p>
-      <p>
-        As the Service grows we may add to or otherwise modify the Service. If we do so we will update the documentation. Occasionally we may need to make changes that require you to modify your usage.
-      </p>
-      <p>
-        Octobox.io shall not be liable to you or to any third party for any modification, price change, suspension or discontinuance of the Service.
-      </p>
-
-      <h4 id='copyrights'>Copyrights and Content Ownership</h4>
-      <p>
-        We claim no intellectual property rights over the material you provide to the Service.
-      </p>
-      <p>
-        The name and logos for Octobox.io are property of Octobox.io. All rights reserved. You may not use the Octobox.io name without written permission from Octobox.io.
-      </p>
-
-      <h4 id='agreements'>Agreements (Things You Agree To)</h4>
-      <ul>
-        <li>Your use of the Service is at your sole risk. The Service is provided on an “as is” and “as available” basis.</li>
-        <li>You understand that Octobox.io uses third party vendors and hosting partners to provide the necessary hardware, software, networking, storage, and related technology required to run the Service.</li>
-        <li>You agree to the terms of our <a href='/privacy'>Privacy Policy</a>.</li>
-        <li>If you are conducting security research you also agree to the terms of our <a href='https://github.com/octobox/octobox/blob/master/docs/RESPONSIBLE_DISCLOSURE_POLICY.md'>responsible disclosure policy</a>.</li>
-      </ul>
-
-      <h4 id='provisions'>Provisions (Things You Must Do)</h4>
-      <ul>
-        <li>You must Comply with the terms of service.</li>
-      </ul>
-
-      <h4 id='restrictions'>Restrictions (Things You Must Not Do)</h4>
-      <ul>
-        <li>You must not perform any action with the intent to introduce errors within or otherwise disrupt or interfere with the provision of the service.</li>
-        <li>You must not make representations regarding ownership, partnership, sponsorship or any other type of endorsement between you and Octobox.io.</li>
-        <li>You may not use the Service for any illegal or unauthorized purpose. </li>
-        <li>You must not, in the use of the Service, violate any laws in your jurisdiction (including but not limited to copyright laws).</li>
-      </ul>
-
-      <h4 id='limitations'>Limitations (Things We Cannot Promise)</h4>
-      <p>
-        Octobox.io does not warrant that (i) the Service will meet your specific requirements, (ii) the Service will be uninterrupted, timely, secure, or error-free, (iii) the results that may be obtained from the use of the Service will be accurate or reliable, (iv) the quality of any products, services, information, or other material purchased or obtained by you through the Service will meet your expectations, and (v) any errors in the Service will be corrected.
-      </p>
-      <p>
-        You expressly understand and agree that  Octobox.io shall not be liable for any direct, indirect, incidental, special, consequential or exemplary damages, including but not limited to, damages for loss of profits, goodwill, use, data or other intangible losses (even if Octobox.io has been advised of the possibility of such damages), resulting from: (i) the use or the inability to use the Service; (ii) the cost of procurement of substitute goods and services resulting from any goods, data, information or services purchased or obtained or messages received or transactions entered into through or from the Service; (iii) unauthorized access to or alteration of your transmissions or data; (iv) statements or conduct of any third party on the Service; (v) or any other matter relating to the Service.
-      </p>
-      <p>
-        Data provided by Octobox.io is gathered from third party sources. Therefore we cannot and do not warrant that it is accurate or up to date and we accept no liability for any errors.
-      </p>
-      <p>
-        The failure of Octobox.io to exercise or enforce any right or provision of the Terms of Service shall not constitute a waiver of such right or provision. The Terms of Service constitutes the entire agreement between you and Octobox.io and govern your use of the Service, superceding any prior agreements between you and Octobox.io (including, but not limited to, any prior versions of the Terms of Service).
-      </p>
-
-      <h4 id='bugs'>Bugs, Errors and Issues</h4>
-      <p>
-        If you find a bug or error in the operation or content of the service please file an issue in our <a href='https://github.com/octobox/octobox/issues/new'>bug tracker</a>.
-      </p>
-
-      <h4 id='support'>Support</h4>
-      <p>
-        Octobox.io is a small community of people supporting the service. We do not offer formal support processes. If you require mroe formal support arrangements please <a href='mailto:support@octobox.io'>email us</a> otherwise you can try:
-      </p>
-      <ul>
-        <li>Filing an issue in our <a href='https://github.com/octobox/octobox/issues/new'>bug tracker</a> following the template provided.</li>
-        <li>Asking for help in our <a href='https://gitter.im/octobox/octobox'>public chat room</a>.</li>
-        <li>Email us at <%= mail_to 'support@octobox.io' %>.</li>
-        <li>Tweet us at <%= link_to '@octoboxio', 'https://twitter.com/octoboxio' %>.</li>
-      </ul>
-      <hr>
+<div class="flex-content justify-content-center">
+  <div class="flex-main readable pt-5">
+    <div class='d-flex align-items-end justify-content-between'>
+      <h1>Terms and Conditions</h1>
+      <%= link_to octobox_round(80), root_path  %>
     </div>
+    <hr>
+    <p>
+      Thank you for using Octobox.io!
+    </p>
+    <p>
+      Octobox.io is owned and operated operated by Octobox Ltd. ("Octobox.io"), company number 11469796 registered in England and Wales.
+    </p>
+    <h4 id='acceptance'>Acceptance (How To Accept These Things)</h4>
+    <p>
+      By using the Octobox.io web site ("Service") you are agreeing to the terms and conditions ("Terms of Service") presented below.
+    </p>
+
+    <h4 id='account'>Account Terms</h4>
+      You may not enter into this agreement if you are not of legal age to do so, you are legally prohibited from doing so or you are not a human.
+    </p>
+    <p>
+      If you are using the Service on behalf of a legal entity you are representing that you have authority to bind that entity to these terms. By accepting these terms you are doing so on behalf of that entity and all references to 'you' and 'your' refer to that entity from here on.
+    </p>
+
+    <h4 id='termination'>Cancellation and Termination (How To Cancel This Agreement)</h4>
+    <p>
+      You may stop using the Service without notice. If you do not use the Service for thirty (30) calendar days we will consider your agreement under these terms terminated. You may also give prior notice of termination by emailing <%= mail_to 'support@octobox.io', 'support@octobox.io', subject: 'Termination of agreement' %>.
+    </p>
+
+    <h4 id='modifications'>Modifications (Things We May Change)</h4>
+    <p>
+      Octobox.io reserves the right at any time and from time to time to modify or discontinue, temporarily or permanently, the Service (or any part thereof) with or without notice.
+    </p>
+    <p>
+      Octobox.io reserves the right to update and change the Terms of Service from time to time without notice. Any new features that augment or enhance the current Service, including the release of new tools and resources, shall be subject to the Terms of Service. Continued use of the Service after any such changes shall constitute your consent to such changes.
+    </p>
+    <p>
+      As the Service grows we may add to or otherwise modify the Service. If we do so we will update the documentation. Occasionally we may need to make changes that require you to modify your usage.
+    </p>
+    <p>
+      Octobox.io shall not be liable to you or to any third party for any modification, price change, suspension or discontinuance of the Service.
+    </p>
+
+    <h4 id='copyrights'>Copyrights and Content Ownership</h4>
+    <p>
+      We claim no intellectual property rights over the material you provide to the Service.
+    </p>
+    <p>
+      The name and logos for Octobox.io are property of Octobox.io. All rights reserved. You may not use the Octobox.io name without written permission from Octobox.io.
+    </p>
+
+    <h4 id='agreements'>Agreements (Things You Agree To)</h4>
+    <ul>
+      <li>Your use of the Service is at your sole risk. The Service is provided on an “as is” and “as available” basis.</li>
+      <li>You understand that Octobox.io uses third party vendors and hosting partners to provide the necessary hardware, software, networking, storage, and related technology required to run the Service.</li>
+      <li>You agree to the terms of our <a href='/privacy'>Privacy Policy</a>.</li>
+      <li>If you are conducting security research you also agree to the terms of our <a href='https://github.com/octobox/octobox/blob/master/docs/RESPONSIBLE_DISCLOSURE_POLICY.md'>responsible disclosure policy</a>.</li>
+    </ul>
+
+    <h4 id='provisions'>Provisions (Things You Must Do)</h4>
+    <ul>
+      <li>You must Comply with the terms of service.</li>
+    </ul>
+
+    <h4 id='restrictions'>Restrictions (Things You Must Not Do)</h4>
+    <ul>
+      <li>You must not perform any action with the intent to introduce errors within or otherwise disrupt or interfere with the provision of the service.</li>
+      <li>You must not make representations regarding ownership, partnership, sponsorship or any other type of endorsement between you and Octobox.io.</li>
+      <li>You may not use the Service for any illegal or unauthorized purpose. </li>
+      <li>You must not, in the use of the Service, violate any laws in your jurisdiction (including but not limited to copyright laws).</li>
+    </ul>
+
+    <h4 id='limitations'>Limitations (Things We Cannot Promise)</h4>
+    <p>
+      Octobox.io does not warrant that (i) the Service will meet your specific requirements, (ii) the Service will be uninterrupted, timely, secure, or error-free, (iii) the results that may be obtained from the use of the Service will be accurate or reliable, (iv) the quality of any products, services, information, or other material purchased or obtained by you through the Service will meet your expectations, and (v) any errors in the Service will be corrected.
+    </p>
+    <p>
+      You expressly understand and agree that  Octobox.io shall not be liable for any direct, indirect, incidental, special, consequential or exemplary damages, including but not limited to, damages for loss of profits, goodwill, use, data or other intangible losses (even if Octobox.io has been advised of the possibility of such damages), resulting from: (i) the use or the inability to use the Service; (ii) the cost of procurement of substitute goods and services resulting from any goods, data, information or services purchased or obtained or messages received or transactions entered into through or from the Service; (iii) unauthorized access to or alteration of your transmissions or data; (iv) statements or conduct of any third party on the Service; (v) or any other matter relating to the Service.
+    </p>
+    <p>
+      Data provided by Octobox.io is gathered from third party sources. Therefore we cannot and do not warrant that it is accurate or up to date and we accept no liability for any errors.
+    </p>
+    <p>
+      The failure of Octobox.io to exercise or enforce any right or provision of the Terms of Service shall not constitute a waiver of such right or provision. The Terms of Service constitutes the entire agreement between you and Octobox.io and govern your use of the Service, superceding any prior agreements between you and Octobox.io (including, but not limited to, any prior versions of the Terms of Service).
+    </p>
+
+    <h4 id='bugs'>Bugs, Errors and Issues</h4>
+    <p>
+      If you find a bug or error in the operation or content of the service please file an issue in our <a href='https://github.com/octobox/octobox/issues/new'>bug tracker</a>.
+    </p>
+
+    <h4 id='support'>Support</h4>
+    <p>
+      Octobox.io is a small community of people supporting the service. We do not offer formal support processes. If you require mroe formal support arrangements please <a href='mailto:support@octobox.io'>email us</a> otherwise you can try:
+    </p>
+    <ul>
+      <li>Filing an issue in our <a href='https://github.com/octobox/octobox/issues/new'>bug tracker</a> following the template provided.</li>
+      <li>Asking for help in our <a href='https://gitter.im/octobox/octobox'>public chat room</a>.</li>
+      <li>Email us at <%= mail_to 'support@octobox.io' %>.</li>
+      <li>Tweet us at <%= link_to '@octoboxio', 'https://twitter.com/octoboxio' %>.</li>
+    </ul>
+    <hr>
+
+    <%= render 'layouts/footer'%>
   </div>
 </div>
-
-<%= render 'layouts/footer'%>


### PR DESCRIPTION
* moves `/`, `/terms`, `/privacy` and `/pricing` to basic containers and adds touch scrolling
* fixes broken `list-group-flush` on `/documentation`
* replaces `mt` with `pt` on footer which seems to work smoother on iOS
* moves pricing card styling to CSS over utilities

deployed at https://octobox-benjam.herokuapp.com/