### PR TITLE
Add a linked button to reply on GitHub to bottom of threads

### DIFF
--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -87,6 +87,10 @@ class Subject < ApplicationRecord
      comment_count && comment_count > 0
   end
 
+  def commentable?
+    !comment_count.nil?
+  end
+
   def update_status
     if sha.present?
       remote_status = download_status

--- a/app/views/notifications/_thread.html.erb
+++ b/app/views/notifications/_thread.html.erb
@@ -89,5 +89,12 @@
         </div>
       </div>
     <% end %>
+
+    <% if @notification.subject.commentable? %>
+      <%= link_to @notification.subject.html_url+'#new_comment_field', target: :blank, class: 'btn btn-success mt-2 float-right' do %>
+        Reply on GitHub
+        <%= octicon('link-external', height: 18, class: 'ml-1') %>
+      <% end %>
+    <% end %>
   <% end %>
 </div>


### PR DESCRIPTION
Handy to bounce you to the comment form until we implement the ability to reply directly from Octobox.

Screenshot: 

<img width="679" alt="screen shot 2018-11-23 at 09 48 01" src="https://user-images.githubusercontent.com/1060/48937176-3487f380-ef05-11e8-942c-eba6acf94a66.png">
