### PR TITLE
Allow notifications horizontal scrolling

### DIFF
--- a/app/assets/stylesheets/_layout.scss
+++ b/app/assets/stylesheets/_layout.scss
@@ -50,7 +50,7 @@ body {
 .flex-main {
   flex: 1;
   min-width: 0;
-  overflow-x: hidden;
+  overflow-x: scroll;
   padding-left: 0;
 }
 


### PR DESCRIPTION
To fix the case where notification actions, like archive or mute, are hidden by the notification thread section, allow horizontal scrolling for overflow content.

Example: 

The quick actions are hidden from access due to the thread area. 

<img width="1659" alt="screen shot 2018-11-14 at 11 13 48 am" src="https://user-images.githubusercontent.com/3051193/48495611-65c63c80-e7fe-11e8-9893-9b43bf29699f.png">
