### PR TITLE
Only require sidekiq-scheduler gem if if sidekiq_schedule_enabled?

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'git'
 gem 'rgb'
 gem 'sidekiq'
 gem 'sidekiq-unique-jobs'
-gem 'sidekiq-scheduler'
+gem 'sidekiq-scheduler', require: false
 gem 'rack-canonical-host'
 gem 'sidekiq-status'
 gem 'gemoji', require: false

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 if Octobox.background_jobs_enabled?
-  require 'sidekiq-scheduler'
+  require 'sidekiq-scheduler' if Octobox.config.sidekiq_schedule_enabled?
   require 'sidekiq-status'
 
   Sidekiq.configure_server do |config|


### PR DESCRIPTION
Saves a few mb of ram per rails process if the cronjob option is not enabled.