### PR TITLE
Align notification date to the right

### DIFF
--- a/app/assets/stylesheets/_notifications.scss
+++ b/app/assets/stylesheets/_notifications.scss
@@ -112,6 +112,7 @@ $notification-items: (
     }
     .notification-date{
       min-width: 5.5em;
+      text-align: right;
     }
     .buttons{
       display: none;


### PR DESCRIPTION
Fixes a text overlap bug on small screens:

<img width="466" alt="screen shot 2018-11-18 at 13 49 45" src="https://user-images.githubusercontent.com/1060/48673425-41899900-eb39-11e8-8c91-72045e6ac9cb.png">
