### PR TITLE
Remove 'alternatives' from the Readme's Table of Contents 

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ Octobox adds an extra "archived" state to each notification so you can mark it a
 	- [Web extension](#web-extension)
 - [Requirements](#requirements)
 - [Keyboard shortcuts](#keyboard-shortcuts)
-- [Alternatives](#alternatives)
 - [Contribute](#contribute)
 	- [Vulnerability disclosure](#vulnerability-disclosure)
 	- [Note on Patches/Pull Requests](#note-on-patchespull-requests)


### PR DESCRIPTION
The list of alternatives was removed in 23c37f4685459ae22121255c450e591295681f18