### PR TITLE
Specify the allowed origins for actioncable via an env var

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -40,7 +40,10 @@ Rails.application.configure do
   # Mount Action Cable outside main process or domain
   # config.action_cable.mount_path = nil
   # config.action_cable.url = 'wss://example.com/cable'
-  # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
+
+  if ENV['WEBSOCKET_ALLOWED_ORIGINS'].present?
+    config.action_cable.allowed_request_origins = ENV['WEBSOCKET_ALLOWED_ORIGINS'].split(',')
+  end
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = ENV.fetch("FORCE_SSL") { false }

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -432,4 +432,4 @@ You can set the `OPEN_IN_SAME_TAB` environment variable, which will force all no
 
 Octobox has an experimental feature where it can live-update notifications when they change using websockets. Only notifications you are currently viewing will be updated, no rows will be added or removed dynamically.
 
-To enable this set the environment variable `PUSH_NOTIFICATIONS` to `true` and ensure you have redis configured for your instance.
+To enable this set the environment variable `PUSH_NOTIFICATIONS` to `true` and ensure you have redis configured for your instance. Also, set `WEBSOCKET_ALLOWED_ORIGIN` to Octobox base URL, e.g. `http://localhost` (it can take multiple values, e.g. `http://localhost,https://localhost`).


### PR DESCRIPTION
Despite having turn on `PUSH_NOTIFICATIONS`, the `/cable` endpoint was always returning a 404 and following lines were logged: 

```
| 12:55:24 web.1    | I, [2018-12-17T12:55:24.360905 #35]  INFO -- : [2259cd52-43e2-4f6b-9887-db835c5e136b] Started GET "/cable/" [WebSocket] for 172.28.0.5 at 2018-12-17 12:55:24 +0000
| 12:55:24 web.1    | E, [2018-12-17T12:55:24.361083 #35] ERROR -- : [2259cd52-43e2-4f6b-9887-db835c5e136b] Request origin not allowed: http://localhost
| 12:55:24 web.1    | E, [2018-12-17T12:55:24.361150 #35] ERROR -- : [2259cd52-43e2-4f6b-9887-db835c5e136b] Failed to upgrade to WebSocket (REQUEST_METHOD: GET, HTTP_CONNECTION: Upgrade, HTTP_UPGRADE: websocket)
| 12:55:24 web.1    | I, [2018-12-17T12:55:24.361212 #35]  INFO -- : [2259cd52-43e2-4f6b-9887-db835c5e136b] Finished "/cable/" [WebSocket] for 172.28.0.5 at 2018-12-17 12:55:24 +0000
```

I'm not sure if it happens due to Octobox running behind a proxy (nginx), but setting `config.action_cable.allowed_request_origins` solves the issue in any case.