### PR TITLE
Reduce pinned search sql query count

### DIFF
--- a/app/views/notifications/_sidebar.html.erb
+++ b/app/views/notifications/_sidebar.html.erb
@@ -28,7 +28,7 @@
   </li>
 </ul>
 
-<% if current_user.pinned_searches.any? || any_active_filters? %>
+<% if current_user.pinned_searches.present? || any_active_filters? %>
   <ul class="nav nav-pills flex-column nav-filters">
     <% current_user.pinned_searches.each do |pinned_search| %>
       <li role="presentation" class="nav-item pinned_search">


### PR DESCRIPTION
Just a small performance tweak that reduces the total sql queries when loading the notifications index by 1.

`.any?` was making a query to see if at least one pinned search existed for that user, .present? makes a query to load them all which then gets cached for the line before which iterates over them with `.each`.