### PR TITLE
Reduce padding in sidebar

### DIFF
--- a/app/assets/stylesheets/_layout.scss
+++ b/app/assets/stylesheets/_layout.scss
@@ -42,7 +42,6 @@ body {
 .flex-sidebar {
   flex: 0 0 250px;
   width: $sidebar-width;
-  padding: 15px;
   padding-bottom: 60px;
   overflow: auto;
 }

--- a/app/assets/stylesheets/_sidebar.scss
+++ b/app/assets/stylesheets/_sidebar.scss
@@ -8,6 +8,9 @@
     &:hover{
       background-color: $list-group-hover-bg;
     }
+    .nav-link{
+      border-radius: 0;
+    }
   }
 
   &:first-child{


### PR DESCRIPTION
Aligns the top sidebar menu item with the fixed header on the notifications table and removes the rounded corners on active sidebar menu items. 

I felt like the two sections didn't really match in style and placement.

Before and after:

<img width="1098" alt="screen shot 2018-11-18 at 11 56 32" src="https://user-images.githubusercontent.com/1060/48672067-0e3f0e00-eb29-11e8-8cf1-b2fe47d78eec.png">
