### PR TITLE
Allow more names in private_repositories_enabled?

### DIFF
--- a/app/models/subscription_plan.rb
+++ b/app/models/subscription_plan.rb
@@ -6,7 +6,7 @@ class SubscriptionPlan < ApplicationRecord
   scope :github, -> { where.not(github_id: nil) }
 
   def private_repositories_enabled?
-    name.match?(/private/i) || name.match?(/personal/i)
+    name.match?(/private/i) || name.match?(/personal/i) || name.match?(/individual/i) || name.match?(/organisation/i)
   end
 
   def github?


### PR DESCRIPTION
'Open Collective Individual' and 'Open Collective Organisation' plan names allow private notifications.