### PR TITLE
Uncheck all selected notifications after "Mark as Read" is done

### DIFF
--- a/app/assets/javascripts/octobox.js
+++ b/app/assets/javascripts/octobox.js
@@ -130,6 +130,11 @@ var Octobox = (function() {
     getDisplayedRows().find("input").prop("checked", checked).trigger("change");
   };
 
+  var uncheckAll = function () {
+    $(".js-select_all").prop("checked", false);
+    checkAll();
+  }
+
   var muteThread = function() {
     var id = $('#notification-thread').data('id');
     mute(id);
@@ -165,7 +170,7 @@ var Octobox = (function() {
     .done(function () {
       rows.removeClass("blur-action");
       rows.removeClass("active");
-      rows.find("input[type=checkbox]").prop('checked', false);
+      uncheckAll();
       updateFavicon();
     })
     .fail(function(){


### PR DESCRIPTION
When "Select All" is used with "Mark as Read" it will only uncheck list items,
but leave "Select All" checked.

This will use "Select All" to uncheck All items and fixes the issue in #1285.

![kapture 2018-11-24 at 17 32 11](https://user-images.githubusercontent.com/7757/48970707-d6940280-f00f-11e8-8871-cf2994465e2b.gif)
