### PR TITLE
Change queues of some sidekiq jobs

### DIFF
--- a/app/workers/mark_read_worker.rb
+++ b/app/workers/mark_read_worker.rb
@@ -1,6 +1,6 @@
 class MarkReadWorker
   include Sidekiq::Worker
-  sidekiq_options queue: :sync_notifications, unique: :until_and_while_executing
+  sidekiq_options queue: :user, unique: :until_and_while_executing
 
   def perform(user_id, notification_ids)
     user = User.find_by_id(user_id)

--- a/app/workers/mute_notifications_worker.rb
+++ b/app/workers/mute_notifications_worker.rb
@@ -1,6 +1,6 @@
 class MuteNotificationsWorker
   include Sidekiq::Worker
-  sidekiq_options queue: :sync_notifications, unique: :until_and_while_executing
+  sidekiq_options queue: :user, unique: :until_and_while_executing
 
   def perform(user_id, notification_ids)
     user = User.find_by_id(user_id)

--- a/app/workers/sync_github_app_authorization_worker.rb
+++ b/app/workers/sync_github_app_authorization_worker.rb
@@ -2,7 +2,7 @@
 
 class SyncGithubAppAuthorizationWorker
   include Sidekiq::Worker
-  sidekiq_options queue: :sync_subjects, unique: :until_and_while_executing
+  sidekiq_options queue: :marketplace, unique: :until_and_while_executing
 
   def perform(github_id)
     user = User.find_by_github_id(github_id)

--- a/app/workers/sync_installation_permissions_worker.rb
+++ b/app/workers/sync_installation_permissions_worker.rb
@@ -2,7 +2,7 @@
 
 class SyncInstallationPermissionsWorker
   include Sidekiq::Worker
-  sidekiq_options queue: :sync_subjects, unique: :until_and_while_executing
+  sidekiq_options queue: :marketplace, unique: :until_and_while_executing
 
   def perform(user_id)
     User.find_by_id(user_id).try(:sync_app_installation_access)

--- a/app/workers/sync_installation_repositories_worker.rb
+++ b/app/workers/sync_installation_repositories_worker.rb
@@ -2,7 +2,7 @@
 
 class SyncInstallationRepositoriesWorker
   include Sidekiq::Worker
-  sidekiq_options queue: :sync_subjects, unique: :until_and_while_executing
+  sidekiq_options queue: :sync_repos, unique: :until_and_while_executing
 
   def perform(payload)
     app_installation = AppInstallation.find_by_github_id(payload['installation']['id'])

--- a/app/workers/sync_installation_worker.rb
+++ b/app/workers/sync_installation_worker.rb
@@ -2,7 +2,7 @@
 
 class SyncInstallationWorker
   include Sidekiq::Worker
-  sidekiq_options queue: :sync_subjects, unique: :until_and_while_executing
+  sidekiq_options queue: :marketplace, unique: :until_and_while_executing
 
   def perform(payload)
     app_installation = AppInstallation.create(AppInstallation.map_from_api(payload['installation']))

--- a/app/workers/sync_repository_worker.rb
+++ b/app/workers/sync_repository_worker.rb
@@ -2,7 +2,7 @@
 
 class SyncRepositoryWorker
   include Sidekiq::Worker
-  sidekiq_options queue: :sync_subjects, unique: :until_and_while_executing
+  sidekiq_options queue: :sync_repos, unique: :until_and_while_executing
 
   def perform(remote_repository)
     Repository.sync(remote_repository)

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,6 +1,7 @@
 ---
 :concurrency: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 }.to_i %> # From lib/database_config.rb
 :queues:
+  - [user, 4]
   - [sync_notifications, 2]
   - [marketplace, 2]
   - [sync_subjects, 1]


### PR DESCRIPTION
Avoids some quick/important jobs getting stuck in the sync_subjects or sync_notification queues.

cc https://github.com/octobox/octobox/issues/1277