### PR TITLE
Fix broken UI issue for long words

### DIFF
--- a/app/assets/stylesheets/_notifications.scss
+++ b/app/assets/stylesheets/_notifications.scss
@@ -231,6 +231,7 @@ $notification-items: (
     .notification-subject {
       display: inline-block;
       .link {
+        word-break: break-all;
         overflow-wrap: break-word;
       }
       &:first-child .badge{


### PR DESCRIPTION
Currently, if a notification's subject is a single word and more than certain characters then it breaks the listing and doesn't show all of the fields

This commit changes a style rule, so longer words will work like any other title, break it down to a certain limit.

Fixes #1799