### PR TITLE
Fix javascript error when opening external subject links

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -66,4 +66,4 @@ $(document).on('click', '.toggle-star', function() {
   Octobox.toggleStarClick($(this))
 });
 
-$(document).on('click', '.subject-link', Octobox.viewThread);
+$(document).on('click', '.thread-link', Octobox.viewThread);

--- a/app/views/notifications/_notification.html.erb
+++ b/app/views/notifications/_notification.html.erb
@@ -45,7 +45,7 @@
     <% end %>
   </td>
   <td class='notification-subject'>
-    <%= link_to notification_link(notification), target: (Octobox.config.open_in_same_tab ? nil : '_blank'), rel: "noopener", class: 'subject-link link', onclick: "Octobox.markRead(#{notification.id})", data:{toggle:(notification.display_thread? ? 'showthread' : nil)}, title: notification.title do %>
+    <%= link_to notification_link(notification), target: (Octobox.config.open_in_same_tab ? nil : '_blank'), rel: "noopener", class: "subject-link link #{'thread-link' if notification.display_thread?}", onclick: "Octobox.markRead(#{notification.id})", data:{toggle:(notification.display_thread? ? 'showthread' : nil)}, title: notification.title do %>
         <%= subject_with_number(notification) %>
         <%= octicon('link-external', class:'text-primary') unless notification.display_thread? %>
     <% end %>


### PR DESCRIPTION
Should only try to pushstate for links that open a thread view, not external links.