### PR TITLE
improved meta description

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,7 +7,7 @@
     <%= render 'layouts/favicons' %>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="turbolinks-cache-control" content="no-preview">
-    <meta name="Description" content="Untangle your GitHub Notifications">
+    <meta name="Description" content="Untangle your GitHub Notifications with Octobox, a notification manager for GitHub">
 
     <link rel="preconnect" href="https://api.github.com">
 


### PR DESCRIPTION
The meta description was previously too short so Google did not use it. I have updated it so that Google will be more likely to use it.