### PR TITLE
Show a spinner when loading a thread view

### DIFF
--- a/app/assets/javascripts/octobox.js
+++ b/app/assets/javascripts/octobox.js
@@ -386,6 +386,9 @@ var Octobox = (function() {
 
     window.onpopstate = function(event) {
       if(event.state.thread){
+
+        $('#thread').html($('#loading').html())
+
         $.get(event.state.thread, function(data){
           $('#thread').html(data)
         });
@@ -423,6 +426,9 @@ var Octobox = (function() {
 
   var viewThread = function() {
     history.pushState({thread: $(this).attr('href')}, 'Octobox', $(this).attr('href'))
+
+    $('#thread').html($('#loading').html())
+
     $.get($(this).attr('href'), function(data){
       if (data["error"] != null) {
         $(".header-flash-messages").empty();

--- a/app/views/notifications/_loading.html.erb
+++ b/app/views/notifications/_loading.html.erb
@@ -1,0 +1,5 @@
+<div id="loading" class='d-none'>
+  <div class="nothing-here text-center align-self-center">
+    <%= octicon 'sync', height: 32, class: 'spinning' %>
+  </div>
+</div>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -21,6 +21,7 @@
         <% end %>
       </div>
     </div>
+    <%= render 'loading' %>
   <% end %>
 </div>
 

--- a/app/views/notifications/show.html.erb
+++ b/app/views/notifications/show.html.erb
@@ -13,6 +13,7 @@
   <div id='thread' class='flex-thread'>
    <%= render 'thread' %>
   </div>
+  <%= render 'loading' %>
 </div>
 
 <%= render 'help-box' %>


### PR DESCRIPTION
Useful on slower connections so you know something is happening.

Looks like this when loading (but with the icon spinning):

<img width="1726" alt="screen shot 2018-11-20 at 14 50 20" src="https://user-images.githubusercontent.com/1060/48781299-aaa51400-ecd3-11e8-945d-c94853fdff7c.png">
