### PR TITLE
Remove visual test dependencies from Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,8 @@ rvm:
 before_install:
   - gem update --system
   - gem install bundler
-  - wget https://github.com/mozilla/geckodriver/releases/download/v0.22.0/geckodriver-v0.22.0-linux64.tar.gz
-  - tar -xzf geckodriver-v0.22.0-linux64.tar.gz -C bin
-  - export PATH=$(pwd)/bin:$PATH
 
 addons:
-  firefox: latest
   postgresql: "9.6"
 
 services:
@@ -30,8 +26,6 @@ bundler_args: --without development production --deployment --jobs=3 --retry=3
 cache: bundler
 
 env:
-  global:
-    - MOZ_HEADLESS=1
   matrix:
     - DATABASE=mysql2
     - DATABASE=postgresql


### PR DESCRIPTION
They aren't used at the moment and slow the builds down.