### PR TITLE
Formats pinned searchs to ensure consistency

### DIFF
--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -287,6 +287,8 @@ module NotificationsHelper
   end
 
   def search_query_matches?(query, other_query)
+    query = Search.new(query: query, scope: {}).to_query
+    other_query = Search.new(query: other_query, scope: {}).to_query
     query.split(' ').sort == other_query.split(' ').sort
   end
 

--- a/app/models/pinned_search.rb
+++ b/app/models/pinned_search.rb
@@ -5,4 +5,12 @@ class PinnedSearch < ApplicationRecord
   validates :user_id, presence: true
   validates :query, presence: true
   validates :name, presence: true
+
+  before_commit :format_query, on: [:create, :update]
+
+  def format_query
+    return unless self.query.present?
+    # ensures consistent formatting by formatting with Search.new
+    self.query = Search.new(query: self.query, scope: {}).to_query
+  end
 end

--- a/test/helpers/notifications_helper_test.rb
+++ b/test/helpers/notifications_helper_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+
+class NotificationsHelperTest < ActionView::TestCase
+  test 'returns true when equal' do
+    query = "inbox:true state:open unread:true reason:team_mention"
+    assert search_query_matches?(query, query), "search query should have matched"
+  end
+
+  test 'returns false when not equal' do
+    query = "inbox:true state:open unread:true reason:team_mention"
+    other_query = "inbox:true state:open unread:unread reason:team_mention"
+    refute search_query_matches?(query, other_query), "search query should not have matched"
+  end
+
+  test 'returns true when equal despite formatting differences' do
+    query = "inbox:true state:open unread:true reason:team_mention"
+    other_query = "inbox: true state: open unread: true reason: team_mention"
+    assert search_query_matches?(query, other_query), "search query should have matched"
+  end
+
+  test 'returns true when equal despite formatting differences and order' do
+    query = "unread:true reason:team_mention inbox:true state:open"
+    other_query = "inbox: true state: open unread: true reason: team_mention"
+    assert search_query_matches?(query, other_query), "search query should have matched"
+  end
+end

--- a/test/models/pinned_search_test.rb
+++ b/test/models/pinned_search_test.rb
@@ -20,4 +20,10 @@ class PinnedSearchTest < ActiveSupport::TestCase
     @pinned_search.user_id = nil
     refute @pinned_search.valid?
   end
+
+  test 'formats query on save' do
+    @pinned_search.query = "inbox: true state: open unread: true reason: team_mention"
+    @pinned_search.save
+    assert_equal "inbox:true state:open unread:true reason:team_mention", @pinned_search.query
+  end
 end


### PR DESCRIPTION
# Problem

I was experiencing a bug on GitHub's instance of octobox where a pinned search worked no problem, but then it wouldnt highlight.

In looking at the code, I realized that an unformatted query worked fine but wasnt taken into account in the helper.

For example, my saved query is `inbox:true state:open unread: true reason:team_mention` (notice the space between unread and true), but when executed `Search.new.to_query` will format that properly to `inbox:true state:open unread:true reason:team_mention`.

# Solution

The solution here is twofold:

1. Format query on `PinnedSearch` save using `Search.new.to_query`
2. Make the helper accept any formatting by formatting both queries anyways