### PR TITLE
Pinned searches count

### DIFF
--- a/app/assets/javascripts/octobox.js
+++ b/app/assets/javascripts/octobox.js
@@ -4,6 +4,15 @@ var Octobox = (function() {
     $(".js-select_all").click();
   };
 
+  var updatePinnedSearchCounts = function(pinned_search) {
+    var pinned_search = $(pinned_search);
+    $.get(pinned_search.data('url'), function(data) {
+      pinned_search.html(data.count);
+    }).fail(function() {
+      pinned_search.remove(); // Remove the total value if there's an error
+    });
+  }
+
   var moveCursorToClickedRow = function(event) {
     // Don't event.preventDefault(), since we want the
     // normal clicking behavior for links, starring, etc
@@ -384,6 +393,11 @@ var Octobox = (function() {
       recoverPreviousCursorPosition();
       setAutoSyncTimer();
     }
+
+    // Unread counts for pinned searches
+    $("span.pinned-search-count").each(function() {
+      updatePinnedSearchCounts(this);
+    });
 
     // Sync Handling
     if($(".js-is_syncing").length){ refreshOnSync() }

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -359,19 +359,16 @@ class NotificationsController < ApplicationController
   end
 
   def notifications_for_presentation
-    eager_load_relation = [{subject: :labels}, {repository: {app_installation: {subscription_purchase: :subscription_plan}}}]
-    scope = current_user.notifications.includes(eager_load_relation)
-
-    @search = Search.new(scope: scope, query: params[:q], params: params)
+    @search = Search.initialize_for_saved_search(query: params[:q], user: current_user, params: params)
 
     if params[:q].present?
       @search.results
     elsif params[:starred].present?
-      scope.starred
+      @search.scope.starred
     elsif params[:archive].present?
-      scope.archived
+      @search.scope.archived
     else
-      scope.inbox
+      @search.scope.inbox
     end
   end
 

--- a/app/controllers/pinned_searches_controller.rb
+++ b/app/controllers/pinned_searches_controller.rb
@@ -36,7 +36,13 @@ class PinnedSearchesController < ApplicationController
   end
 
   def show
-    redirect_to settings_path
+    respond_to do |format|
+      format.html { redirect_to settings_path }
+      format.json do
+        @pinned_search = current_user.pinned_searches.find(params[:id])
+        @search = Search.initialize_for_saved_search(query: @pinned_search.query, user: current_user)
+      end
+    end
   end
 
   private

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -2,6 +2,12 @@ class Search
   attr_accessor :parsed_query
   attr_accessor :scope
 
+  def self.initialize_for_saved_search(query:, user:, params: {})
+    eager_load_relation = [{subject: :labels}, {repository: {app_installation: {subscription_purchase: :subscription_plan}}}]
+    scope = user.notifications.includes(eager_load_relation)
+    Search.new(query: query, scope: scope, params: params)
+  end
+
   def initialize(query: '', scope:, params: {})
     @parsed_query = SearchParser.new(query)
     @scope = scope

--- a/app/views/notifications/_sidebar.html.erb
+++ b/app/views/notifications/_sidebar.html.erb
@@ -37,6 +37,8 @@
           <%= pinned_search.name %>
           <% if search_query_matches?(@search.to_query, pinned_search.query) %>
             <span class="badge badge-light"><%= @total %></span>
+          <% else %>
+            <span class="badge badge-light pinned-search-count" data-url="<%= pinned_search_path(pinned_search, format: 'json') %>"><%= octicon 'sync', height: 12, class: 'spinning' %></span>
           <% end %>
         <% end %>
       </li>

--- a/app/views/pinned_searches/show.json.jbuilder
+++ b/app/views/pinned_searches/show.json.jbuilder
@@ -1,0 +1,7 @@
+json.id @pinned_search.id
+json.user_id @pinned_search.user_id
+json.query @pinned_search.query
+json.name @pinned_search.name
+json.count @search.results.size
+json.created_at @pinned_search.created_at
+json.updated_at @pinned_search.updated_at

--- a/test/controllers/pinned_searches_controller_test.rb
+++ b/test/controllers/pinned_searches_controller_test.rb
@@ -97,4 +97,25 @@ class PinnedSearchesControllerTest < ActionDispatch::IntegrationTest
     assert_response :redirect
     assert_redirected_to '/settings'
   end
+
+  test 'will show json for json format' do
+    pinned_search = create(:pinned_search, user: @user)
+
+    sign_in_as(@user)
+    get "/pinned_searches/#{pinned_search.id}.json"
+    assert_response :success
+
+    expected_attributes = {
+      'id'      => pinned_search.id,
+      'user_id' => pinned_search.user_id,
+      'query'   => pinned_search.query,
+      'name'    => pinned_search.name,
+      'count'   => 0,
+    }
+    actual_response = JSON.parse(@response.body)
+    expected_attributes.each do |attribute, value|
+      assert_equal value, actual_response[attribute],
+        "Expected pinned_search.#{attribute} to be #{value}, but it was #{actual_response[value]}. Full response: #{actual_response}"
+    end
+  end
 end


### PR DESCRIPTION
Introduces a new pinned_search#show.json endpoint for internal use that includes the count of the search, this then leverages the endpoint by asynchronously populating the count badge for each saved search.

I chose to do this asynchronously to anticipate that one user with like 40 saved queries that would time out if we did this normally.

If the async request fails, we just remove the count badge. Until load we show a small syncing icon spinning to indicate a request is going on.

Slowed down gif for reference:
![octobox_counts](https://user-images.githubusercontent.com/3074765/63480346-8abba000-c45f-11e9-8568-9dda66b3e779.gif)
