### PR TITLE
Added dump.rdb to the .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ public/docs
 .database
 config/sidekiq_custom_schedule.yml
 .yardoc
+dump.rdb


### PR DESCRIPTION
The dump.rdb file is created every time I run the test suite and should be added to .gitignore.