### PR TITLE
Shift breakpoints down  

### DIFF
--- a/app/assets/stylesheets/_layout.scss
+++ b/app/assets/stylesheets/_layout.scss
@@ -131,7 +131,7 @@ body {
   }
 }
 
-@include media-breakpoint-down(lg) {
+@include media-breakpoint-down(md) {
   @include responsive;
   .flex-main.show-thread{
     display:none;

--- a/app/assets/stylesheets/_notifications.scss
+++ b/app/assets/stylesheets/_notifications.scss
@@ -234,12 +234,9 @@ $notification-items: (
   }
 }
 
-@include media-breakpoint-up(xl){
-  @include regular-table;
-}
+@include regular-table;
 
-@include media-breakpoint-down(lg) {
-  @include regular-table;
+@include media-breakpoint-down(xl) {
   .flex-main.show-thread{
     @include remove-borders;
     @include responsive-table;

--- a/app/assets/stylesheets/_notifications.scss
+++ b/app/assets/stylesheets/_notifications.scss
@@ -234,11 +234,11 @@ $notification-items: (
   }
 }
 
-@include media-breakpoint-up(xxxl){
+@include media-breakpoint-up(xl){
   @include regular-table;
 }
 
-@include media-breakpoint-down(xxl) {
+@include media-breakpoint-down(lg) {
   @include regular-table;
   .flex-main.show-thread{
     @include remove-borders;

--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -148,7 +148,7 @@ module NotificationsHelper
 
   def function_button(title, octicon, css_class, tooltip, hidden=true)
     button_tag(type: 'button', class: "#{css_class} btn btn-sm btn-outline-dark #{'hidden-button' if hidden}", 'data-toggle': "tooltip", 'data-placement': "bottom", 'title': tooltip ) do
-      octicon(octicon, height: 16) + content_tag(:span, "#{title}", class: 'd-none d-md-inline-block ml-1')
+      octicon(octicon, height: 16) + content_tag(:span, "#{title}", class: 'd-none d-xl-inline-block ml-1')
     end
   end
 

--- a/app/views/notifications/_list.html.erb
+++ b/app/views/notifications/_list.html.erb
@@ -16,7 +16,7 @@
     <div class="btn btn-sm btn-link help float-right d-none d-md-inline-block" data-toggle="modal" data-target="#help-box">
       <%= octicon 'keyboard', :height => 16 %>
     </div>
-    <button id='sidebar_toggle' type="button" class="d-inline-block d-xl-none btn btn-sm btn-outline-dark" data-toggle="offcanvas" aria-label='Toggle sidebar'>
+    <button id='sidebar_toggle' type="button" class="d-inline-block d-lg-none btn btn-sm btn-outline-dark" data-toggle="offcanvas" aria-label='Toggle sidebar'>
       <%= octicon 'three-bars', :height => 16 %>
     </button>
     <% if @notifications.to_a.any? %>


### PR DESCRIPTION
![breakpoints](https://user-images.githubusercontent.com/158833/51126073-2033e900-181a-11e9-9456-b661b100dfa4.gif)

moves breakpoints down to large (996px) from extra-large (1,200px).

should now:

* >1,200 display table, sidebar and thread
* =<1,200 display table, sidebar and responsive table when thread is viewed
* =<996 display responsive table, sidebar and thread

addresses #1453 