### PR TITLE
Increase time inbetween automatic syncing of users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,7 +26,7 @@ class User < ApplicationRecord
   }
   validates_with PersonalAccessTokenValidator
 
-  scope :not_recently_synced, -> { where('last_synced_at < ?', 1.minute.ago) }
+  scope :not_recently_synced, -> { where('last_synced_at < ?', 5.minutes.ago) }
 
   def admin?
     Octobox.config.github_admin_ids.include?(github_id.to_s)


### PR DESCRIPTION
Avoid getting into a loop of syncing the same few users every minute by only syncing users who've not been synced in the last 5 minutes when a subject is updated.