### PR TITLE
Add next billing date to OC subscriptions

### DIFF
--- a/app/controllers/open_collective_controller.rb
+++ b/app/controllers/open_collective_controller.rb
@@ -11,7 +11,8 @@ class OpenCollectiveController < ApplicationController
       subscription_purchase = SubscriptionPurchase.new(account_id: current_user.github_id,
                                                        unit_count: 1,
                                                        subscription_plan: plan,
-                                                       oc_transactionid: transaction_id)
+                                                       oc_transactionid: transaction_id,
+                                                       next_billing_date: Time.now + 1.month)
 
       if subscription_purchase.save
         redirect_to root_path, flash: {success: "Subscription updated. Remember to <a href='#{Octobox.config.app_install_url}'>install the GitHub app</a> on repositories (may require additional authority) "}

--- a/lib/octobox/open_collective.rb
+++ b/lib/octobox/open_collective.rb
@@ -49,9 +49,9 @@ module Octobox
         current_subs_purchases.each do |purchase|
 
           next if purchase.app_installation.nil?
-
-          unless subscriber_names.include? purchase.app_installation.account_login
-            purchase.update_attributes(unit_count: 0) unless purchase.next_billing_date.present? && purchase.next_billing_date > Time.now
+          next if subscriber_names.include? purchase.app_installation.account_login
+          unless purchase.next_billing_date.present? && purchase.next_billing_date > Time.now
+            purchase.update_attributes(unit_count: 0) 
             Rails.logger.info("n\n\033[32m[#{Time.current}] INFO -- Removed #{plan_name} for #{purchase.app_installation.account_login}\033[0m\n\n")
           end
         end


### PR DESCRIPTION
At the moment users without a GH username on their OC account will be stripped of their subscription when the open collective members are synced. This change adds a next_billing_date to subscription purchases that use the synchronous OC flow to ensure that they're only reevaluated after one month.  

* Simplify logic for removing subscriptions in OC rake task
* Add next_billing_date to open collective synchronous transactions