### PR TITLE
Cleanup unique jobs digest after death

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -16,6 +16,10 @@ if Octobox.background_jobs_enabled?
     Sidekiq::Status.configure_client_middleware config, expiration: 60.minutes
   end
 
+  config.death_handlers << ->(job, _ex) do
+    SidekiqUniqueJobs::Digests.del(digest: job['unique_digest']) if job['unique_digest']
+  end
+
   Sidekiq.configure_client do |config|
     config.redis = { url: Octobox.config.redis_url }
     Sidekiq::Status.configure_client_middleware config, expiration: 60.minutes


### PR DESCRIPTION
Should stop users being unable to resync after a previous sync job has died like in https://github.com/octobox/octobox/issues/1067