### PR TITLE
Rails 6 requires Redis 4+

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,7 @@ services:
       - POSTGRES_PASSWORD=development
 
   redis.service.octobox.internal:
-    image: redis:3.2-alpine
+    image: redis:4.0-alpine
     networks:
       - internal
 


### PR DESCRIPTION
Docker image needs updating to work with Rails 6.

Closes #2032 