### PR TITLE
Add draft state to the API

### DIFF
--- a/app/views/notifications/index.json.jbuilder
+++ b/app/views/notifications/index.json.jbuilder
@@ -30,6 +30,7 @@ json.notifications do
       json.title notification.subject_title
       json.url notification.subject_url
       json.type notification.subject_type
+      json.draft notification.draft?
       json.state notification.state
     end
 


### PR DESCRIPTION
Follow-up to #1724 to surface the draft state in the API.  As it stands, you can filter in the api with notifications.json?draft=true, but not determine this information when unfiltered.