### PR TITLE
Add 10 to pagination intervals

### DIFF
--- a/app/views/notifications/_list.html.erb
+++ b/app/views/notifications/_list.html.erb
@@ -7,7 +7,7 @@
           <span class="caret"></span>
         </button>
         <ul class="dropdown-menu dropdown-menu-right text-right">
-          <% %w(20 40 60 80 100).map do |pagination_interval| %>
+          <% %w(10 20 40 60 80 100).map do |pagination_interval| %>
             <%= link_to pagination_interval, root_path(filtered_params(per_page: pagination_interval.to_i)), class: "dropdown-item #{'active' if @per_page == pagination_interval.to_i}" %>
           <% end %>
         </ul>


### PR DESCRIPTION
When viewing octobox on small screens like an iPad, 20 notfications do not fit on the screen. Thus you'll always have to scroll to see the lower part of the items list and the navigation buttons.

This PR adds a new item for just showing 10 notifications per page, so that everything is visible without scrolling.