### PR TITLE
Fix table row border hover bug in chrome by making it 1px wide

### DIFF
--- a/app/assets/stylesheets/_notifications.scss
+++ b/app/assets/stylesheets/_notifications.scss
@@ -49,19 +49,19 @@ $notification-items: (
 
 @mixin add-borders{
   .table-notifications tr td:first-child {
-    border-left: 2px solid $list-group-bg;
+    border-left: 1px solid $list-group-bg;
   }
   .table-notifications tr.active td:first-child {
-    border-left: 2px solid $list-group-action-active-bg;
+    border-left: 1px solid $list-group-action-active-bg;
   }
   .table-notifications tr:hover td:first-child {
-    border-left: 2px solid $list-group-action-hover-color;
+    border-left: 1px solid $list-group-action-hover-color;
   }
   .table-notifications tr.active:hover td:first-child {
-    border-left: 2px solid $list-group-action-hover-color;
+    border-left: 1px solid $list-group-action-hover-color;
   }
   td.current {
-    border-left: 2px solid $list-group-active-border-color !important;
+    border-left: 1px solid $list-group-active-border-color !important;
   }
 }
 
@@ -84,7 +84,7 @@ $notification-items: (
 }
 
 @mixin regular-table{
-  
+
   @include add-borders;
 
   @each $item in $notification-items{
@@ -229,11 +229,11 @@ $notification-items: (
 }
 
 @include media-breakpoint-up(xxxl){
-  @include regular-table; 
+  @include regular-table;
 }
 
 @include media-breakpoint-down(xxl) {
-  @include regular-table; 
+  @include regular-table;
   .flex-main.show-thread{
     @include remove-borders;
     @include responsive-table;


### PR DESCRIPTION
Fixes https://github.com/octobox/octobox/issues/1178