### PR TITLE
Sync read/unread state of all notifications every time

### DIFF
--- a/test/workers/sync_notifications_worker_test.rb
+++ b/test/workers/sync_notifications_worker_test.rb
@@ -16,7 +16,7 @@ class SyncNotificationsWorkerTest < ActiveSupport::TestCase
       SyncNotificationsWorker.perform_async(@user.id)
     end
 
-    assert_requested(@stubbed_user_notification_sync)
+    assert_requested(@stubbed_user_notification_sync, times: 2)
   end
 
   test 'enqueues one job per user at a time' do


### PR DESCRIPTION
Fixes #1500, also may help with https://github.com/octobox/octobox/issues/1437

Since GitHub added the ability to mark a notification as unread in their UI (not available via the API yet), we can't know which notifications have changed their unread state since the last time we synced.

This PR adds a second request to the notifications API to get all notifications and then toggles the ones we have locally that have the incorrect `unread` state.