### PR TITLE
Show different app install prompt for notifications from oss repos

### DIFF
--- a/app/views/notifications/_app_prompt.html.erb
+++ b/app/views/notifications/_app_prompt.html.erb
@@ -1,5 +1,10 @@
 <p>
-  Pull in state, labels, authors, assignees and CI status on issues and pull requests by installing the GitHub App on
+  <% if notification.repository.try(:open_source?) %>
+    Get realtime updates
+  <% else %>
+    Pull in state, labels, authors, assignees and CI status
+  <% end %>
+  on issues and pull requests by installing the GitHub App on
   <%= notification.repository_full_name %>.
 </p>
 


### PR DESCRIPTION
Now that https://github.com/octobox/octobox/pull/1415 is live, the app install prompt is slightly different for open source repositories as we now sync state, status, author and labels for them.