### PR TITLE
Avoid requiring rake at startup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem 'faraday_middleware'
 gem 'uglifier'
 gem 'pg_search'
 gem 'jbuilder'
-gem 'rake'
+gem 'rake', require: false
 gem 'git'
 gem 'rgb'
 gem 'sidekiq'


### PR DESCRIPTION
We only have it in the Gemfile to ensure the correct version is always available for `$ rake` commands, saves ~0.8mb per rails process