### PR TITLE
Mark as read should always update unread state on GitHub

### DIFF
--- a/app/assets/javascripts/octobox.js
+++ b/app/assets/javascripts/octobox.js
@@ -372,7 +372,7 @@ var Octobox = (function() {
   };
 
   function markRead(id) {
-    $.post( "/notifications/"+id+"/mark_read")
+    $.post("/notifications/mark_read_selected" + location.search, {"id": id})
     .done(function() {
       updateFavicon();
     })

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -2,7 +2,7 @@
 class NotificationsController < ApplicationController
   skip_before_action :authenticate_user!
   before_action :authenticate_web_or_api!
-  before_action :find_notification, only: [:star, :mark_read]
+  before_action :find_notification, only: [:star]
 
   # Return a listing of notifications, including a summary of unread repos, notification reasons, and notification types
   #
@@ -187,20 +187,6 @@ class NotificationsController < ApplicationController
     else
       redirect_back fallback_location: root_path
     end
-  end
-
-  # Mark a notification as read
-  #
-  # :category: Notifications Actions
-  #
-  # ==== Example
-  #
-  # <code>POST notifications/:id/mark_read.json</code>
-  #   HEAD 204
-  #
-  def mark_read
-    @notification.update_columns unread: false
-    head :ok
   end
 
   # Star a notification

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,7 +49,6 @@ Rails.application.routes.draw do
     member do
       get  :show
       post :star
-      post :mark_read
     end
   end
 

--- a/test/controllers/notifications_controller_test.rb
+++ b/test/controllers/notifications_controller_test.rb
@@ -287,17 +287,6 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
     assert notification.reload.starred?
   end
 
-  test 'toggles unread on a notification' do
-    notification = create(:notification, user: @user, unread: true)
-
-    sign_in_as(@user)
-
-    post "/notifications/#{notification.id}/mark_read"
-    assert_response :ok
-
-    refute notification.reload.unread?
-  end
-
   test 'syncs users notifications' do
     sign_in_as(@user)
 


### PR DESCRIPTION
Fixes #1277

Before threadview we could rely on a user clicking a link through to GitHub where a notification would be marked as read which we then read back via the API, but that didn't hold true when a threadview was opened without taking the user to GitHub.

We marked the notification as read locally but never updated the notification on GitHub, this PR fixes that as well as removes the now unused `/notifications/"+id+"/mark_read` endpoint.