### PR TITLE
Fix login redirect loop in Safari

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -5,7 +5,11 @@ class SessionsController < ApplicationController
   before_action :authorize_access!, only: :create
 
   def new
-    redirect_to '/auth/github'
+    if logged_in?
+      redirect_to root_path
+    else
+      redirect_to '/auth/github'
+    end
   end
 
   def create

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -22,6 +22,12 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to '/auth/github'
   end
 
+  test 'GET #new redirects to /root if already logged in' do
+    sign_in_as(@user)
+    get '/login'
+    assert_redirected_to '/'
+  end
+
   test 'POST #create finds the GitHub user from the hash and redirects to the root_path' do
     OmniAuth.config.mock_auth[:github].uid = @user.github_id
     post '/auth/github/callback'


### PR DESCRIPTION
If you visit /login when already logged in, go directly to the homepage rather than back to to oauth.