### PR TITLE
Allow limiting syncing of open source subjects before a given date.

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -384,6 +384,10 @@ To enable this feature set the following environment variable:
 
 If you want this feature to work for private repositories, you'll need to [Customize the Scopes on GitHub](#customizing-the-scopes-on-github) adding `repo` scope to allow Octobox to get subject information for private issues and pull requests.
 
+As of 4th January 2019, Octobox can sync subjects from open source repositories without requiring `repo` scope. To limit the downloading of old open source subjects, add the current date to the `PUBLIC_SUBJECT_ROLLOUT` environment variable to minimize syncing of old notifications on large installations:
+
+    PUBLIC_SUBJECT_ROLLOUT=2019-01-04 12:30:00 UTC
+
 ## API Documentation
 
 API Documentation will be generated from the application's controllers using `bin/rake api_docs:generate`. Once generated it will be automatically listed in the Header dropdown.

--- a/lib/octobox/configurator.rb
+++ b/lib/octobox/configurator.rb
@@ -193,6 +193,11 @@ module Octobox
     end
     attr_writer :push_notifications
 
+    def public_subject_rollout
+      @public_subject_rollout || ENV['PUBLIC_SUBJECT_ROLLOUT'].try(:to_time)
+    end
+    attr_writer :public_subject_rollout
+
     private
 
     def env_boolean(env_var_name)

--- a/lib/octobox/notifications/sync_subject.rb
+++ b/lib/octobox/notifications/sync_subject.rb
@@ -36,7 +36,16 @@ module Octobox
       end
 
       def download_subject?
-        @download_subject ||= subjectable? && github_client && (Octobox.fetch_subject? || github_app_installed? || repository.try(:open_source?))
+        @download_subject ||= subjectable? && github_client && (Octobox.fetch_subject? || github_app_installed? || download_public_subjects?)
+      end
+
+      def download_public_subjects?
+        return false unless repository.try(:open_source?)
+        if Octobox.config.public_subject_rollout
+          updated_at > Octobox.config.public_subject_rollout
+        else
+          return true
+        end
       end
 
       private


### PR DESCRIPTION
To avoid filling the background queue with millions of jobs on Octobox.io, shouldn't affect anyone running instances with `FETCH_SUBJECT` already enabled, so I can deploy https://github.com/octobox/octobox/pull/1415 to https://octobox.io
