### PR TITLE
Load last five comments on initial thread view

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -67,3 +67,5 @@ $(document).on('click', '.toggle-star', function() {
 });
 
 $(document).on('click', '.thread-link', Octobox.viewThread);
+
+$(document).on('click', '.expand-comments', Octobox.expandComments);

--- a/app/assets/javascripts/octobox.js
+++ b/app/assets/javascripts/octobox.js
@@ -457,6 +457,22 @@ var Octobox = (function() {
     return false;
   }
 
+  var expandComments = function() {
+    history.pushState({thread: $(this).attr('href')}, 'Octobox', $(this).attr('href'))
+
+    $('#more-comments').html($('#loading').html())
+
+    $.get($(this).attr('href'), function(data){
+      if (data["error"] != null) {
+        $(".header-flash-messages").empty();
+        notify(data["error"], "danger")
+      } else {
+        $('#more-comments').html(data)
+      }
+    });
+    return false;
+  }  
+
   // private methods
 
   var getDisplayedRows = function() {
@@ -661,6 +677,7 @@ var Octobox = (function() {
     markRead: markRead,
     deleteSelected: deleteSelected,
     deleteThread: deleteThread,
-    viewThread: viewThread
+    viewThread: viewThread,
+    expandComments: expandComments
   }
 })();

--- a/app/assets/stylesheets/_breakpoints.scss
+++ b/app/assets/stylesheets/_breakpoints.scss
@@ -5,5 +5,5 @@ $grid-breakpoints: (
   lg: 992px,
   xl: 1200px,
   xxl: 1440px,
-  xxxl: 1600px
+  xxxl: 1680px
 );

--- a/app/assets/stylesheets/_notifications.scss
+++ b/app/assets/stylesheets/_notifications.scss
@@ -128,8 +128,10 @@ $notification-items: (
       }
     }
     &:hover, &:focus{
-      .notification-date small{
-        display: none;
+      .notification-date{
+        small, .badge {
+          display: none;
+        }
       }
       .buttons{
         display: inline;
@@ -226,6 +228,9 @@ $notification-items: (
       content: "by ";
       color: $text-muted;
       font-size: 10px;
+    }
+    .notification-comment-count {
+      display:none
     }
     .notification-date {
       top: 10px;

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 class NotificationsController < ApplicationController
+
   skip_before_action :authenticate_user!
   before_action :authenticate_web_or_api!
   before_action :find_notification, only: [:star, :mark_read]
@@ -88,7 +89,7 @@ class NotificationsController < ApplicationController
 
     if @notification.subject
       @comments = @notification.subject.comments.order('created_at DESC').limit(comments_loaded).reverse
-      @comments_left_to_load = @notification.subject.comments.count - comments_loaded > 0 ? @notification.subject.comments.count : 0
+      @comments_left_to_load = @notification.subject.comments.count - comments_loaded > 0 ? @notification.subject.comments.count - comments_loaded : 0
     else
       @comments = []
     end
@@ -119,7 +120,7 @@ class NotificationsController < ApplicationController
     @next = ids[position+1] unless position.nil? || position+1 > ids.length
 
     comments_loaded = 5
-    @comments_to_load = 0
+    @comments_left_to_load = 0
     @more_comments = false
 
     if @notification.subject
@@ -128,7 +129,11 @@ class NotificationsController < ApplicationController
       @comments = []
     end
 
-    render partial: "notifications/comments", locals:{comments: @comments}, layout: false if request.xhr?
+    if request.xhr?
+      render partial: "notifications/comments", locals:{comments: @comments}, layout: false
+    else
+      render 'notifications/show'
+    end
   end
 
   # Return a count for the number of unread notifications

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -100,16 +100,6 @@ class NotificationsController < ApplicationController
 
   def expand_comments(comments_loaded = 5)
 
-    # return unless request.xhr?
-
-    # scope = original_scope = notifications_for_presentation.newest
-    # ids = scope.pluck(:id)
-    # @notification = original_scope.find(params[:id])
-
-    # @comments = @notification.subject.comments.order('created_at ASC').pop(comments_loaded)
-    
-    # render :partial => "notifications/comments", layout:false, locals:{comments: @comments}
-
     scope = original_scope = notifications_for_presentation.newest
     scope = load_and_count_notifications(scope) unless request.xhr?
 

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -98,7 +98,7 @@ class NotificationsController < ApplicationController
   end
 
 
-  def expand_comments(comments_loaded = 5)
+  def expand_comments
 
     scope = original_scope = notifications_for_presentation.newest
     scope = load_and_count_notifications(scope) unless request.xhr?
@@ -109,7 +109,6 @@ class NotificationsController < ApplicationController
     @previous = ids[position-1] unless position.nil? || position-1 < 0
     @next = ids[position+1] unless position.nil? || position+1 > ids.length
 
-    comments_loaded = 5
     @comments_left_to_load = 0
     @more_comments = false
 

--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -41,23 +41,24 @@ module NotificationsHelper
 
   def filters
     {
-      reason:     params[:reason],
-      unread:     params[:unread],
-      repo:       params[:repo],
-      type:       params[:type],
-      archive:    params[:archive],
-      starred:    params[:starred],
-      owner:      params[:owner],
-      per_page:   params[:per_page],
-      q:          params[:q],
-      state:      params[:state],
-      label:      params[:label],
-      author:     params[:author],
-      bot:        params[:bot],
-      unlabelled: params[:unlabelled],
-      assigned:   params[:assigned],
-      is_private: params[:is_private],
-      status:     params[:status]
+      reason:          params[:reason],
+      unread:          params[:unread],
+      repo:            params[:repo],
+      type:            params[:type],
+      archive:         params[:archive],
+      starred:         params[:starred],
+      owner:           params[:owner],
+      per_page:        params[:per_page],
+      q:               params[:q],
+      state:           params[:state],
+      label:           params[:label],
+      author:          params[:author],
+      bot:             params[:bot],
+      unlabelled:      params[:unlabelled],
+      assigned:        params[:assigned],
+      is_private:      params[:is_private],
+      status:          params[:status],
+      expand_comments: params[:expand_comments]
     }
   end
 

--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -58,7 +58,6 @@ module NotificationsHelper
       assigned:        params[:assigned],
       is_private:      params[:is_private],
       status:          params[:status],
-      expand_comments: params[:expand_comments]
     }
   end
 

--- a/app/views/notifications/_comments.html.erb
+++ b/app/views/notifications/_comments.html.erb
@@ -1,0 +1,17 @@
+<% comments.each_with_index do |comment, index| %>
+  <div id="<%= 'comment-'+comment.id.to_s %>" class="card-comment card mt-3 ">
+
+    <div class="card-header clickable media d-flex align-items-center text-muted" data-toggle='collapse' data-target=".comment-<%= comment.id.to_s%>" aria-expanded='false' aria-controls="comment-<%= comment.id.to_s%>">
+
+      <%= image_tag(avatar_url(comment.author), width: 30, class: 'mr-3 align-self-center') %>
+
+      <div class='media-body'>
+        <b><%= link_to comment.author, Octobox.config.github_domain+'/'+comment.author_url_path, class: 'text-muted'%></b> commented <%= link_to time_ago_in_words(comment.created_at).to_s+' ago', comment.web_url, class: 'text-muted', target: :blank %>
+      </div>
+    </div>
+
+    <div class="<%= 'comment-'+comment.id.to_s %> card-body collapse <%= 'show' if comment.unread?(@notification) || @comments.length <= index + 1 %> ">
+      <%== parse_markdown(comment.body) %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/notifications/_notification.html.erb
+++ b/app/views/notifications/_notification.html.erb
@@ -81,7 +81,15 @@
   <td class='notification-reason'>
     <%= link_to notification.reason.humanize, root_path(filtered_params(reason: notification.reason)), class: "badge badge-#{reason_label(notification.reason)}" %>
   </td>
+
   <td class='notification-date'>
+    <% if notification.subject %>
+      <span class='badge badge-light n notification-comment-count mr-2'>
+        <%= octicon 'comment', height: 10%>
+        <%= notification.subject.comments.count %>
+      </span>
+    <% end %>
+
     <small class='text-muted'>
       <%= local_relative_time(notification.updated_at, type: 'time-or-date') %>
     </small>

--- a/app/views/notifications/_thread.html.erb
+++ b/app/views/notifications/_thread.html.erb
@@ -25,7 +25,7 @@
   </div>
 </div>
 
-<div id='notification-thread' class="p-3" data-id='<%= @notification.id %>'>
+<div id='notification-thread' class="p-3 mb-5" data-id='<%= @notification.id %>'>
 
   <h2>
     <span class='badge <%= notification_badge_color(@notification.state) %>'>

--- a/app/views/notifications/_thread.html.erb
+++ b/app/views/notifications/_thread.html.erb
@@ -25,7 +25,7 @@
   </div>
 </div>
 
-<div id='notification-thread' class="p-3 mb-5" data-id='<%= @notification.id %>'>
+<div id='notification-thread' class="p-3" data-id='<%= @notification.id %>'>
 
   <h2>
     <span class='badge <%= notification_badge_color(@notification.state) %>'>
@@ -70,23 +70,16 @@
       </div>
     <% end %>
 
-    <% @comments.each_with_index do |comment, index| %>
-      <div id="<%= 'comment-'+comment.id.to_s %>" class="card-comment card mt-3 ">
-
-        <div class="card-header clickable media d-flex align-items-center text-muted" data-toggle='collapse' data-target=".comment-<%= comment.id.to_s%>" aria-expanded='false' aria-controls="comment-<%= comment.id.to_s%>">
-
-          <%= image_tag(avatar_url(comment.author), width: 30, class: 'mr-3 align-self-center') %>
-
-          <div class='media-body'>
-            <b><%= link_to comment.author, Octobox.config.github_domain+'/'+comment.author_url_path, class: 'text-muted'%></b> commented <%= link_to time_ago_in_words(comment.created_at).to_s+' ago', comment.web_url, class: 'text-muted', target: :blank %>
-          </div>
-        </div>
-
-        <div class="<%= 'comment-'+comment.id.to_s %> card-body collapse <%= 'show' if comment.unread?(@notification) || @comments.length <= index + 1 %> ">
-          <%== parse_markdown(comment.body) %>
-        </div>
+    <% if @more_comments %>
+      <div class='more comments'>
+        <%= link_to notification_url(filtered_params(expand_comments:true)), class: 'btn btn-secondary mt-3 load_comments' do %>
+          <%= octicon('comment', height: 16, class: 'ml-1') %>
+          View <%= @comments_to_load %> more comments
+        <% end %>
       </div>
     <% end %>
+
+    <%= render partial: 'comments', locals: {comments: @comments} %>
 
     <% if @notification.subject.commentable? %>
       <%= link_to @notification.subject.html_url+'#new_comment_field', target: :blank, class: 'btn btn-success mt-2 float-right' do %>

--- a/app/views/notifications/_thread.html.erb
+++ b/app/views/notifications/_thread.html.erb
@@ -71,8 +71,8 @@
     <% end %>
 
     <% if @more_comments %>
-      <div class='more comments'>
-        <%= link_to notification_url(filtered_params(expand_comments:true)), class: 'btn btn-secondary mt-3 load_comments' do %>
+      <div id='more-comments'>
+        <%= link_to expand_comments_notification_url, class: 'btn btn-secondary mt-3 expand_comments' do %>
           <%= octicon('comment', height: 16, class: 'ml-1') %>
           View <%= @comments_to_load %> more comments
         <% end %>

--- a/app/views/notifications/_thread.html.erb
+++ b/app/views/notifications/_thread.html.erb
@@ -25,7 +25,7 @@
   </div>
 </div>
 
-<div id='notification-thread' class="p-3" data-id='<%= @notification.id %>'>
+<div id='notification-thread' class="p-3 mb-5" data-id='<%= @notification.id %>'>
 
   <h2>
     <span class='badge <%= notification_badge_color(@notification.state) %>'>
@@ -70,11 +70,11 @@
       </div>
     <% end %>
 
-    <% if @@comments_left_to_load > 0 %>
+    <% if @comments_left_to_load > 0 %>
       <div id='more-comments'>
         <%= link_to expand_comments_notification_url, class: 'btn btn-secondary mt-3 expand_comments' do %>
           <%= octicon('comment', height: 16, class: 'ml-1') %>
-          View <%= @comments_to_load %> more comments
+          View <%= @comments_left_to_load %> more comments
         <% end %>
       </div>
     <% end %>

--- a/app/views/notifications/_thread.html.erb
+++ b/app/views/notifications/_thread.html.erb
@@ -70,7 +70,7 @@
       </div>
     <% end %>
 
-    <% if @more_comments %>
+    <% if @@comments_left_to_load > 0 %>
       <div id='more-comments'>
         <%= link_to expand_comments_notification_url, class: 'btn btn-secondary mt-3 expand_comments' do %>
           <%= octicon('comment', height: 16, class: 'ml-1') %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,9 +48,9 @@ Rails.application.routes.draw do
 
     member do
       get  :show
-      get  :expand_comments
       post :star
       post :mark_read
+      get  :expand_comments
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,6 +48,7 @@ Rails.application.routes.draw do
 
     member do
       get  :show
+      get  :expand_comments
       post :star
       post :mark_read
     end


### PR DESCRIPTION
* Decreases the initial load of comments to five
* shows comments counts in notifications table 
* adds /expand_comments route to expand commetn thread to all comments

