### PR TITLE
Move responsive table when thread is present up to XXL (1440)

### DIFF
--- a/app/assets/stylesheets/_notifications.scss
+++ b/app/assets/stylesheets/_notifications.scss
@@ -236,7 +236,7 @@ $notification-items: (
 
 @include regular-table;
 
-@include media-breakpoint-down(xl) {
+@include media-breakpoint-down(xxl) {
   .flex-main.show-thread{
     @include remove-borders;
     @include responsive-table;


### PR DESCRIPTION
yesterday's update is right on the breakpoint for mac devices. 