### PR TITLE
Fix rubocop warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ group :development, :test do
   gem 'active_record_query_trace'
   gem 'rubocop', require: false
   gem 'rubocop-performance'
+  gem 'rubocop-rails'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -276,6 +276,9 @@ GEM
       unicode-display_width (>= 1.4.0, < 1.7)
     rubocop-performance (1.4.1)
       rubocop (>= 0.71.0)
+    rubocop-rails (2.2.1)
+      rack (>= 1.1)
+      rubocop (>= 0.72.0)
     ruby-enum (0.7.2)
       i18n
     ruby-progressbar (1.10.1)
@@ -413,6 +416,7 @@ DEPENDENCIES
   rgb
   rubocop
   rubocop-performance
+  rubocop-rails
   sassc-rails
   sidekiq
   sidekiq-scheduler


### PR DESCRIPTION
added back in the rubocop-rails gem