### PR TITLE
Improve the app install prompt when option is free

### DIFF
--- a/app/views/notifications/_app_prompt.html.erb
+++ b/app/views/notifications/_app_prompt.html.erb
@@ -4,8 +4,16 @@
   <% else %>
     Pull in state, labels, authors, assignees and CI status
   <% end %>
-  on issues and pull requests by installing the GitHub App on
+  on issues and pull requests by installing the
+  <% if notification.repository.try(:open_source?) || notification.user.has_personal_plan? %>
+    <strong>free</strong>
+  <% end %>
+   GitHub App on
   <%= notification.repository_full_name %>.
 </p>
 
-<a href='<%= Octobox.config.app_url %>' class='btn btn-primary btn-sm'>Install the GitHub App</a>
+<% if notification.user.has_personal_plan? %>
+  <a href='<%= Octobox.config.static_app_url %>' class='btn btn-primary btn-sm'>Install the free GitHub App</a>
+<% else %>
+  <a href='<%= Octobox.config.app_url %>' class='btn btn-primary btn-sm'>Install the <% if notification.repository.try(:open_source?) %>free <% end %>GitHub App</a>
+<% end %>

--- a/lib/octobox/configurator.rb
+++ b/lib/octobox/configurator.rb
@@ -138,8 +138,12 @@ module Octobox
       if marketplace_url.present?
         marketplace_url
       else
-        "#{github_domain}/#{app_path}/#{app_slug}"
+        static_app_url
       end
+    end
+
+    def static_app_url
+      "#{github_domain}/#{app_path}/#{app_slug}"
     end
 
     def app_path


### PR DESCRIPTION
For open source repos and user's who've got a personal plan, this makes it clear that the GitHub app is free.

Also for users on the personal plan it links them to the direct app install link, rather than through the marketplace: https://github.com/apps/octobox

<img width="363" alt="screenshot 2019-01-28 at 11 12 40" src="https://user-images.githubusercontent.com/1060/51832829-aad21900-22ed-11e9-8420-1831f3641e4b.png">
