### PR TITLE
Only update repository records if changed when syncing

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -189,13 +189,16 @@ class Notification < ApplicationRecord
   end
 
   def update_repository(api_response)
-    repo = Repository.find_or_create_by(github_id: api_response['repository']['id'])
-    repo.update_attributes({
+    repo = repository ||  Repository.find_or_create_by(github_id: api_response['repository']['id'])
+    repo.assign_attributes({
       full_name: api_response['repository']['full_name'],
       private: api_response['repository']['private'],
       owner: api_response['repository']['full_name'].split('/').first,
-      github_id: api_response['repository']['id'],
-      last_synced_at: Time.current
+      github_id: api_response['repository']['id']
     })
+    if repo.changed?
+      repo.last_synced_at = Time.current
+      repo.save
+    end
   end
 end

--- a/test/models/notification_test.rb
+++ b/test/models/notification_test.rb
@@ -125,7 +125,7 @@ class NotificationTest < ActiveSupport::TestCase
     api_response = notifications_from_fixture('morty_notifications.json').second
     notification = user.notifications.find_or_initialize_by(github_id: api_response[:id])
     notification.update_from_api_response(api_response, unarchive: true)
-
+    notification.reload
     refute_nil notification.repository
     assert_equal notification.repository.full_name, 'octobox/octobox'
   end
@@ -138,7 +138,7 @@ class NotificationTest < ActiveSupport::TestCase
     notification = user.notifications.find_or_initialize_by(github_id: api_response[:id])
     create(:repository, github_id: api_response[:repository][:id], full_name: 'old/name')
     notification.update_from_api_response(api_response, unarchive: true)
-
+    notification.reload
     refute_equal notification.repository.full_name, 'old/name'
   end
 


### PR DESCRIPTION
Significantly reduces SQL queries when syncing notifications for a user.