### PR TITLE
Revert "Eager load labels when syncing subjects"

### DIFF
--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -19,7 +19,7 @@ class Subject < ApplicationRecord
   def update_labels(remote_labels)
     existing_labels = labels.to_a
     remote_labels.each do |l|
-      label = existing_labels.first{|lbl| lbl.github_id == l['id']} || labels.find_by_github_id(l['id'])
+      label = labels.find_by_github_id(l['id'])
       if label.nil?
         labels.create({
           github_id: l['id'],
@@ -46,7 +46,7 @@ class Subject < ApplicationRecord
   end
 
   def self.sync(remote_subject)
-    subject = Subject.includes(:labels).find_or_create_by(url: remote_subject['url'])
+    subject = Subject.find_or_create_by(url: remote_subject['url'])
 
     # webhook payloads don't always have 'repository' info
     if remote_subject['repository']


### PR DESCRIPTION
Reverts octobox/octobox#1550 which is causing https://github.com/octobox/octobox/issues/1554