### PR TITLE
Only download subjects for a notification if the user is present

### DIFF
--- a/lib/octobox/notifications/sync_subject.rb
+++ b/lib/octobox/notifications/sync_subject.rb
@@ -36,7 +36,7 @@ module Octobox
       end
 
       def download_subject?
-        @download_subject ||= subjectable? && github_client && (Octobox.fetch_subject? || github_app_installed? || download_public_subjects?)
+        @download_subject ||= user.present? && subjectable? && github_client && (Octobox.fetch_subject? || github_app_installed? || download_public_subjects?)
       end
 
       def download_public_subjects?


### PR DESCRIPTION
Avoids an edge case where the user has deleted their account whilst their notifications are being synced