### PR TITLE
Fix spinner animation when background jobs is not enabled.

### DIFF
--- a/app/assets/javascripts/octobox.js
+++ b/app/assets/javascripts/octobox.js
@@ -257,7 +257,11 @@ var Octobox = (function() {
     if($("a.js-sync.js-async").length) {
       $.get("/notifications/sync.json", refreshOnSync);
     } else {
+      if(!$(".js-sync .octicon").hasClass("spinning")){
+        $(".js-sync .octicon").addClass("spinning");
+      }
       Turbolinks.visit($("a.js-sync").attr("href"))
+      $(".sync .octicon").removeClass("spinning");
     }
   };
 


### PR DESCRIPTION
Fixes #913 

Sync spinner will now animate correctly even when `OCTOBOX_BACKGROUND_JOBS_ENABLED=false`