### PR TITLE
Document the `GITHUB_APP_JWT` environment variable

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -429,6 +429,7 @@ Then add the following ENV variables to `.env` (or `heroku config:add` if you're
 - `GITHUB_APP_CLIENT_SECRET` - From the GitHub App "OAuth credentials" section labelled `Client secret`
 - `GITHUB_APP_ID` - From the GitHub App "About" section labelled `ID`
 - `GITHUB_APP_SLUG`-  - From the GitHub App "About" section labelled `Public link`, the last section of the url, i.e https://github.com/apps/my-octobox -> `my-octobox`
+- `GITHUB_APP_JWT`- - In the GitHub App "Private keys" section, generate a private key, which will cause a `.pem` file to be downloaded to your computer. This environment variable must contain the contents of the `.pem` file with newlines preserved.
 - `GITHUB_WEBHOOK_SECRET` - The Webhook secret if you generated one earlier
 
 Then start the rails app and visit <https://github.com/apps/my-octobox/installations/new> to install it on the orgs/repos you wish, it should log you into Octobox on completion of the install.


### PR DESCRIPTION
To properly sync information about the App installation and the resources it has access to, Octobox needs access to a private key for the App. I knew this, since I worked on Apps at GitHub 😂, but this requirement isn't documented for Octobox. I noticed in the code that we have a `GITHUB_APP_JWT` variable (the name seemed a bit off to me, but it's not a big deal), so here's some updated documentation on how to generate the key and use it in Octobox.