### PR TITLE
Skip syncing the repository if it's already present

### DIFF
--- a/lib/octobox/notifications/sync_repository.rb
+++ b/lib/octobox/notifications/sync_repository.rb
@@ -12,7 +12,7 @@ module Octobox
 
       def update_repository_in_foreground(force = false)
         return unless Octobox.config.subjects_enabled?
-        return if !force && repository != nil && updated_at - repository.updated_at < 2.seconds
+        return if !force && repository
 
         remote_repository = download_repository
 


### PR DESCRIPTION
Follow up from https://github.com/octobox/octobox/pull/1278, reducing the amount of update repository background jobs by skipping when the repo is present