### PR TITLE
Disable actioncable logs in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -52,6 +52,9 @@ Rails.application.configure do
   # when problems arise.
   config.log_level = :info
 
+  # disable logging of action cable messages
+  config.action_cable.logger = Logger.new(nil)
+
   # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]
 


### PR DESCRIPTION
Actioncable logging is very noisy, even at info level and is filling up our papertrail account on a daily basis for https://octobox.io at the moment, so going to disable it for now.