### PR TITLE
Hide thread view options 

### DIFF
--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -118,22 +118,24 @@
         </div>
       </div>
 
-      <div class="w-100 mb-3 card">
-        <div class='ribbon info'>
-          <span>Beta</span>
-        </div>
-        <h5 class="card-header">
-          Open notifications
-        </h5>
-        <div class="card-body">
-          <div class="form-group">
-            <%= f.select :display_comments, [['On GitHub', 'false'], ['On Octobox', 'true']], {}, class: 'form-control' %>
+      <% if Octobox.config.subjects_enabled? && Octobox.config.include_comments %>
+        <div class="w-100 mb-3 card">
+          <div class='ribbon info'>
+            <span>Beta</span>
           </div>
+          <h5 class="card-header">
+            Open notifications
+          </h5>
+          <div class="card-body">
+            <div class="form-group">
+              <%= f.select :display_comments, [['On GitHub', 'false'], ['On Octobox', 'true']], {}, class: 'form-control' %>
+            </div>
 
-          <%= submit_tag 'Save', class: 'btn btn-primary' %>
-          <%= link_to 'Cancel', root_path, class: 'btn btn-light' %>
+            <%= submit_tag 'Save', class: 'btn btn-primary' %>
+            <%= link_to 'Cancel', root_path, class: 'btn btn-light' %>
+          </div>
         </div>
-      </div>
+      <% end %>
     </div>
   <% end %>
 


### PR DESCRIPTION
if instance does not have subjects enabled and include_comments in the .env file then we should not show the option in the /settings page. i.e. #1384 could be caused because of this. 