### PR TITLE
Corrected mismatched header tags on the privacy page; added tests

### DIFF
--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -22,17 +22,17 @@
       We collect information about your GitHub notifications including some basic data about notifications from private repositories. If you install the GitHub App we collect more detailed data about these notifications including but not limitted to authors, labels, comments and status. If you enable private repository access then we collect this data for your private repositories too.
     </p>
 
-    <h3>Transmitting Your Data</h4>
+    <h3>Transmitting Your Data</h3>
     <p>
       Transmitting information over the Internet is generally not completely secure, and we can’t guarantee the security of your data.
     </p>
 
-    <h3>Processing And Storing Your Data</h4>
+    <h3>Processing And Storing Your Data</h3>
     <p>
       Your data is processed by servers in France and Ireland. Your data is stored on our servers in France, once it is stored we have processes in place to secure it.
     </p>
 
-    <h3>Sharing Your Data</h4>
+    <h3>Sharing Your Data</h3>
     <p>
       The information we collect is not shared with or sold to other organizations, except to provide products or services you have requested, with your permission, or under the following circumstances:
     </p>

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -13,4 +13,18 @@ class PagesControllerTest < ActionDispatch::IntegrationTest
     assert_response :redirect
     assert_redirected_to '/documentation#support'
   end
+
+  test 'privacy page renders the home page if OCTOBOX_IO is not set' do
+    get privacy_path
+    assert_response :redirect
+    assert_redirected_to '/422'
+  end
+
+  test 'will render the privacy page if OCTOBOX_IO is set to true' do
+    set_env('OCTOBOX_IO', 'true') do
+      get privacy_path
+      assert_response :success
+      assert_template 'pages/privacy'
+    end
+  end
 end

--- a/test/integration/privacy_page_test.rb
+++ b/test/integration/privacy_page_test.rb
@@ -1,0 +1,59 @@
+require 'test_helper'
+
+class PrivacyPageTest < ActionDispatch::IntegrationTest
+  def setup
+    stub_notifications_request
+    stub_comments_requests
+    stub_fetch_subject_enabled(value: false)
+    @user = create(:user)
+  end
+
+  def teardown
+    User.destroy_all
+  end
+
+  def check_redirected
+    get privacy_path
+    assert_match 'You are being', response.body
+    assert_select "a[href=?]", 'http://www.example.com/422', text: 'redirected'
+  end
+
+  def check_privacy_page_contents
+    get privacy_path
+    assert_select 'h1', text: 'Privacy Policy'
+    assert_select 'h2', text: 'We Care About Your Privacy'
+    assert_select 'h3', text: 'Data We Collect'
+    assert_select 'h3', text: 'Transmitting Your Data'
+    assert_select 'h3', text: 'Processing And Storing Your Data'
+    assert_select 'h3', text: 'Sharing Your Data'
+    assert_select 'h2', text: 'Services We Use'
+    assert_select 'h3', text: 'Cookies'
+    assert_select 'h3', text: 'Logging'
+    assert_select 'h4', text: "Bugsnag's DPA"
+    assert_select 'h2', text: 'Your Rights'
+  end
+
+  test 'privacy page is not shown when OCTOBOX_IO is not set' do
+    check_redirected
+    sign_in_as(@user)
+    check_redirected
+  end
+
+  test 'privacy page is shown when OCTOBOX_IO is set' do
+    set_env('OCTOBOX_IO', 'true') do
+      check_privacy_page_contents
+      sign_in_as(@user)
+      check_privacy_page_contents
+    end
+  end
+
+  test 'index page provides link to privacy page when OCTOBOX_IO is set' do
+    set_env('OCTOBOX_IO', 'true') do
+      get root_path
+      assert_select "a[href=?]", privacy_path, text: 'Privacy Policy'
+      sign_in_as(@user)
+      get root_path
+      assert_select "a[href=?]", privacy_path, text: 'Privacy Policy'
+    end
+  end
+end


### PR DESCRIPTION
* Corrected mismatched header tags on the privacy page (opened as h3, closed as h4)
* Added controller tests of the privacy page
* Added integration tests of the privacy page