### PR TITLE
Updates to comment_count should be pushed over the websocket

### DIFF
--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -135,7 +135,7 @@ class Subject < ApplicationRecord
   private
 
   def pushable_fields
-    ['state', 'status', 'body']
+    ['state', 'status', 'body', 'comment_count']
   end
 
   def assign_status(remote_status)


### PR DESCRIPTION
Now that comment count is visible in the notification list we can update it live whenever it changes from a background job.