### PR TITLE
Add the 'Organization members' permission for GitHub App

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -416,6 +416,7 @@ Then create a new GitHub App, <https://github.com/settings/apps/new>, with the f
 - Webhook URL: The domain plus `/hooks/github`, i.e. http://myoctoboxdomain.com/hooks/github
 - Webhook secret: generate a password and paste it in here and save for later
 - Permissions:
+  - Organization members: Read-only (only needed if your organization has private members)
   - Repository metadata: Read-only
   - Issues: write
   - Pull Requests: Read-only


### PR DESCRIPTION
This is necessary to be able to confirm that a user is a member of the
organization if their membership is private.

This was inspired by https://github.com/octobox/octobox/pull/1521

Our private GitHub App was always leading to "Access Denied" until we activated the permission.