### PR TITLE
Add hirefire configuration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,4 +77,5 @@ group :production do
   gem 'skylight', '4.0.0.beta'
   gem 'lograge'
   gem 'puma_worker_killer'
+  gem 'hirefire-resource'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,6 +139,7 @@ GEM
       minitest (>= 3.0)
     hashdiff (0.3.8)
     hashie (3.6.0)
+    hirefire-resource (0.7.1)
     i18n (1.5.3)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.2)
@@ -427,6 +428,7 @@ DEPENDENCIES
   git
   guard
   guard-minitest
+  hirefire-resource
   jbuilder
   jquery-rails
   jwt

--- a/config/initializers/hirefire_resource.rb
+++ b/config/initializers/hirefire_resource.rb
@@ -1,0 +1,7 @@
+if Rails.application.secrets.hirefire_token.present?
+  HireFire::Resource.configure do |config|
+    config.dyno(:worker) do
+      HireFire::Macro::Sidekiq.queue
+    end
+  end
+end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -18,6 +18,7 @@ default: &default
   bugsnag_js_api_key:    <%= ENV['BUGSNAG_JS_API_KEY']    %>
   github_webhook_secret: <%= ENV['GITHUB_WEBHOOK_SECRET'] %>
   github_app_id:         <%= ENV['GITHUB_APP_ID']         %>
+  hirefire_token:        <%= ENV['HIREFIRE_TOKEN']        %>
   github_app_client_id:      <%= ENV['GITHUB_APP_CLIENT_ID']      %>
   github_app_client_secret:  <%= ENV['GITHUB_APP_CLIENT_SECRET']  %>
   open_collective_api_key:  <%= ENV['OPEN_COLLECTIVE_API_KEY']    %>


### PR DESCRIPTION
To enable autoscaling of heroku workers based on number of jobs in the queue, should save lots of 💰 on heroku hosting costs.