### PR TITLE
Use subject comment counter cache where available

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -85,11 +85,10 @@ class NotificationsController < ApplicationController
     @next = ids[position+1] unless position.nil? || position+1 > ids.length
 
     comments_loaded = 5
-    @comments_to_load = 0
 
     if @notification.subject
       @comments = @notification.subject.comments.order('created_at DESC').limit(comments_loaded).reverse
-      @comments_left_to_load = @notification.subject.comments.count - comments_loaded > 0 ? @notification.subject.comments.count - comments_loaded : 0
+      @comments_left_to_load = @notification.subject.comment_count - comments_loaded > 0 ? @notification.subject.comment_count - comments_loaded : 0
     else
       @comments = []
     end
@@ -110,7 +109,6 @@ class NotificationsController < ApplicationController
     @next = ids[position+1] unless position.nil? || position+1 > ids.length
 
     @comments_left_to_load = 0
-    @more_comments = false
 
     if @notification.subject
       @comments = @notification.subject.comments.order('created_at ASC')

--- a/app/views/notifications/_notification.html.erb
+++ b/app/views/notifications/_notification.html.erb
@@ -86,7 +86,7 @@
     <% if notification.subject %>
       <span class='badge badge-light n notification-comment-count mr-2'>
         <%= octicon 'comment', height: 10%>
-        <%= notification.subject.comments.count %>
+        <%= notification.subject.comment_count %>
       </span>
     <% end %>
 

--- a/app/views/notifications/_thread.html.erb
+++ b/app/views/notifications/_thread.html.erb
@@ -32,7 +32,7 @@
     <%= @notification.subject_title %>
     <span class='text-muted font-weight-light'> #<%= @notification.subject_number %> </span>
   </h2>
-  
+
   <%= link_to @notification.web_url, target: :blank, class: "btn btn-sm #{notification_button_color(@notification.state)} mr-2" do %>
     <%= octicon notification_icon(@notification), :height => 16, title: notification_icon_title(@notification.subject_type, @notification.state), data: {toggle: 'tooltip'} %>
     <%= notification_button_title(@notification.subject_type, @notification.state) %>
@@ -58,7 +58,7 @@
     </div>
     <% if @notification.subject %>
       <div>
-        <%= link_to pluralize(@comments.count+@comments_left_to_load,'comment'), expand_comments_notification_url,  class: 'text-muted'%>
+        <%= link_to pluralize(@notification.subject.comment_count,'comment'), expand_comments_notification_url,  class: 'text-muted'%>
       </div>
     <% end %>
   </div>

--- a/test/controllers/notifications_controller_test.rb
+++ b/test/controllers/notifications_controller_test.rb
@@ -991,7 +991,7 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
   test 'renders a notification page' do
     sign_in_as(@user)
     notification1 = create(:notification, user: @user)
-    
+
     get notification_path(notification1)
 
     assert_response :success
@@ -1002,9 +1002,9 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
     sign_in_as(@user)
     Subject.delete_all
     notification = create(:notification, user: @user)
-    subject = create(:subject, notifications: [notification])
+    subject = create(:subject, notifications: [notification], comment_count: 10)
     10.times.each { create(:comment, subject: subject)}
-    
+
     get notification_path(notification)
     assert_equal assigns(:comments).length, 5
   end
@@ -1013,9 +1013,9 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
     sign_in_as(@user)
     Subject.delete_all
     notification = create(:notification, user: @user)
-    subject = create(:subject, notifications: [notification])
+    subject = create(:subject, notifications: [notification], comment_count: 10)
     10.times.each { create(:comment, subject: subject) }
-    
+
     get expand_comments_notification_path(notification)
     assert_response :success
     assert_template 'notifications/_thread'

--- a/test/factories/subject.rb
+++ b/test/factories/subject.rb
@@ -1,9 +1,11 @@
 FactoryBot.define do
   factory :subject do
     sequence(:url) { |n| "https://api.github.com/repos/octobox/octobox/issues/#{n}" }
+    sequence(:html_url) { |n| "https://github.com/octobox/octobox/issues/#{n}" }
     sequence(:github_id, 1000000) { |n| n }
     state { 'open' }
     author { 'andrew' }
     repository_full_name { 'octobox/octobox' }
+    comment_count { 0 }
   end
 end


### PR DESCRIPTION
Speeds up rendering list of notifications and thread view by reducing sql query count