### PR TITLE
Always add read:org to scopes when limiting access

### DIFF
--- a/lib/octobox/configurator.rb
+++ b/lib/octobox/configurator.rb
@@ -32,7 +32,7 @@ module Octobox
 
     def scopes
       default_scopes = 'notifications'
-      default_scopes += ', read:org' if !github_app && Octobox.restricted_access_enabled?
+      default_scopes += ', read:org' if Octobox.restricted_access_enabled?
       default_scopes += ', repo'     if !github_app && fetch_subject
 
       ENV.fetch('GITHUB_SCOPE', default_scopes)

--- a/test/lib/octobox/configurator_test.rb
+++ b/test/lib/octobox/configurator_test.rb
@@ -15,6 +15,26 @@ class ConfiguratorTest < ActiveSupport::TestCase
     end
   end
 
+  test "config.scopes defaults to 'notifications'" do
+    assert_equal 'notifications', Octobox.config.scopes
+  end
+
+  test "when ENV['RESTRICTED_ACCESS_ENABLED'] is true, config.scopes includes read:org" do
+    stub_env_var('RESTRICTED_ACCESS_ENABLED', 'true')
+    assert_includes 'read:org', Octobox.config.scopes
+  end
+
+  test "when ENV['FETCH_SUBJECT'] is true, config.scopes includes repo" do
+    stub_env_var('FETCH_SUBJECT', 'true')
+    assert_includes 'repo', Octobox.config.scopes
+  end
+
+  test "when ENV['FETCH_SUBJECT'] is true and ENV['GITHUB_APP_ID'] is present, config.scopes does not include repo" do
+    stub_env_var('FETCH_SUBJECT', 'true')
+    stub_env_var('GITHUB_APP_ID', '12345')
+    refute_includes 'repo', Octobox.config.scopes
+  end
+
   test "when ENV['FETCH_SUBJECT'] is false, config.fetch_subject is false" do
     stub_env_var('FETCH_SUBJECT', 'false')
     assert_equal false, Octobox.config.fetch_subject


### PR DESCRIPTION
Currently, we don't add `read:org` to the default OAuth scopes when
Octobox is also connected to a GitHub App. However, this leads to a bug
where access is denied to _private_ members of the organization. I was
able to manually allow access by defining the `GITHUB_SCOPE` variable
but it would be good to get an official fix in :smile: