### PR TITLE
Turn off autocomplete on all checkboxes

### DIFF
--- a/app/views/notifications/_list.html.erb
+++ b/app/views/notifications/_list.html.erb
@@ -21,7 +21,7 @@
     </button>
     <% if @notifications.to_a.any? %>
       <div class="custom-control custom-checkbox select-all d-inline-block">
-        <input id="select_all" type="checkbox" class='custom-control-input js-select_all' aria-label='Select All'>
+        <input id="select_all" type="checkbox" autocomplete="off" class='custom-control-input js-select_all' aria-label='Select All'>
         <%= label_tag "select_all", '', class: "custom-control-label" %>
       </div>
       <%= select_all_button(@cur_selected, @total) %>

--- a/app/views/notifications/_notification.html.erb
+++ b/app/views/notifications/_notification.html.erb
@@ -6,7 +6,8 @@
           notification.id,
           false,
           title: (notification.archived ? 'Unarchive' : 'Archive'),
-          class: 'custom-control-input ' + (notification.archived ? 'unarchive' : 'archive')
+          class: 'custom-control-input ' + (notification.archived ? 'unarchive' : 'archive'),
+          autocomplete: "off"
         )
       %>
       <%= label_tag "notification_#{notification.id}", '', class: "custom-control-label" %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -91,7 +91,7 @@
             <div class="form-group">
               <div class="checkbox">
                 <label>
-                  <input type="checkbox" name="clear_personal_access_token" id="clear_personal_access_token"/>
+                  <input type="checkbox" autocomplete="off" name="clear_personal_access_token" id="clear_personal_access_token"/>
                   Clear personal access token
                 </label>
               </div>


### PR DESCRIPTION
Firefox persists selected checkboxes across refreshes (and turbolinks page loads it seems), adding autocomplete="off" disables that annoying "feature".

Possibly related to https://github.com/octobox/octobox/issues/1285