### PR TITLE
Update comments in thread when updated on the DB.

### DIFF
--- a/app/assets/javascripts/channels/comments.js
+++ b/app/assets/javascripts/channels/comments.js
@@ -9,6 +9,8 @@ var subscribeToComments = function(){
     received: function(data){
       if ($('#notification-thread').attr('data-id') == data.subject_id && !$("#comment-"+data.comment_id).length){
         $('.discussion-thread').append(data.comment_html);
+      }else if ($("#comment-"+data.comment_id).length){
+        $("#comment-"+data.comment_id)[0].outerHTML = data.comment_html;
       }
     }
   });

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -29,10 +29,6 @@ class Comment < ApplicationRecord
     push_to_channels if (saved_changes.keys & pushable_fields).any?
   end
 
-  def pushable_fields
-    ['body', 'github_id']
-  end
-
   def push_to_channels
     comment_html = ApplicationController.render(partial: 'notifications/comment', locals: {subject: self.subject.id, comment: self, comments:1})
     ActionCable.server.broadcast "comments:#{subject.id}", {comment_id: self.id, comment_html: comment_html, subject_id: self.subject.id}
@@ -41,6 +37,7 @@ class Comment < ApplicationRecord
   private
 
   def pushable_fields
-    ['body']
+    ['body', 'github_id']
   end
+
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,7 +1,7 @@
 class Comment < ApplicationRecord
   belongs_to :subject
 
-  after_create :push_to_channels
+  after_save :push_to_channels
 
   BOT_AUTHOR_REGEX = /\A(.*)\[bot\]\z/.freeze
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -30,7 +30,7 @@ class Comment < ApplicationRecord
   end
 
   def pushable_fields
-      ['body', 'github_id']
+    ['body', 'github_id']
   end
 
   def push_to_channels

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,7 +1,7 @@
 class Comment < ApplicationRecord
   belongs_to :subject
 
-  after_save :push_to_channels
+  after_save :push_if_changed
 
   BOT_AUTHOR_REGEX = /\A(.*)\[bot\]\z/.freeze
 
@@ -23,6 +23,14 @@ class Comment < ApplicationRecord
 
   def unread?(notification)
     notification.last_read_at && DateTime.parse(notification.last_read_at) < created_at
+  end
+
+  def push_if_changed
+    push_to_channels if (saved_changes.keys & pushable_fields).any?
+  end
+
+  def pushable_fields
+      ['body', 'github_id']
   end
 
   def push_to_channels

--- a/test/channels/comments_channel_test.rb
+++ b/test/channels/comments_channel_test.rb
@@ -13,7 +13,7 @@ class CommentsChannelTest < ActionCable::Channel::TestCase
     assert_no_streams
   end
 
-  test "receives comment webhooks when updated" do
+  test "receives comment webhooks when created" do
 
     user = create(:user)
     notification = create(:notification, user: user)
@@ -26,6 +26,24 @@ class CommentsChannelTest < ActionCable::Channel::TestCase
 
     assert_broadcasts(subject, 1) do
       create(:comment, subject: subject)
+    end
+
+  end
+
+  test "receives comment webhooks when updated" do
+
+    user = create(:user)
+    notification = create(:notification, user: user)
+    subject = create(:subject, notifications: [notification])
+    comment = create(:comment, subject: subject)
+
+    stub_connection(current_user: user)
+    subscribe notification: notification.id
+
+    assert_has_stream "comments:#{subject.id}"
+
+    assert_broadcasts(subject, 1) do
+      comment.update_attributes(body: "A new body")
     end
 
   end


### PR DESCRIPTION
I noticed that the sync icon persists on a new comment because the comment view isn't updated when the model is updated with a GitHub id. 

Should also be useful for #1662 at some point. 