### PR TITLE
Paid plans can be named "private" or "personal"

### DIFF
--- a/app/models/subscription_plan.rb
+++ b/app/models/subscription_plan.rb
@@ -6,7 +6,7 @@ class SubscriptionPlan < ApplicationRecord
   scope :github, -> { where.not(github_id: nil) }
 
   def private_repositories_enabled?
-    name.match?(/private/i)
+    name.match?(/private/i) || name.match?(/personal/i)
   end
 
   def github?

--- a/test/factories/subscription_plan.rb
+++ b/test/factories/subscription_plan.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :subscription_plan do
+    name { 'Free projects' }
+  end
+end

--- a/test/models/subscription_plan_test.rb
+++ b/test/models/subscription_plan_test.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+class SubscriptionPlanTest < ActiveSupport::TestCase
+  setup do
+    @subscription_plan = create(:subscription_plan)
+  end
+
+  test 'must have a name' do
+    @subscription_plan.name = nil
+    refute @subscription_plan.valid?
+  end
+
+  test 'private_repositories_enabled for "private" plans' do
+    @subscription_plan.name = 'Private projects'
+    assert @subscription_plan.private_repositories_enabled?
+  end
+
+  test 'private_repositories_enabled for "personal" plans' do
+    @subscription_plan.name = 'Personal projects'
+    assert @subscription_plan.private_repositories_enabled?
+  end
+
+  test 'private_repositories_enabled for "other" plans' do
+    @subscription_plan.name = 'Free'
+    refute @subscription_plan.private_repositories_enabled?
+  end
+
+  test 'github?' do
+    @subscription_plan.github_id = 1
+    assert @subscription_plan.github?
+  end
+
+  test 'not github?' do
+    @subscription_plan.github_id = nil
+    refute @subscription_plan.github?
+  end
+
+  test 'open_collective?' do
+    @subscription_plan.name = 'Open Collective Sponsor'
+    assert @subscription_plan.open_collective?
+  end
+
+  test 'not open_collective?' do
+    @subscription_plan.name = 'Free'
+    refute @subscription_plan.open_collective?
+  end
+end


### PR DESCRIPTION
To handle the upcoming personal plan on https://octobox.io.

Also adds some basic unit tests for the subscription plan class