### PR TITLE
Allow custom port to be set for postgres OCTOBOX_DATABASE_PASSWORD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM ruby:2.6.3-alpine
 
 ENV APP_ROOT /usr/src/app
+ENV OCTOBOX_DATABASE_PORT 5432
 WORKDIR $APP_ROOT
 
 # =============================================

--- a/bin/docker-start
+++ b/bin/docker-start
@@ -2,7 +2,7 @@
 set -e
 
 db_host=${OCTOBOX_DATABASE_HOST:-database.service.octobox.internal}
-while ! nc -z $db_host 5432; do
+while ! nc -z $db_host ${OCTOBOX_DATABASE_PORT:-5432}; do
   echo "Waiting for database to be available..."
   sleep 1
 done

--- a/config/database.yml
+++ b/config/database.yml
@@ -4,6 +4,7 @@ default: &default
   username: <%= DatabaseConfig.username %>
   password: <%= DatabaseConfig.password %>
   host:     <%= DatabaseConfig.host %>
+  port:     <%= DatabaseConfig.port %>
 
 development:
   <<: *default

--- a/lib/database_config.rb
+++ b/lib/database_config.rb
@@ -80,6 +80,15 @@ module DatabaseConfig
       end
     end
 
+    # Port for the database
+    # Overridden by DATABASE_URL
+    #
+    def port
+      database_url_or_fallback('port') do
+        ENV.fetch('OCTOBOX_DATABASE_PORT') { 5432 }
+      end
+    end
+
     # Connection Pool count for the database
     #
     def connection_pool

--- a/test/lib/database_config_test.rb
+++ b/test/lib/database_config_test.rb
@@ -156,4 +156,14 @@ class DatabaseConfigTest < ActiveSupport::TestCase
       refute DatabaseConfig.is_postgres?, 'was postgres, it should not have been'
     end
   end
+
+  test 'port is specified properly' do
+    set_env('DATABASE_URL', DB_URL) do
+      assert_equal 'port', DatabaseConfig.port
+    end
+
+    set_env('OCTOBOX_DATABASE_PASSWORD', 1234) do |val|
+      assert_equal val, DatabaseConfig.port
+    end
+  end
 end

--- a/test/lib/database_config_test.rb
+++ b/test/lib/database_config_test.rb
@@ -162,7 +162,7 @@ class DatabaseConfigTest < ActiveSupport::TestCase
       assert_equal 1234, DatabaseConfig.port
     end
 
-    set_env('OCTOBOX_DATABASE_PORT', 1234) do |val|
+    set_env('OCTOBOX_DATABASE_PORT', "1234") do |val|
       assert_equal val, DatabaseConfig.port
     end
   end

--- a/test/lib/database_config_test.rb
+++ b/test/lib/database_config_test.rb
@@ -162,7 +162,7 @@ class DatabaseConfigTest < ActiveSupport::TestCase
       assert_equal 'port', DatabaseConfig.port
     end
 
-    set_env('OCTOBOX_DATABASE_PASSWORD', 1234) do |val|
+    set_env('OCTOBOX_DATABASE_PORT', 1234) do |val|
       assert_equal val, DatabaseConfig.port
     end
   end

--- a/test/lib/database_config_test.rb
+++ b/test/lib/database_config_test.rb
@@ -159,7 +159,7 @@ class DatabaseConfigTest < ActiveSupport::TestCase
 
   test 'port is specified properly' do
     set_env('DATABASE_URL', DB_URL) do
-      assert_equal 'port', DatabaseConfig.port
+      assert_equal 1234, DatabaseConfig.port
     end
 
     set_env('OCTOBOX_DATABASE_PORT', 1234) do |val|


### PR DESCRIPTION
Im not a rails dev so not sure if I have missed anything or not.

Environmental variable `OCTOBOX_DATABASE_PASSWORD` can be used to set the postgres port to anything you need.