### PR TITLE
Involved users should always be ones that haven't been recently synced

### DIFF
--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -168,7 +168,7 @@ class Subject < ApplicationRecord
   end
 
   def involved_user_ids
-    ids = users.pluck(:id)
+    ids = users.not_recently_synced.pluck(:id)
     ids += repository.users.not_recently_synced.pluck(:id) if repository.present?
     ids.uniq
   end


### PR DESCRIPTION
Follow on from https://github.com/octobox/octobox/pull/1265, picks up some users that shouldn't be synced because they have been recently synced.