### PR TITLE
Eager load data for rendering a notification row when pushing_to_channel

### DIFF
--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -128,7 +128,7 @@ class Subject < ApplicationRecord
   end
 
   def push_to_channels
-    notifications.find_each(&:push_to_channel) if (saved_changes.keys & pushable_fields).any?
+    notifications.includes({:subject => :labels}, :repository, {:user => :individual_subscription_purchase}).find_each(&:push_to_channel) if (saved_changes.keys & pushable_fields).any?
   end
 
   private


### PR DESCRIPTION
Reduce n+1 sql queries when publishing notification updates over the websocket