### PR TITLE
Skip enqueuing repository sync tasks if repo exists

### DIFF
--- a/lib/octobox/notifications/sync_repository.rb
+++ b/lib/octobox/notifications/sync_repository.rb
@@ -5,7 +5,7 @@ module Octobox
 
       def update_repository(force = false)
         return unless Octobox.config.subjects_enabled?
-        return if !force && repository != nil && updated_at - repository.updated_at < 2.seconds
+        return if !force && repository
 
         UpdateRepositoryWorker.perform_async_if_configured(self.id, force)
       end


### PR DESCRIPTION
Many of the current repo syncing jobs are no-ops