### PR TITLE
Add coverage to Subject.sync

### DIFF
--- a/test/models/subject_test.rb
+++ b/test/models/subject_test.rb
@@ -12,7 +12,7 @@ class SubjectTest < ActiveSupport::TestCase
     response = { status: 200, body: file_fixture('status_success.json'), headers: { 'Content-Type' => 'application/json' } }
     stub_request(:get, url).and_return(response)
 
-  	Subject.sync_status(sha, 'octobox/octobox')
+    Subject.sync_status(sha, 'octobox/octobox')
 
     subject.reload
 
@@ -47,10 +47,40 @@ class SubjectTest < ActiveSupport::TestCase
     assert subject.body.present?
   end
 
-  test "sync doesnt update comment_count of releases" do
+  test "sync doesn't update comment_count of releases" do
     remote_subject = Oj.load(File.open(file_fixture('release.json')))
     Subject.sync(remote_subject)
     subject = Subject.first
     assert_nil subject.comment_count
+  end
+
+  test 'sync updates a matching subject' do
+    remote_subject = Oj.load(File.open(file_fixture('subject_56.json')))
+    subject = create(:subject, url: remote_subject['url'], comment_count: nil)
+    Subject.expects(:find_or_create_by).returns(subject)
+    Subject.sync(remote_subject)
+    assert_equal 8, subject.comment_count
+  end
+
+  test "sync creates a new subject when a matching one can't be found" do
+    assert_equal 0, Subject.count
+    remote_subject = Oj.load(File.open(file_fixture('subject_56.json')))
+    Subject.sync(remote_subject)
+    assert_equal 1, Subject.count
+  end
+
+  test 'sync sets the full name when there is repository info' do
+    remote_subject = Oj.load(File.open(file_fixture('subject_56.json')))
+    remote_subject['repository'] = {'full_name' => 'repository full name'}
+    Subject.sync(remote_subject)
+    assert_equal 'repository full name', Subject.last.repository_full_name
+  end
+
+  test 'sync sets the full name when there is no repository info' do
+    remote_subject = Oj.load(File.open(file_fixture('subject_56.json')))
+    assert_nil remote_subject['repository']
+    remote_subject['repository'] = {'full_name' => 'repository full name'}
+    Subject.sync(remote_subject)
+    assert_equal 'repository full name', Subject.last.repository_full_name
   end
 end


### PR DESCRIPTION
👋 I've got my eye on`Subject.sync` for some refactoring, but first I thought I'd add some tests to make sure I don't break things going forward.

I haven't implemented all the tests just yet because I thought you might have opinions on how they're structured, or you might not be interested in this change (which is totally fine).

My thinking is this:

1. Add code coverage in this branch
2. In a new branch, extract an instance method `Subject#sync` since most of the things going on in `Subject.sync` are working on an instance anyway.
3. Maybe extract some private method while I'm on (e.g. `extract_full_name_from_remote_subject`)

Once that's in place, we might be in a better position to do some larger refactoring of the class depending on how you feel.

The class is fairly generic, but seems to have logic in there that's specific to certain kinds of subjects (knowledge of whether the subject is merged, or if a subject is a commit and has comments), which mixes the layers of abstraction a bit. We could introduce a template method pattern where the shared/default behaviour lives in the base class `Subject`, and the sub classes of `Subject` (`Commit`, `PullRequest`, etc) override certain methods like `full_name` or `comment_count` if they need to. That could all be overkill though and I don't have too much domain knowledge here, so I'm keen to know what you think!

