### PR TITLE
Fix links in header dropdown menu

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -75,7 +75,7 @@
               <% end %>
             <% end %>
           <% end %>
-          <%= link_to "documentation", class: 'dropdown-item' do %>
+          <%= link_to "/documentation", class: 'dropdown-item' do %>
             <%= octicon 'book', height: 16, class: 'text-muted' %>
             User Documentation
           <% end %>
@@ -86,12 +86,12 @@
               <% end %>
           <% end %>
           <% if File.exist?(Rails.root.join('public', 'docs', 'index.html')) %>
-            <%= link_to "docs/", class: 'dropdown-item' do %>
+            <%= link_to "/docs/", class: 'dropdown-item' do %>
               <%= octicon 'code', height: 16, class: 'text-muted' %>
               API Documentation
             <% end %>
           <% end %>
-          <%= link_to "settings", class: 'dropdown-item' do %>
+          <%= link_to "/settings", class: 'dropdown-item' do %>
             <%= octicon 'settings', height: 16, class: 'text-muted' %>
             Settings
           <% end %>


### PR DESCRIPTION
When notifications are open, links will have a different root and
need to be made absolute in order to avoid that.