### PR TITLE
Sync supporters fix

### DIFF
--- a/lib/octobox/open_collective.rb
+++ b/lib/octobox/open_collective.rb
@@ -48,6 +48,9 @@ module Octobox
       
       if current_subs_purchases
         current_subs_purchases.each do |purchase|
+
+          next if app_installation.nil?
+          
           unless subscriber_names.include? purchase.app_installation.account_login
             purchase.update_attributes(unit_count: 0) unless purchase.next_billing_date.present? && purchase.next_billing_date > Time.now
             Rails.logger.info("n\n\033[32m[#{Time.current}] INFO -- Removed #{plan_name} for #{purchase.app_installation.account_login}\033[0m\n\n")

--- a/lib/octobox/open_collective.rb
+++ b/lib/octobox/open_collective.rb
@@ -49,7 +49,7 @@ module Octobox
       if current_subs_purchases
         current_subs_purchases.each do |purchase|
 
-          next if app_installation.nil?
+          next if purchase.app_installation.nil?
           
           unless subscriber_names.include? purchase.app_installation.account_login
             purchase.update_attributes(unit_count: 0) unless purchase.next_billing_date.present? && purchase.next_billing_date > Time.now

--- a/test/lib/octobox/open_collective_test.rb
+++ b/test/lib/octobox/open_collective_test.rb
@@ -37,8 +37,14 @@ class OpenCollectiveTest < ActiveSupport::TestCase
 
 	test "removes plans" do
 		create(:subscription_purchase, account_id: @user.github_id, subscription_plan_id: @individual_plan.id, unit_count: 1)
+		@another_user = create(:user, github_login: 'billy', github_id: '5678')
+		create(:app_installation, account_login: @another_user.github_login, account_id: @another_user.github_id)
+		create(:subscription_purchase, account_id: @another_user.github_id, subscription_plan_id: @individual_plan.id, unit_count: 1, next_billing_date: Time.now + 1.week)
+
 		Octobox::OpenCollective.sync
+
 		refute @user.has_personal_plan?
+		assert @another_user.has_personal_plan?
 	end
 
 	test "upgrades plans" do


### PR DESCRIPTION
Skip `SubscriptionPurchases` with no corresponding `AppInstallations`. 