### PR TITLE
Quick, temp fix to lower open collective donor support requests

### DIFF
--- a/app/controllers/open_collective_controller.rb
+++ b/app/controllers/open_collective_controller.rb
@@ -14,7 +14,7 @@ class OpenCollectiveController < ApplicationController
                                                        oc_transactionid: transaction_id)
 
       if subscription_purchase.save
-        redirect_to root_path, flash: {success: 'Your account has been upgraded'}
+        redirect_to root_path, flash: {success: "Subscription updated. Remember to <a href='#{Octobox.config.app_install_url}>install the GitHub app</a> on repositories (may require additional authority) "}
       else
         redirect_to pricing_path, flash: {error: 'There was an error with your donation, please contact support@octobox.io'}
       end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,7 +16,7 @@ module ApplicationHelper
       flash.each do |msg_type, message|
         concat(content_tag(:div, message, class: "alert #{bootstrap_class_for(msg_type)} fade show") do
           concat content_tag(:button, octicon('x'), class: 'close', data: { dismiss: 'alert' })
-          concat message
+          concat message.html_safe
         end)
       end
     end)

--- a/app/views/pages/pricing.html.erb
+++ b/app/views/pages/pricing.html.erb
@@ -9,6 +9,8 @@
 		<%= render('opencollective')%>
 		<%= render('github')%>
 	</div>
+
+  <p class='mt-2'>In order to take advantage of paid-access feature you will need to install the <a href='<%= Octobox.config.app_install_url %>' target="_blank">Octobox GitHub App</a> on each repository or organisation you'd like to enable. This may require additional authorisation. 
 	
 	<h2 id='why' class='text-center mb-5 pt-3'>What... Why?</h2>
 


### PR DESCRIPTION
I had hoped I'd get more time today to look at this but, it ran away with me.

I know that making error message html_safe is not a great thing to do but: in order to stop people from sending support requests I propose adding this until something more permanent can be done.