### PR TITLE
Changed Style/FlipFlop to Lint/FlipFlop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -620,7 +620,7 @@ Layout/FirstParameterIndentation:
   Description: 'Checks the indentation of the first parameter in a method call.'
   Enabled: false
 
-Style/FlipFlop:
+Lint/FlipFlop:
   Description: 'Checks for flip flops'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-flip-flops'
   Enabled: false


### PR DESCRIPTION
Running RuboCop gave me the message ".rubocop.yml: Style/FlipFlop has the wrong namespace - should be Lint".  Changing the heading from "Style/FlipFlop" to "Lint/FlipFlop" addresses this.