### PR TITLE
Use before_validation in pinned_search instead of before_commit

### DIFF
--- a/app/models/pinned_search.rb
+++ b/app/models/pinned_search.rb
@@ -6,7 +6,7 @@ class PinnedSearch < ApplicationRecord
   validates :query, presence: true
   validates :name, presence: true
 
-  before_commit :format_query, on: [:create, :update]
+  before_validation :format_query, on: [:create, :update]
 
   def format_query
     return unless self.query.present?

--- a/test/models/pinned_search_test.rb
+++ b/test/models/pinned_search_test.rb
@@ -25,5 +25,9 @@ class PinnedSearchTest < ActiveSupport::TestCase
     @pinned_search.query = "inbox: true state: open unread: true reason: team_mention"
     @pinned_search.save
     assert_equal "inbox:true state:open unread:true reason:team_mention", @pinned_search.query
+
+    # Make sure the before_validation actually works
+    search = PinnedSearch.find(@pinned_search.id)
+    assert_equal "inbox:true state:open unread:true reason:team_mention", search.query
   end
 end


### PR DESCRIPTION
It turns out that `before_commit` didn't do exactly as I wanted. It just seemed that way due to an unfortunate series of testing events.

I've added a test to make sure that this does what we actually think, and switched to using `before_validation`.

One thing to note that I didn't catch before is that [this line](https://github.com/octobox/octobox/blob/master/app/models/search.rb#L76) causes `unread:true` to become `unread:true inbox:true`

Doesn't change the query as that's what actually gets executed, but it may be jarring.