### PR TITLE
notification_link should return a relative path instead of absolute url

### DIFF
--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -334,7 +334,7 @@ module NotificationsHelper
   end
 
   def notification_link(notification)
-    notification.display_thread? ? notification_url(notification, filtered_params) : notification.web_url
+    notification.display_thread? ? notification_path(notification, filtered_params) : notification.web_url
   end
 
   def display_thread?


### PR DESCRIPTION
Avoid pushstate js error when the partial is rendered and sent over actioncable from sidekiq.