### PR TITLE
Issue 1284 highlight alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Octobox helps you manage your GitHub notifications efficiently so you can spend 
 
 - **Don't lose track** - Octobox adds an extra "archived" state to each notification so you can mark it as "done". If anything happens on an archived thread, issue or PR, Octobox will move it back into your inbox.
 
-- **Starred notifications** - Let's be honest, you probably don't have a 'favourite' issue but Octobox lets you highlight important notifications with a star so you can come back and find them easily. 
+- **Starred notifications** - Let's be honest, you probably don't have a 'favourite' issue but Octobox lets you highlight important notifications with a star so you can come back and find them easily.
 
 - **Enhanced notifications** - Like notifications, but better. With issue/pull-request status, CI status, labels and more shown alongside basic title, organisation, repo and type information.
 

--- a/app/assets/stylesheets/_sidebar.scss
+++ b/app/assets/stylesheets/_sidebar.scss
@@ -12,7 +12,7 @@
       border-radius: 0;
     }
   }
-
+  .nav-item.unread-alert{background-color: red;}
   &:first-child{
     margin-top: 0px;
     padding-top: 0px;

--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -232,7 +232,11 @@ module NotificationsHelper
   end
 
   def sidebar_filter_link(active:, param:, value:, count: nil, except: nil, link_class: nil, path_params: nil, title: nil)
-    content_tag :li, class: (active ? 'nav-item active' : 'nav-item'), title: title do
+    css_class = 'nav-item'
+    css_class += ' active' if active
+    css_class += ' unread-alert' if unread_alerts?(value)
+
+    content_tag :li, class: css_class, title: title do
       active = (active && not_repo_in_active_org(param))
       path_params ||= filtered_params(param => (active ? nil : value)).except(except)
       link_to root_path(path_params), class: (active ? "nav-link active filter #{link_class}" : "nav-link filter #{link_class}") do
@@ -336,5 +340,11 @@ module NotificationsHelper
 
   def display_thread?
     Octobox.include_comments? && current_user.display_comments
+  end
+
+  def unread_alerts?(type)
+    type == 'RepositoryVulnerabilityAlert' &&
+      Notification.reorder(nil).
+                   where(unread: true, subject_type: "RepositoryVulnerabilityAlert").count > 0
   end
 end

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -82,7 +82,10 @@ Protip: To generate a key, you can use `bin/rails secret | cut -c1-32`
 
 ## Local installation
 
-First things first, you'll need to install Ruby 2.5.3. I recommend using the excellent [rbenv](https://github.com/rbenv/rbenv),
+First things first, you'll need to fork and clone Octobox repository to
+your local machine.
+
+Secondly, you'll need to install Ruby 2.5.3. I recommend using the excellent [rbenv](https://github.com/rbenv/rbenv),
 and [ruby-build](https://github.com/rbenv/ruby-build):
 
 ```bash
@@ -125,7 +128,7 @@ Now go and register a new [GitHub OAuth Application](https://github.com/settings
 
 If you're deploying this to production, just replace `http://localhost:3000` with your applications URL.
 
-Once you've created your application you can then then add the following to your `.env`:
+Once you've created your application you can then then create a new `.env` file and then add the following to your file:
 
 ```
 GITHUB_CLIENT_ID=yourclientidhere

--- a/test/controllers/notifications_controller_test.rb
+++ b/test/controllers/notifications_controller_test.rb
@@ -951,4 +951,20 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
     get '/?q=status%3Apending'
     assert_equal assigns(:notifications).length, 1
   end
+
+  test 'highlights vulnerability alerts in the sidebar if there are unread notifications' do
+    sign_in_as(@user)
+    create(:notification, user: @user, subject_type: 'RepositoryVulnerabilityAlert', unread: true)
+    get '/'
+    assert_response :success
+    assert_select '.unread-alert', {count: 1}
+  end
+
+  test 'Does not highlight vulnerability alerts in the sidebar if there are no unread notifications' do
+    sign_in_as(@user)
+    create(:notification, user: @user, subject_type: 'RepositoryVulnerabilityAlert', unread: false)
+    get '/'
+    assert_response :success
+    assert_select '.unread-alert', {count: 0}
+  end
 end


### PR DESCRIPTION
This commit fixes the #1284 issue by adding an unread-alert class for "RepositoryVulnerabilityAlert'  to the notifications_helper. However I don't think querying the database from notification helper is the best solution. Would love some feedback/ideas on improving this solution.

`def sidebar_filter_link(active:, param:, value:, count: nil, except: nil, link_class: nil, path_params: nil, title: nil)
    css_class = 'nav-item'
    css_class += ' active' if active
    css_class += ' unread-alert' if unread_alerts?(value)`

`def unread_alerts?(type)
    type == 'RepositoryVulnerabilityAlert' &&
      Notification.reorder(nil).
                   where(unread: true, subject_type: "RepositoryVulnerabilityAlert").count > 0
  end`

