### PR TITLE
Updated Debian-based local installation documentation.

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -104,7 +104,7 @@ brew install postgres
 On Debian-based Linux distributions you can use apt-get to install Postgres:
 
 ```bash
-sudo apt-get install postgresql postgresql-contrib libpq-dev
+sudo apt-get install postgresql postgresql-contrib libpq-dev rbenv
 ```
 
 Now, let's install the gems from the `Gemfile` ("Gems" are synonymous with libraries in other


### PR DESCRIPTION
`rbenv` is not present in some Debian-like distributions and is assumed to be installed in next commands.

I would suggest to add it to the installation list in the `apt-get` command to make it easy to follow the installation instructions.