### PR TITLE
Add a rake task to clean up sidekiq-unique-jobs cache in redis

### DIFF
--- a/lib/tasks/tasks.rake
+++ b/lib/tasks/tasks.rake
@@ -47,4 +47,13 @@ namespace :tasks do
   task sync_installations: :environment do
     AppInstallation.all.find_each(&:sync)
   end
+
+  desc "cleanup unique-jobs cache"
+  task cleanup_unique_jobs: :environment do
+    Sidekiq.redis do |conn|
+      conn.keys('uniquejobs:*').each do |key|
+        conn.del(key)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Short-term hack, in Octobox.io it slowly grows forever and isn't correctly cleaned up causing redis to eventually run out of ram.