### PR TITLE
Comment counts should only be shown if display_subject is true

### DIFF
--- a/app/views/notifications/_notification.html.erb
+++ b/app/views/notifications/_notification.html.erb
@@ -83,7 +83,7 @@
   </td>
 
   <td class='notification-date'>
-    <% if notification.subject %>
+    <% if notification.display_subject? && notification.subject %>
       <span class='badge badge-light n notification-comment-count mr-2'>
         <%= octicon 'comment', height: 10%>
         <%= notification.subject.comment_count %>


### PR DESCRIPTION
Currently shows on private repos with the app installed but no paid plan, this fixes that.