### PR TITLE
Add default searches to new users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -165,9 +165,8 @@ class User < ApplicationRecord
   end
 
   def create_default_pinned_searches 
-    pinned_searches.new(query: 'state:closed,merged archived:false', name: 'Archivable')
-    pinned_searches.new(query: 'type:pull_request state:open status:success', name: 'Mergeable')
-    pinned_searches.new(query: "type:pull_request author:#{github_login} inbox:true", name: 'My PRs')
-    save
+    pinned_searches.create(query: 'state:closed,merged archived:false', name: 'Archivable')
+    pinned_searches.create(query: 'type:pull_request state:open status:success', name: 'Mergeable')
+    pinned_searches.create(query: "type:pull_request author:#{github_login} inbox:true", name: 'My PRs')
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -165,7 +165,7 @@ class User < ApplicationRecord
 
   def create_default_pinned_searches 
     pinned_searches.create(query: 'state:closed,merged archived:false', name: 'Archivable')
-    pinned_searches.create(query: 'type:pull_request state:open status:success', name: 'Mergeable')
+    pinned_searches.create(query: 'type:pull_request state:open status:success archived:false', name: 'Mergeable')
     pinned_searches.create(query: "type:pull_request author:#{github_login} inbox:true", name: 'My PRs')
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -166,7 +166,7 @@ class User < ApplicationRecord
 
   def create_default_pinned_searches 
     pinned_searches.new(query: 'state:closed,merged archived:false', name: 'Archivable')
-    pinned_searches.new(query: 'type:pull_request state:open status:success', name: 'Mergable')
+    pinned_searches.new(query: 'type:pull_request state:open status:success', name: 'Mergeable')
     pinned_searches.new(query: "type:pull_request author:#{github_login} inbox:true", name: 'My PRs')
     save
   end

--- a/test/controllers/notifications_controller_test.rb
+++ b/test/controllers/notifications_controller_test.rb
@@ -850,11 +850,10 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
 
   test 'shows saved searches in sidebar' do
     sign_in_as(@user)
-    create(:pinned_search, user: @user)
     get '/'
     assert_response :success
     assert_template 'notifications/index'
-    assert_select '.pinned_search', {count: 1}
+    assert_select '.pinned_search', {count: 3}
   end
 
   test 'highlights active saved searches in sidebar' do

--- a/test/controllers/pinned_searches_controller_test.rb
+++ b/test/controllers/pinned_searches_controller_test.rb
@@ -21,7 +21,7 @@ class PinnedSearchesControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :redirect
     assert_redirected_to '/settings'
-    assert_equal @user.pinned_searches.count, 1
+    assert_equal @user.pinned_searches.count, 4
   end
 
   test 'will render edit saved search form' do
@@ -69,7 +69,7 @@ class PinnedSearchesControllerTest < ActionDispatch::IntegrationTest
     delete "/pinned_searches/#{pinned_search.id}"
     assert_response :redirect
     assert_redirected_to '/settings'
-    assert_equal @user.pinned_searches.count, 0
+    assert_equal @user.pinned_searches.count, 3
   end
 
   test 'will only delete saved searches owned by the current user' do
@@ -81,7 +81,7 @@ class PinnedSearchesControllerTest < ActionDispatch::IntegrationTest
       assert_response :not_found
     end
 
-    assert_equal other_user.pinned_searches.count, 1
+    assert_equal other_user.pinned_searches.count, 4
   end
 
   test 'will redirect index page requests to settings' do


### PR DESCRIPTION
Adds three default 'pinned searches' to new user accounts:

- Archivable: any closed or merged issues or PRs that are not yet in the archive
- Mergeable: any open pull request that is currently passing CI 
- My PRs: any PR that is in your inbox for which you were the author

The aim here is to get every new user _aware_ of pinned searches and to help onboard them quickly by removing all the chaff (archivable) focussing on quick wins (mergeable) and then getting focussed on their own work (my prs).

I'm not sure how best to roll this across the 12k users we have on Octobox.io. Some help there would be 👌