### PR TITLE
Use _blank when opening external links

### DIFF
--- a/app/views/notifications/_thread_subject.html.erb
+++ b/app/views/notifications/_thread_subject.html.erb
@@ -3,7 +3,7 @@
   <span class='text-muted font-weight-light'> #<%= notification.subject_number %> </span>
 </h2>
 
-<%= link_to notification.web_url, target: :blank, class: "btn btn-sm #{notification_button_color(notification)} mr-2" do %>
+<%= link_to notification.web_url, target: '_blank', class: "btn btn-sm #{notification_button_color(notification)} mr-2" do %>
   <%= octicon notification_icon(notification), :height => 16, title: notification_icon_title(notification), data: {toggle: 'tooltip'} %>
   <%= notification_button_title(notification) %>
 <% end %>


### PR DESCRIPTION
When clicking the status button in the upper left of a thread view it links you to the external github item, however, it uses 'blank' instead of '_blank' for the href attribute. This means that if I:

Click the status button to view something in github
Navigate away to do something else with that tab
Go back to octobox to view a thread
Click the status button again

Chrome will just activate the previously used tab instead of navigating the user to the item on github