### PR TITLE
Only attempt to load comments in thread view if subject is present

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -83,7 +83,11 @@ class NotificationsController < ApplicationController
     @previous = ids[position-1] unless position.nil? || position-1 < 0
     @next = ids[position+1] unless position.nil? || position+1 > ids.length
 
-    @comments = @notification.subject.comments.order('created_at ASC')
+    if @notification.subject
+      @comments = @notification.subject.comments.order('created_at ASC')
+    else
+      @comments = []
+    end
 
     render partial: "notifications/thread", layout: false if request.xhr?
   end


### PR DESCRIPTION
Fixes a rare exception when a thread view is loaded when there's no subject to display.