### PR TITLE
Display subjects for all repositories if a user has a personal plan

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -161,7 +161,7 @@ class Notification < ApplicationRecord
   end
 
   def display_subject?
-    @display_subject ||= subjectable? && (Octobox.fetch_subject? || repository.try(:display_subject?))
+    @display_subject ||= subjectable? && (Octobox.fetch_subject? || repository.try(:display_subject?) || user.has_personal_plan?)
   end
 
   def upgrade_required?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,7 @@ class User < ApplicationRecord
   has_many :app_installation_permissions, dependent: :delete_all
   has_many :app_installations, through: :app_installation_permissions
   has_many :pinned_searches, dependent: :delete_all
+  has_one :personal_app_installation, foreign_key: :account_login, primary_key: :github_login, class_name: 'AppInstallation'
 
   ERRORS = {
     refresh_interval_size: [:refresh_interval, 'must be less than 1 day']
@@ -40,6 +41,10 @@ class User < ApplicationRecord
   def refresh_interval=(val)
     val = nil if 0 == val
     super(val)
+  end
+
+  def has_personal_plan?
+    personal_app_installation && personal_app_installation.private_repositories_enabled?
   end
 
   # For users who had zero values set before 20170111185505_allow_null_for_last_synced_at_in_users.rb


### PR DESCRIPTION
Preparing for https://github.com/octobox/octobox/pull/1433, if you have a personal plan, subject's should be displayed for all repositories even if those repository owners don't have a paid plan. GitHub app still required for permission to download subject.