### PR TITLE
Activated the channel and validator tests

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,8 +8,9 @@ Rails.application.load_tasks
 Rake::Task['assets:precompile'].enhance ['api_docs:generate']
 
 task 'test:skip_visuals' => 'test:prepare' do
-  ["models", "helpers", "controllers", "integration", "workers"].each do |name|
-    $: << "test"
+  ['channels', 'controllers', 'integration', 'helpers', 'models',
+   'validators', 'workers'].each do |name|
+    $: << 'test'
     Rails::TestUnit::Runner.rake_run(["test/#{name}"])
   end
 end


### PR DESCRIPTION
This pull request activates the channel and validator tests, which are not being run under the skip_visuals banner.  Activating the lib and services tests led to many errors.  We need to fix those tests before we can activate them.