### PR TITLE
Use full_name field when syncing subjects if available in API response

### DIFF
--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -52,6 +52,8 @@ class Subject < ApplicationRecord
     # webhook payloads don't always have 'repository' info
     if remote_subject['repository']
       full_name = remote_subject['repository']['full_name']
+    elsif remote_subject['full_name']
+      full_name = remote_subject['full_name']
     else
       full_name = extract_full_name(remote_subject['url'])
     end


### PR DESCRIPTION
Specifically useful for syncing security vulnerability alert subjects.