### PR TITLE
Handle notifications without users more gracefully

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -151,7 +151,7 @@ class Notification < ApplicationRecord
   end
 
   def github_app_installed?
-    Octobox.github_app? && user.github_app_authorized? && repository.try(:github_app_installed?)
+    Octobox.github_app? && user.try(:github_app_authorized?) && repository.try(:github_app_installed?)
   end
 
   def subjectable?


### PR DESCRIPTION
Occasionally notification jobs get stuck in the queue that don't have an associated user and so never complete, this change means they'll fail early and won't get stuck in the retry queue.