### PR TITLE
Only download notifications that have been updated since last_synced_at

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -140,11 +140,11 @@ class Notification < ApplicationRecord
     end
   end
 
-  def update_from_api_response(api_response, unarchive: false)
+  def update_from_api_response(api_response)
     attrs = Notification.attributes_from_api_response(api_response)
     self.attributes = attrs
     self.archived = false if archived.nil? # fixup existing records where archived is nil
-    unarchive_if_updated if unarchive
+    unarchive_if_updated
     if changed?
       save(touch: false)
       update_repository(api_response)

--- a/app/services/download_service.rb
+++ b/app/services/download_service.rb
@@ -23,13 +23,7 @@ class DownloadService
 
   def download
     timestamp = Time.current
-
-    if user.last_synced_at
-      fetch_read_notifications
-      fetch_unread_notifications
-    else
-      new_user_fetch
-    end
+    fetch_new_notifications
     user.update_column(:last_synced_at, timestamp)
   end
 
@@ -45,42 +39,26 @@ class DownloadService
     client.notifications(params)
   end
 
-  def fetch_unread_notifications
+  def fetch_new_notifications
     headers = {cache_control: %w(no-store no-cache)}
     headers[:if_modified_since] = user.last_synced_at.iso8601 if user.last_synced_at.respond_to?(:iso8601)
-    notifications = fetch_notifications(params: {headers: headers})
-    process_notifications(notifications, unarchive: true)
+    notifications = fetch_notifications(params: {all: true, headers: headers})
+    process_notifications(notifications)
   end
 
-  def fetch_read_notifications
-    oldest_unread = user.notifications.unread(true).newest.select(:updated_at).last
-    if oldest_unread && oldest_unread.updated_at.respond_to?(:iso8601)
-      headers = {cache_control: %w(no-store no-cache)}
-      since = oldest_unread.updated_at - 1.second
-      notifications = fetch_notifications(params: {all: true, since: since.iso8601, headers: headers})
-      process_notifications(notifications)
-    end
-  end
-
-  def process_notifications(notifications, unarchive: false)
+  def process_notifications(notifications)
     return if notifications.blank?
     eager_load_relation = Octobox.config.subjects_enabled? ? [:subject, :repository, :app_installation] : nil
     existing_notifications = user.notifications.includes(eager_load_relation).where(github_id: notifications.map(&:id))
-    notifications.reject{|n| !unarchive && n.unread }.each do |notification|
+    notifications.each do |notification|
       n = existing_notifications.find{|en| en.github_id == notification.id.to_i}
       n = user.notifications.new(github_id: notification.id, archived: false) if n.nil?
       next unless n
       begin
-        n.update_from_api_response(notification, unarchive: unarchive)
+        n.update_from_api_response(notification)
       rescue ActiveRecord::RecordNotUnique
         nil
       end
     end
-  end
-
-  def new_user_fetch
-    headers = {cache_control: %w(no-store no-cache)}
-    notifications = fetch_notifications(params: {all: true, headers: headers})
-    process_notifications(notifications, unarchive: true)
   end
 end

--- a/test/models/notification_test.rb
+++ b/test/models/notification_test.rb
@@ -85,7 +85,7 @@ class NotificationTest < ActiveSupport::TestCase
         archived: false,
         latest_comment_url: "https://api.github.com/repos/octobox/octobox/issues/comments/123"
       }.stringify_keys)
-    notification.update_from_api_response(api_response, unarchive: true)
+    notification.update_from_api_response(api_response)
     assert notification.unread?
     refute notification.archived?
     assert_equal expected_attributes, notification.attributes
@@ -113,7 +113,7 @@ class NotificationTest < ActiveSupport::TestCase
     }.stringify_keys
     api_response = notifications_from_fixture('morty_notifications.json').second
     n = user.notifications.find_or_initialize_by(github_id: api_response[:id])
-    n.update_from_api_response(api_response, unarchive: true)
+    n.update_from_api_response(api_response)
     attributes = n.attributes
     assert_equal attributes, attributes.merge(expected_attributes)
   end
@@ -124,7 +124,7 @@ class NotificationTest < ActiveSupport::TestCase
     user = create(:user)
     api_response = notifications_from_fixture('morty_notifications.json').second
     notification = user.notifications.find_or_initialize_by(github_id: api_response[:id])
-    notification.update_from_api_response(api_response, unarchive: true)
+    notification.update_from_api_response(api_response)
     notification.reload
     refute_nil notification.repository
     assert_equal notification.repository.full_name, 'octobox/octobox'
@@ -137,7 +137,7 @@ class NotificationTest < ActiveSupport::TestCase
     api_response = notifications_from_fixture('morty_notifications.json').second
     notification = user.notifications.find_or_initialize_by(github_id: api_response[:id])
     create(:repository, github_id: api_response[:repository][:id], full_name: 'old/name')
-    notification.update_from_api_response(api_response, unarchive: true)
+    notification.update_from_api_response(api_response)
     notification.reload
     refute_equal notification.repository.full_name, 'old/name'
   end
@@ -148,7 +148,7 @@ class NotificationTest < ActiveSupport::TestCase
     user = create(:user)
     api_response = notifications_from_fixture('morty_notifications.json').second
     notification = user.notifications.find_or_initialize_by(github_id: api_response[:id])
-    notification.update_from_api_response(api_response, unarchive: true)
+    notification.update_from_api_response(api_response)
 
     assert_nil notification.subject
   end
@@ -164,7 +164,7 @@ class NotificationTest < ActiveSupport::TestCase
     user = create(:user)
     api_response = notifications_from_fixture('morty_notifications.json').second
     notification = user.notifications.find_or_initialize_by(github_id: api_response[:id])
-    notification.update_from_api_response(api_response, unarchive: true)
+    notification.update_from_api_response(api_response)
 
     notification.reload
 
@@ -184,7 +184,7 @@ class NotificationTest < ActiveSupport::TestCase
     create(:morty)
     subject = create(:subject, url: url, updated_at: (notification_updated_at - 1.seconds))
     notification = create(:morty_updated, updated_at: (notification_updated_at - 1.minute), subject_url: url)
-    notification.update_from_api_response(api_response, unarchive: true)
+    notification.update_from_api_response(api_response)
 
     refute_requested :get, subject.url
   end
@@ -202,7 +202,7 @@ class NotificationTest < ActiveSupport::TestCase
     create(:morty)
     subject = create(:subject, url: url, updated_at: (notification_updated_at - 5.seconds))
     notification = create(:morty_updated, updated_at: (notification_updated_at - 1.minute), subject_url: url)
-    notification.update_from_api_response(api_response, unarchive: true)
+    notification.update_from_api_response(api_response)
 
     assert_requested :get, subject.url
   end
@@ -219,7 +219,7 @@ class NotificationTest < ActiveSupport::TestCase
     notification = create(:morty_updated)
 
     assert_difference 'Subject.count' do
-      notification.update_from_api_response(api_response, unarchive: true)
+      notification.update_from_api_response(api_response)
     end
   end
 
@@ -234,7 +234,7 @@ class NotificationTest < ActiveSupport::TestCase
     notification = create(:morty_updated)
 
     assert_no_difference 'Subject.count' do
-      notification.update_from_api_response(api_response, unarchive: true)
+      notification.update_from_api_response(api_response)
     end
   end
 
@@ -255,7 +255,7 @@ class NotificationTest < ActiveSupport::TestCase
     create(:morty)
     subject = create(:subject, state: 'open', url: url, updated_at: (notification_updated_at - 5.seconds))
     notification = create(:morty_updated, updated_at: (notification_updated_at - 1.minute), subject_url: url)
-    notification.update_from_api_response(api_response, unarchive: true)
+    notification.update_from_api_response(api_response)
 
     subject.reload
     assert_equal 'merged', subject.state


### PR DESCRIPTION
Whilst investigating speeding up some of the background jobs, I noticed that when calling `#sync_notifications` on a user would result in attempted updates to notifications that hadn't changed.

I initially sped that up by skipping some work on notifications that hadn't changed (https://github.com/octobox/octobox/pull/1464 and https://github.com/octobox/octobox/pull/1468) but I was still left with a feeling that the [`DownloadService`](https://github.com/octobox/octobox/blob/d3dc604920a3af36f2579c86fd0b6cf10041e2a5/app/services/download_service.rb) was pulling down more notifications that required. 

After doing some more poking around in the production console, I found that even if you ran `sync_notifications_in_foreground` twice in quick succession, the second time would still download and process many notifications for some users, which are effectively no-ops as they were all synced 
the first time and nothing had changed.

This lead me to look at the `fetch_read_notifications` method:
```ruby
def fetch_read_notifications
  oldest_unread = user.notifications.unread(true).newest.select(:updated_at).last
  if oldest_unread && oldest_unread.updated_at.respond_to?(:iso8601)
    headers = {cache_control: %w(no-store no-cache)}
    since = oldest_unread.updated_at - 1.second
    notifications = fetch_notifications(params: {all: true, since: since.iso8601, headers: headers})
    process_notifications(notifications)
  end
end
```

This method has been in Octobox for a long time, over 2 years infact: https://github.com/octobox/octobox/pull/227

What it appears to do is look for the oldest existing notification for a user and use the `updated_at` timestamp to limit the number of notifications fetched from the GitHub API, but not just read but unread too. 

The weird thing is that this method is called along side `fetch_unread_notifications`, which uses the `last_synced_at` timestamp of a user if it's present to only get notifications that are new or updated since the last time we synced.

Turns out that for some users, they have a really old, unread notifications, which then causes `fetch_read_notifications` to ask for all the notifications since `1.year.ago` (for example).

Out of curiosity I commented out the call to `fetch_read_notifications` in https://github.com/octobox/octobox/blob/d3dc604920a3af36f2579c86fd0b6cf10041e2a5/app/services/download_service.rb#L28 to see which tests would break, but none broke!

That lead me down a refactoring path that ended up as this pull request, where we use a modified version of `fetch_unread_notifications` that gets both read and unread notifications that have changed since the last time the user synced their notifications (or all of them for new users).

I can't see any issue with merging this but changing code that's been running quietly in production for two years made me question if the tests are really testing the right things but it looks like all the bases are covered there too.