### PR TITLE
Always sync subjects for open source repositories

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -146,8 +146,8 @@ class Notification < ApplicationRecord
     self.archived = false if archived.nil? # fixup existing records where archived is nil
     unarchive_if_updated if unarchive
     save(touch: false) if changed?
-    update_subject
     update_repository(api_response)
+    update_subject
   end
 
   def github_app_installed?

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -12,6 +12,10 @@ class Repository < ApplicationRecord
 
   scope :github_app_installed, -> { joins(:app_installation) }
 
+  def open_source?
+    !private?
+  end
+
   def github_app_installed?
     app_installation_id.present?
   end

--- a/lib/octobox/notifications/sync_subject.rb
+++ b/lib/octobox/notifications/sync_subject.rb
@@ -36,7 +36,7 @@ module Octobox
       end
 
       def download_subject?
-        @download_subject ||= subjectable? && (Octobox.fetch_subject? || github_app_installed?)
+        @download_subject ||= subjectable? && (Octobox.fetch_subject? || github_app_installed? || repository.try(:open_source?))
       end
 
       private

--- a/test/controllers/admin_controller_test.rb
+++ b/test/controllers/admin_controller_test.rb
@@ -5,6 +5,7 @@ class AdminControllerTest < ActionDispatch::IntegrationTest
   setup do
     stub_fetch_subject_enabled(value: false)
     stub_notifications_request
+    stub_comments_requests
     @user = create(:user)
   end
 

--- a/test/controllers/notifications_controller_test.rb
+++ b/test/controllers/notifications_controller_test.rb
@@ -624,6 +624,7 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
 
   test 'search results can filter by author' do
     sign_in_as(@user)
+    Subject.delete_all
     notification1 = create(:notification, user: @user, subject_type: 'Issue')
     notification2 = create(:notification, user: @user, subject_type: 'PullRequest')
     create(:subject, notifications: [notification1], author: 'andrew')
@@ -634,6 +635,7 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
 
   test 'search results can filter by multiple authors' do
     sign_in_as(@user)
+    Subject.delete_all
     notification1 = create(:notification, user: @user, subject_type: 'Issue')
     notification2 = create(:notification, user: @user, subject_type: 'PullRequest')
     create(:subject, notifications: [notification1], author: 'andrew')
@@ -677,6 +679,7 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
 
   test 'search results can filter by multiple labels' do
     sign_in_as(@user)
+    Subject.delete_all
     notification1 = create(:notification, user: @user)
     notification2 = create(:notification, user: @user)
     subject1 = create(:subject, notifications: [notification1])
@@ -689,6 +692,7 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
 
   test 'search results can filter to exclude label' do
     sign_in_as(@user)
+    Subject.delete_all
     notification1 = create(:notification, user: @user)
     notification2 = create(:notification, user: @user)
     subject1 = create(:subject, notifications: [notification1])
@@ -702,6 +706,7 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
 
   test 'search results can filter to exclude multiple labels' do
     sign_in_as(@user)
+    Subject.delete_all
     notification1 = create(:notification, user: @user)
     notification2 = create(:notification, user: @user)
     subject1 = create(:subject, notifications: [notification1])
@@ -714,6 +719,7 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
 
   test 'search results can filter by state' do
     sign_in_as(@user)
+    Subject.delete_all
     notification1 = create(:notification, user: @user)
     notification2 = create(:notification, user: @user)
     create(:subject, notifications: [notification1], state: "open")
@@ -724,6 +730,7 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
 
   test 'search results can filter by multiple states' do
     sign_in_as(@user)
+    Subject.delete_all
     notification1 = create(:notification, user: @user)
     notification2 = create(:notification, user: @user)
     create(:subject, notifications: [notification1], state: "open")
@@ -734,6 +741,7 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
 
   test 'search results can filter to exclude state' do
     sign_in_as(@user)
+    Subject.delete_all
     notification1 = create(:notification, user: @user)
     notification2 = create(:notification, user: @user)
     create(:subject, notifications: [notification1], state: "open")
@@ -745,6 +753,7 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
 
   test 'search results can filter to exclude multiple states' do
     sign_in_as(@user)
+    Subject.delete_all
     notification1 = create(:notification, user: @user)
     notification2 = create(:notification, user: @user)
     create(:subject, notifications: [notification1], state: "open")
@@ -755,6 +764,7 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
 
   test 'search results can filter by assignee' do
     sign_in_as(@user)
+    Subject.delete_all
     notification1 = create(:notification, user: @user)
     notification2 = create(:notification, user: @user)
     create(:subject, notifications: [notification1], assignees: ":andrew:")
@@ -765,6 +775,7 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
 
   test 'search results can filter by multiple assignees' do
     sign_in_as(@user)
+    Subject.delete_all
     notification1 = create(:notification, user: @user)
     notification2 = create(:notification, user: @user)
     create(:subject, notifications: [notification1], assignees: ":andrew:")
@@ -806,6 +817,7 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
 
   test 'search results can filter by locked:false' do
     sign_in_as(@user)
+    Subject.delete_all
     notification1 = create(:notification, user: @user, subject_type: 'Issue')
     notification2 = create(:notification, user: @user, subject_type: 'PullRequest')
     create(:subject, notifications: [notification1], locked: false)

--- a/test/controllers/pinned_searches_controller_test.rb
+++ b/test/controllers/pinned_searches_controller_test.rb
@@ -4,6 +4,7 @@ class PinnedSearchesControllerTest < ActionDispatch::IntegrationTest
   setup do
     stub_fetch_subject_enabled(value: false)
     stub_notifications_request
+    stub_comments_requests
     @user = create(:user)
   end
 

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -4,6 +4,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   setup do
     stub_fetch_subject_enabled(value: false)
     stub_notifications_request
+    stub_comments_requests
     @user = create(:user)
   end
 

--- a/test/integration/routes_test.rb
+++ b/test/integration/routes_test.rb
@@ -5,6 +5,7 @@ require 'test_helper'
 class RoutesTest < ActionDispatch::IntegrationTest
   setup do
     stub_notifications_request
+    stub_comments_requests
     stub_fetch_subject_enabled(value: false)
     @user = create(:user)
   end


### PR DESCRIPTION
Follow up from https://github.com/octobox/octobox/pull/1409, this enables subject syncing for open source repositories without needing repo scope or a github app installation.

Solves a question that's come up multiple times: 
 - https://github.com/octobox/octobox/issues/1385
 - https://github.com/octobox/octobox/issues/1254
 - https://github.com/octobox/octobox/issues/1137
