### PR TITLE
Improve scrolling behaviour on iOS

### DIFF
--- a/app/assets/javascripts/octobox.js
+++ b/app/assets/javascripts/octobox.js
@@ -387,9 +387,17 @@ var Octobox = (function() {
     $("#notification-"+id).removeClass("active");
   };
 
+  function setViewportHeight() {
+    var vh = window.innerHeight * 0.01;
+    document.documentElement.style.setProperty('--vh', `${vh}px`);
+  };
+
   var initialize = function() {
     enableTooltips();
     enablePopOvers();
+
+    setViewportHeight();
+    window.addEventListener('resize', setViewportHeight);
 
     if ($("#help-box").length){
       enableKeyboardShortcuts();

--- a/app/assets/stylesheets/_layout.scss
+++ b/app/assets/stylesheets/_layout.scss
@@ -6,6 +6,7 @@ body {
   font-size: 14px;
   display: flex;
   height: 100vh;
+  height: calc(var(--vh, 1vh) * 100);
   flex-direction: column;
 }
 


### PR DESCRIPTION
Based on https://css-tricks.com/the-trick-to-viewport-units-on-mobile/

Behaviour before:

![before mov](https://user-images.githubusercontent.com/1060/55351802-2b142680-54b7-11e9-8580-d100a6ac2b32.gif)

After:

![after mov](https://user-images.githubusercontent.com/1060/55351813-310a0780-54b7-11e9-9ff2-0c842b2dd618.gif)
