### PR TITLE
Don't try to return a title if we don't want to display the subject

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -56,8 +56,11 @@ class Notification < ApplicationRecord
   end
 
   def title
-    body = subject.try(:body)
-    body.split("\n")[0..3].join if body
+    return unless display_subject?
+
+    if (body = subject.try(:body))
+      body.split("\n")[0..3].join
+    end
   end
 
   def state


### PR DESCRIPTION
From my findings in https://github.com/octobox/octobox/pull/1345

This stops a `Notification` from returning a title if we don't want to display the subject.

Currently this is causing an N+1 because we only eager load the `Subject` if we want to display them https://github.com/octobox/octobox/blob/38900ef58ef559d8c8a233ffb2f08ccc7375b28c/app/controllers/notifications_controller.rb#L343

and in https://github.com/octobox/octobox/blob/38900ef58ef559d8c8a233ffb2f08ccc7375b28c/app/views/notifications/_notification.html.erb#L47-L51

we call `Notification#title` which looks for a `subject`.

---

I'm open to other solutions, feedback welcome ✨ 