### PR TITLE
[POC]: Add team vs individual review requests

### DIFF
--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -1,4 +1,9 @@
 module NotificationsHelper
+  REASON_OCTICON = {
+    'review_requested'      => 'person',
+    'team_review_requested' => 'organization'
+  }.freeze
+
   REASON_LABELS = {
     'comment'        => 'primary',
     'author'         => 'success',
@@ -194,6 +199,10 @@ module NotificationsHelper
       'closed' => 'text-danger',
       'merged' => 'text-subscribed'
     }[notification.state]
+  end
+
+  def reason_octicon(reason)
+    REASON_OCTICON.fetch(reason, 'primitive-dot')
   end
 
   def reason_label(reason)

--- a/app/views/notifications/_sidebar.html.erb
+++ b/app/views/notifications/_sidebar.html.erb
@@ -124,9 +124,9 @@
 
 <% if @reasons.any? %>
   <ul class="nav nav-pills flex-column nav-filters">
-    <% @reasons.sort_by{|reason, count| reason.downcase }.each do |reason, count| %>
+    <% @reasons.each do |reason, count| %>
       <%= reason_filter_link reason, count do %>
-        <%= octicon 'primitive-dot', height: 24, class: "sidebar-icon text-#{reason_label(reason)}" %>
+        <%= octicon reason_octicon(reason), height: 24, class: "sidebar-icon text-#{reason_label(reason)}" %>
         <%= reason.underscore.humanize %>
       <% end %>
     <% end %>

--- a/db/migrate/20190525042845_add_requested_reviewers_to_subjects.rb
+++ b/db/migrate/20190525042845_add_requested_reviewers_to_subjects.rb
@@ -1,0 +1,5 @@
+class AddRequestedReviewersToSubjects < ActiveRecord::Migration[5.2]
+  def change
+    add_column :subjects, :requested_reviewers, :string, default: '::'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_06_173231) do
+ActiveRecord::Schema.define(version: 2019_05_25_042845) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -124,6 +124,7 @@ ActiveRecord::Schema.define(version: 2019_04_06_173231) do
     t.text "body"
     t.integer "comment_count"
     t.boolean "draft", default: false
+    t.string "requested_reviewers", default: "::"
     t.index ["repository_full_name"], name: "index_subjects_on_repository_full_name"
     t.index ["url"], name: "index_subjects_on_url"
   end

--- a/lib/octobox/notifications/exclusive_scope.rb
+++ b/lib/octobox/notifications/exclusive_scope.rb
@@ -10,6 +10,7 @@ module Octobox
         scope :exclude_reason, ->(reason)       { where.not(reason: reason) }
         scope :not_locked,     -> { joins(:subject).where(subjects: { locked: false }) }
         scope :without_subject, -> { includes(:subject).where(subjects: { url: nil }) }
+        scope :exclude_github_login, ->(github_login) { joins(:user).where.not(users: { github_login: github_login }) }
 
         scope :exclude_repo, lambda { |repo_names|
           repo_names = [repo_names] if repo_names.is_a?(String)

--- a/lib/octobox/notifications/inclusive_scope.rb
+++ b/lib/octobox/notifications/inclusive_scope.rb
@@ -29,6 +29,7 @@ module Octobox
         scope :is_private, ->(is_private = true) { joins(:repository).where('repositories.private = ?', is_private) }
         scope :unlabelled, -> { labelable.with_subject.left_outer_joins(:labels).where(labels: {id: nil})}
         scope :with_subject,-> { includes(:subject).where.not(subjects: { url: nil }) }
+        scope :github_login, ->(github_login) { joins(:user).where(users: { github_login: github_login }) }
 
         scope :repo, lambda { |repo_names|
           repo_names = [repo_names] if repo_names.is_a?(String)

--- a/test/fixtures/files/subject_56.json
+++ b/test/fixtures/files/subject_56.json
@@ -40,6 +40,43 @@
   "assignees": [
 
   ],
+  "requested_reviewers": [
+    {
+      "login": "chrisarcand",
+      "id": 2430490,
+      "node_id": "MDQ6VXNlcjI0MzA0OTA=",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/2430490?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/chrisarcand",
+      "html_url": "https://github.com/chrisarcand",
+      "followers_url": "https://api.github.com/users/chrisarcand/followers",
+      "following_url": "https://api.github.com/users/chrisarcand/following{/other_user}",
+      "gists_url": "https://api.github.com/users/chrisarcand/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/chrisarcand/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/chrisarcand/subscriptions",
+      "organizations_url": "https://api.github.com/users/chrisarcand/orgs",
+      "repos_url": "https://api.github.com/users/chrisarcand/repos",
+      "events_url": "https://api.github.com/users/chrisarcand/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/chrisarcand/received_events",
+      "type": "User",
+      "site_admin": false
+    }
+  ],
+  "requested_teams": [
+    {
+      "name": "Cool Kids",
+      "id": 2471073,
+      "node_id": "MDQ6VGVhbTI0NzEwNzM=",
+      "slug": "cool-kids",
+      "description": "Where they are",
+      "privacy": "closed",
+      "url": "https://api.github.com/teams/2471073",
+      "html_url": "https://github.com/orgs/octobox/teams/cool-kids",
+      "members_url": "https://api.github.com/teams/2471073/members{/member}",
+      "repositories_url": "https://api.github.com/teams/2471073/repos",
+      "permission": "pull"
+    }
+  ],
   "milestone": null,
   "comments": 8,
   "created_at": "2016-12-19T21:30:41Z",

--- a/test/models/subject_test.rb
+++ b/test/models/subject_test.rb
@@ -193,10 +193,22 @@ class SubjectTest < ActiveSupport::TestCase
     assert_equal ':andrew:', Subject.last.assignees
   end
 
-  test 'sync sets an empty assignees value when there are non present' do
+  test 'sync sets an empty assignees value when there are none present' do
     remote_subject = load_subject('subject_56.json')
     Subject.sync(remote_subject)
     assert_equal '::', Subject.last.assignees
+  end
+
+  test 'sync sets the requested reviewers' do
+    remote_subject = load_subject('subject_57.json')
+    Subject.sync(remote_subject)
+    assert_equal ':andrew:', Subject.last.requested_reviewers
+  end
+
+  test 'sync sets an empty reviewers value when there are none present' do
+    remote_subject = load_subject('subject_56.json')
+    Subject.sync(remote_subject)
+    assert_equal '::', Subject.last.requested_reviewers
   end
 
   test 'sync sets the locked value' do


### PR DESCRIPTION
_**This is a proof of concept/work in progress. Don't merge it yet.**_

_Opening this for others to try if they like, as well as to open the door for UI help as I think it needs a little help there (I like the person vs multi person icons, but they look misaligned last I saw)._

---

The GitHub Notifications API doesn't distinguish between individual and team review requests for a reason field.  Regardless if its for a team you're on or you specifically, you get the same reason and there's no distinction.

...that sucks, a lot. A lot of teams work where someone belongs on a team that gets pinged based on the code owners functionality, but it only means *someone* on the team should review it.  Therefore, 'review requested' gets ignored in the huge number of team requests that look identical to when someone really wants the individual specifically to review it. Whoops.

It's been nearly three years since review requests were added to GitHub, and we've been holding out that they would actually distinguish it eventually. But I thought about it more and realized it's probably considered a breaking change and by now it's never going to happen.

So, I cave! This change introduces the first time we've ever intentionally set a notification reason that isn't just pulled directly from the GitHub API, but it's an extremely useful one that I absolutely need.

On subject syncs, query for all notifications that would affect someone in Octobox who was review requested and set team review requests based on the current state of the subject, which contains lists of reviews by individual and team.

See individual commit messages for additional details.