### PR TITLE
Use update rather than update_attributes when saving existing repos

### DIFF
--- a/lib/octobox/notifications/sync_repository.rb
+++ b/lib/octobox/notifications/sync_repository.rb
@@ -26,7 +26,7 @@ module Octobox
         end
 
         if repository
-          repository.update_attributes({
+          repository.update({
             full_name: remote_repository.full_name,
             private: remote_repository.private,
             owner: remote_repository.owner[:login],


### PR DESCRIPTION
Avoids validation errors when name hasn't changed, which looks like it's causing many repos to be repeatedly synced.