### PR TITLE
Fix HTML in opencollective success flash

### DIFF
--- a/app/controllers/open_collective_controller.rb
+++ b/app/controllers/open_collective_controller.rb
@@ -14,7 +14,7 @@ class OpenCollectiveController < ApplicationController
                                                        oc_transactionid: transaction_id)
 
       if subscription_purchase.save
-        redirect_to root_path, flash: {success: "Subscription updated. Remember to <a href='#{Octobox.config.app_install_url}>install the GitHub app</a> on repositories (may require additional authority) "}
+        redirect_to root_path, flash: {success: "Subscription updated. Remember to <a href='#{Octobox.config.app_install_url}'>install the GitHub app</a> on repositories (may require additional authority) "}
       else
         redirect_to pricing_path, flash: {error: 'There was an error with your donation, please contact support@octobox.io'}
       end


### PR DESCRIPTION
The flash message had an unclosed HTML property value, which caused
issues rendering the flash message.

The screenshot below was how it was rendered, so there maybe another issue with the HTML nesting of the flash message.

![image](https://user-images.githubusercontent.com/282402/55685059-6f3d7600-5952-11e9-8b29-c939fc01383e.png)
