### PR TITLE
Synchronous open collective donation journey

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -24,6 +24,10 @@ class ApplicationController < ActionController::Base
 
   private
 
+  def check_octobox_io
+    redirect_to '/422', flash: {error: 'This page is only available on https://octobox.io'} unless Octobox.io?
+  end
+
   def add_user_info_to_bugsnag(notification)
     return unless logged_in?
 

--- a/app/controllers/open_collective_controller.rb
+++ b/app/controllers/open_collective_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 class OpenCollectiveController < ApplicationController
+  before_action :check_octobox_io
+
   def callback
     transaction_id = params[:transactionid]
     transaction = Octobox::OpenCollective.load_transaction(transaction_id)

--- a/app/controllers/open_collective_controller.rb
+++ b/app/controllers/open_collective_controller.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+class OpenCollectiveController < ApplicationController
+  def callback
+    transaction_id = params[:transactionid]
+    transaction = Octobox::OpenCollective.load_transaction()
+
+    if transaction
+      plan = SubscriptionPlan.find_by_name('Open Collective Individual')
+      subscription_purchase = SubscriptionPurchase.new(account_id: current_user.github_id,
+                                                       unit_count: 1,
+                                                       subscription_plan: plan,
+                                                       oc_transactionid: transaction_id)
+
+      if subscription_purchase.save
+        redirect_to root_path, notice: 'Your account has been upgraded'
+      else
+        redirect_to pricing_path, error: 'There was an error with your donation, please contact support@octobox.io'
+      end
+    else
+      redirect_to pricing_path, error: 'There was an error with your donation, please contact support@octobox.io'
+    end
+  end
+end

--- a/app/controllers/open_collective_controller.rb
+++ b/app/controllers/open_collective_controller.rb
@@ -4,7 +4,7 @@ class OpenCollectiveController < ApplicationController
     transaction_id = params[:transactionid]
     transaction = Octobox::OpenCollective.load_transaction(transaction_id)
 
-    if transaction && transaction["result"]
+    if transaction && transaction["result"] && transaction["result"]["amount"] >= 1000
       plan = SubscriptionPlan.find_by_name('Open Collective Individual')
       subscription_purchase = SubscriptionPurchase.new(account_id: current_user.github_id,
                                                        unit_count: 1,

--- a/app/controllers/open_collective_controller.rb
+++ b/app/controllers/open_collective_controller.rb
@@ -2,9 +2,9 @@
 class OpenCollectiveController < ApplicationController
   def callback
     transaction_id = params[:transactionid]
-    transaction = Octobox::OpenCollective.load_transaction()
+    transaction = Octobox::OpenCollective.load_transaction(transaction_id)
 
-    if transaction
+    if transaction && transaction["result"]
       plan = SubscriptionPlan.find_by_name('Open Collective Individual')
       subscription_purchase = SubscriptionPurchase.new(account_id: current_user.github_id,
                                                        unit_count: 1,
@@ -12,12 +12,12 @@ class OpenCollectiveController < ApplicationController
                                                        oc_transactionid: transaction_id)
 
       if subscription_purchase.save
-        redirect_to root_path, notice: 'Your account has been upgraded'
+        redirect_to root_path, flash: {success: 'Your account has been upgraded'}
       else
-        redirect_to pricing_path, error: 'There was an error with your donation, please contact support@octobox.io'
+        redirect_to pricing_path, flash: {error: 'There was an error with your donation, please contact support@octobox.io'}
       end
     else
-      redirect_to pricing_path, error: 'There was an error with your donation, please contact support@octobox.io'
+      redirect_to pricing_path, flash: {error: 'There was an error with your donation, please contact support@octobox.io'}
     end
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 class PagesController < ApplicationController
   skip_before_action :authenticate_user!
+  before_action :check_octobox_io, only: [:pricing, :privacy, :terms]
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -15,7 +15,7 @@ class SessionsController < ApplicationController
     cookies.permanent.signed[:user_id] = {value: user.id, httponly: true}
 
     user.sync_notifications unless initial_sync?
-    redirect_to root_path
+    redirect_to request.env['omniauth.origin'] || root_path
   end
 
   def destroy

--- a/app/models/subscription_purchase.rb
+++ b/app/models/subscription_purchase.rb
@@ -4,6 +4,7 @@ class SubscriptionPurchase < ApplicationRecord
 
   validates :account_id, presence: true
   validates :subscription_plan_id, presence: true
+  validates_uniqueness_of :oc_transactionid, allow_blank: true
 
   scope :active,         -> { where('unit_count > 0') }
   scope :free_trial,     -> { where(on_free_trial: true) }

--- a/app/views/pages/_opencollective.html.erb
+++ b/app/views/pages/_opencollective.html.erb
@@ -11,7 +11,7 @@
 	  	<span class="price pr-2">$10</span>
 	  	<span class="text-small text-muted d-block mt-1 mt-md-0">/ user / month</span>
 	  </div>
-	  <a href='https://opencollective.com/octobox' target='_blank' class='btn btn-success w-100'>Donate on Open Collective</a>
+	  <a href='https://opencollective.com/octobox/donate?amount=10&interval=month&description=individual&redirect=https://octobox.io/opencollective' target='_blank' class='btn btn-success w-100'>Donate on Open Collective</a>
 	  <p class='text-muted'><small>Next: make your donation on Open Collective</small></p>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -58,12 +58,11 @@ Rails.application.routes.draw do
 
   post '/hooks/github', to: 'hooks#create'
 
-  if Octobox.io?
-    get '/opencollective', to: 'open_collective#callback'
-    get '/pricing', to: 'pages#pricing'
-    get '/privacy', to: 'pages#privacy'
-    get '/terms', to: 'pages#terms'
-  end
+  # Octobox.io specific routes
+  get '/opencollective', to: 'open_collective#callback'
+  get '/pricing', to: 'pages#pricing'
+  get '/privacy', to: 'pages#privacy'
+  get '/terms', to: 'pages#terms'
 
   resources :pinned_searches
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,7 +59,7 @@ Rails.application.routes.draw do
   post '/hooks/github', to: 'hooks#create'
 
   if Octobox.io?
-    get '/opencollective', to: 'open_collective#upgrade'
+    get '/opencollective', to: 'open_collective#callback'
     get '/pricing', to: 'pages#pricing'
     get '/privacy', to: 'pages#privacy'
     get '/terms', to: 'pages#terms'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,6 +59,7 @@ Rails.application.routes.draw do
   post '/hooks/github', to: 'hooks#create'
 
   if Octobox.io?
+    get '/opencollective', to: 'open_collective#upgrade'
     get '/pricing', to: 'pages#pricing'
     get '/privacy', to: 'pages#privacy'
     get '/terms', to: 'pages#terms'

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -20,6 +20,7 @@ default: &default
   github_app_id:         <%= ENV['GITHUB_APP_ID']         %>
   github_app_client_id:      <%= ENV['GITHUB_APP_CLIENT_ID']      %>
   github_app_client_secret:  <%= ENV['GITHUB_APP_CLIENT_SECRET']  %>
+  open_collective_api_key:  <%= ENV['OPEN_COLLECTIVE_API_KEY']    %>
 
 development:
   <<: *default

--- a/db/migrate/20190207110533_add_oc_transactionid_to_subscription_purchases.rb
+++ b/db/migrate/20190207110533_add_oc_transactionid_to_subscription_purchases.rb
@@ -1,0 +1,5 @@
+class AddOcTransactionidToSubscriptionPurchases < ActiveRecord::Migration[5.2]
+  def change
+    add_column :subscription_purchases, :oc_transactionid, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_25_105623) do
+ActiveRecord::Schema.define(version: 2019_02_07_110533) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -151,6 +151,7 @@ ActiveRecord::Schema.define(version: 2019_01_25_105623) do
     t.datetime "next_billing_date"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "oc_transactionid"
   end
 
   create_table "users", id: :serial, force: :cascade do |t|

--- a/lib/octobox/open_collective.rb
+++ b/lib/octobox/open_collective.rb
@@ -5,7 +5,7 @@ module Octobox
     ORGANISATION_COST_PER_PERIOD= 100
 
     def self.load_transaction(transaction_id)
-      Oj.load(Typhoeus.get("https://api.opencollective.com/v1/collectives/octobox/transactions/#{transaction_id}?api_key=#{Rails.application.secrets.open_collective_api_key}").body)
+      Oj.load(Typhoeus.get("https://api.opencollective.com/v1/collectives/octobox/transactions/#{transaction_id}?apiKey=#{Rails.application.secrets.open_collective_api_key}").body)
     end
 
     def self.sync

--- a/lib/octobox/open_collective.rb
+++ b/lib/octobox/open_collective.rb
@@ -4,6 +4,10 @@ module Octobox
     INDIVIDUAL_COST_PER_PERIOD = 10
     ORGANISATION_COST_PER_PERIOD= 100
 
+    def self.load_transaction(transaction_id)
+      Oj.load(Typhoeus.get("https://api.opencollective.com/v1/collectives/octobox/transactions/#{transaction_id}?api_key=#{Rails.application.secrets.open_collective_api_key}").body)
+    end
+
     def self.sync
       Rails.logger.info("n\n\033[32m[#{Time.current}] INFO -- Syncing Open Collective supporters \033[0m\n\n")
 

--- a/test/controllers/open_collective_controller_test.rb
+++ b/test/controllers/open_collective_controller_test.rb
@@ -11,8 +11,17 @@ class OpenCollectiveControllerTest < ActionDispatch::IntegrationTest
     @user = create(:user)
   end
 
+  test 'route is only available on octobox.io' do
+    sign_in_as(@user)
+    Octobox.stubs(:io?).returns(false)
+    get "/opencollective?transactionid=#{@transactionid}"
+    assert_response :redirect
+    assert_redirected_to '/422'
+    assert_equal 'This page is only available on https://octobox.io', flash[:error]
+  end
+
   test 'logged out visitor gets directed to login page' do
-    get '/opencollective?transactionid=165052'
+    get "/opencollective?transactionid=#{@transactionid}"
     assert_response :redirect
     refute @user.has_personal_plan?
   end

--- a/test/controllers/open_collective_controller_test.rb
+++ b/test/controllers/open_collective_controller_test.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+class OpenCollectiveControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    Octobox.stubs(:io?).returns(true)
+    stub_notifications_request
+    stub_fetch_subject_enabled(value: false)
+    @transactionid = 165052
+    @plan = create(:subscription_plan, name: 'Open Collective Individual')
+    @user = create(:user)
+  end
+
+  test 'logged out visitor gets directed to login page' do
+    get '/opencollective?transactionid=165052'
+    assert_response :redirect
+    refute @user.has_personal_plan?
+  end
+
+  test 'logged in visitor gets account upgraded' do
+    sign_in_as(@user)
+
+    stub_request(:get, "https://api.opencollective.com/v1/collectives/octobox/transactions/#{@transactionid}?apiKey=")
+                .to_return({ status: 200, body: file_fixture('oc_transaction.json')})
+
+    get "/opencollective?transactionid=#{@transactionid}"
+    assert_response :redirect
+    assert_redirected_to '/'
+    assert @user.has_personal_plan?
+  end
+
+  test 'logged in visitor doesnt get upgraded if api errors' do
+    sign_in_as(@user)
+
+    stub_request(:get, "https://api.opencollective.com/v1/collectives/octobox/transactions/#{@transactionid}?apiKey=")
+                .to_return({ status: 400, body: file_fixture('oc_error.json')})
+
+    get "/opencollective?transactionid=#{@transactionid}"
+    assert_response :redirect
+    assert_redirected_to '/pricing'
+    refute @user.has_personal_plan?
+  end
+end

--- a/test/fixtures/files/oc_error.json
+++ b/test/fixtures/files/oc_error.json
@@ -1,0 +1,3 @@
+{
+  "error": "TypeError: Cannot read property 'collective' of null"
+}

--- a/test/fixtures/files/oc_transaction.json
+++ b/test/fixtures/files/oc_transaction.json
@@ -1,0 +1,48 @@
+{
+  "result": {
+    "id": 165052,
+    "uuid": null,
+    "type": "CREDIT",
+    "createdAt": "Thu Feb 07 2019 15:35:48 GMT+0000 (UTC)",
+    "description": "individual",
+    "amount": 1000,
+    "currency": "USD",
+    "hostCurrency": "USD",
+    "hostCurrencyFxRate": 1,
+    "netAmountInCollectiveCurrency": 831,
+    "hostFeeInHostCurrency": -50,
+    "platformFeeInHostCurrency": -50,
+    "paymentProcessorFeeInHostCurrency": -69,
+    "paymentMethod": {
+      "id": 42284,
+      "service": "stripe",
+      "name": "0002"
+    },
+    "fromCollective": {
+      "id": 1441,
+      "slug": "teabass",
+      "name": "Andrew Nesbitt",
+      "image": "https://opencollective-production.s3-us-west-1.amazonaws.com/andrew_aff03800-57e2-11e6-a2a8-bb3ee7158535.jpeg"
+    },
+    "collective": {
+      "id": 413,
+      "slug": "octobox",
+      "name": "Octobox",
+      "image": "https://opencollective-production.s3-us-west-1.amazonaws.com/4e491a10-aae0-11e8-a91b-df5253215e9d.png"
+    },
+    "host": {
+      "id": 11004,
+      "slug": "opensourcecollective",
+      "name": "Open Source Collective 501c6 (Non Profit)",
+      "image": "https://opencollective-production.s3-us-west-1.amazonaws.com/5f4a3920-11b6-11e8-b28d-b359f3c5ca14.png"
+    },
+    "order": {
+      "id": 40542,
+      "status": "ACTIVE",
+      "subscription": {
+        "id": 31719,
+        "interval": "month"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes https://github.com/octobox/octobox/issues/1222

Current implementation only works for individual $10/month donations due to a limitation of the OC payments page.

~Haven't been able to test this yet as I don't seem to be able to make an API key that can load transactions for Octobox via the open collective website, will email them to find out.~

Other things that would be nice to do, depending on how receptive OC is to each suggestion:

- Allow users to switch between different plans on the payment UI page
- If user selects an org, then after redirect ask them to choose which github org the donation should apply to
- transactionid should be more random than an incrementing number, current incrementing id implementation allows someone to loop through every possible transactionid.
- embeddable donation form from open collective that we can display on our site
- webhooks for when a user cancels/upgrades their donation amount
- always have users redirected to https://octobox.io/opencollective even if they started the donation journey on https://opencollective.com/octobox