### PR TITLE
Rolling fixes to thread revamp

### DIFF
--- a/app/assets/stylesheets/_notifications.scss
+++ b/app/assets/stylesheets/_notifications.scss
@@ -213,7 +213,7 @@ $notification-items: (
     .notification-subject-author,
     .notification-reason{
       display: block;
-      width: calc(100% - 6rem);
+      width: calc(100% - 8rem);
       position: relative;
       left: 40px
     }

--- a/app/views/notifications/_comments.html.erb
+++ b/app/views/notifications/_comments.html.erb
@@ -1,7 +1,7 @@
 <% comments.each_with_index do |comment, index| %>
   <div id="<%= 'comment-'+comment.id.to_s %>" class="card-comment card mt-3 ">
 
-    <div class="card-header clickable media d-flex align-items-center text-muted <%='collapsed' if !comment.unread?(@notification) || @comments.length <= index + 1 %>" data-toggle='collapse' data-target=".comment-<%= comment.id.to_s%>" aria-expanded='false' aria-controls="comment-<%= comment.id.to_s%>">
+    <div class="card-header clickable media d-flex align-items-center text-muted <%='collapsed' if !comment.unread?(@notification) && !(@comments.length <= index + 1) %>" data-toggle='collapse' data-target=".comment-<%= comment.id.to_s%>" aria-expanded='false' aria-controls="comment-<%= comment.id.to_s%>">
 
       <%= image_tag(avatar_url(comment.author), width: 20, class: 'mr-3 align-self-center') %>
 

--- a/app/views/notifications/_comments.html.erb
+++ b/app/views/notifications/_comments.html.erb
@@ -11,7 +11,13 @@
     </div>
 
     <div class="<%= 'comment-'+comment.id.to_s %> card-body collapse <%= 'show' if comment.unread?(@notification) || @comments.length <= index + 1 %> ">
-      <%== parse_markdown(comment.body) %>
+      <% if comment.body.present? %>
+        <%== parse_markdown(comment.body) %>
+      <% else %>
+        <p>
+          <i>No description given.</i>
+        </p>
+      <% end %>
     </div>
   </div>
 <% end %>

--- a/app/views/notifications/_thread.html.erb
+++ b/app/views/notifications/_thread.html.erb
@@ -77,7 +77,7 @@
           </div>
           <div class="card-body">
             <article class="markdown-body">
-              <% if @notification.subject.body.preset? %>
+              <% if @notification.subject.body.present? %>
                 <%== parse_markdown(@notification.subject.body) %>
               <% else %>
                 <p>

--- a/app/views/notifications/_thread.html.erb
+++ b/app/views/notifications/_thread.html.erb
@@ -33,7 +33,7 @@
     <span class='text-muted font-weight-light'> #<%= @notification.subject_number %> </span>
   </h2>
   
-  <%= link_to @notification.web_url, class: "btn btn-sm #{notification_button_color(@notification.state)} mr-2" do %>
+  <%= link_to @notification.web_url, target: :blank, class: "btn btn-sm #{notification_button_color(@notification.state)} mr-2" do %>
     <%= octicon notification_icon(@notification), :height => 16, title: notification_icon_title(@notification.subject_type, @notification.state), data: {toggle: 'tooltip'} %>
     <%= notification_button_title(@notification.subject_type, @notification.state) %>
   <% end %>
@@ -77,7 +77,13 @@
           </div>
           <div class="card-body">
             <article class="markdown-body">
-              <%== parse_markdown(@notification.subject.body) %>
+              <% if @notification.subject.body.preset? %>
+                <%== parse_markdown(@notification.subject.body) %>
+              <% else %>
+                <p>
+                  <i>No description given.</i>
+                </p>
+              <% end %>
             </article>
           </div>
         </div>

--- a/app/views/notifications/_thread.html.erb
+++ b/app/views/notifications/_thread.html.erb
@@ -30,7 +30,7 @@
 
   <h2 class='text-capitalize'>
     <%= @notification.subject_title %>
-    <span class='text-muted font-weight-light'> #<%= @notification.id %> </span>
+    <span class='text-muted font-weight-light'> #<%= @notification.subject_number %> </span>
   </h2>
   
   <%= link_to @notification.web_url, class: "btn btn-sm #{notification_button_color(@notification.state)} mr-2" do %>


### PR DESCRIPTION
* show GH ids not octo ids
* open GH in new window
* show 'no description' for blank subjects/comments
* shrink subject length to accommodate comment count on responsive table
* fix logic of last (shown) comment header