### PR TITLE
Only attempt to download subjects if there's a github_client available

### DIFF
--- a/lib/octobox/notifications/sync_subject.rb
+++ b/lib/octobox/notifications/sync_subject.rb
@@ -36,7 +36,7 @@ module Octobox
       end
 
       def download_subject?
-        @download_subject ||= subjectable? && (Octobox.fetch_subject? || github_app_installed? || repository.try(:open_source?))
+        @download_subject ||= subjectable? && github_client && (Octobox.fetch_subject? || github_app_installed? || repository.try(:open_source?))
       end
 
       private


### PR DESCRIPTION
Only really affects users who don't have an access_token after we rolled them 9 months ago on octobox.io