### PR TITLE
Fix typos across octobox repo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# This is a comma seperated list
+# This is a comma separated list
 # of GitHub IDs for folks who need
 # "admin" access to your instance
 ADMIN_GITHUB_IDS=""

--- a/app/assets/javascripts/octobox.js
+++ b/app/assets/javascripts/octobox.js
@@ -126,7 +126,7 @@ var Octobox = (function() {
     window.current_id = undefined;
 
     $(document).keydown(function(e) {
-      // disable shortcuts for the seach and comment
+      // disable shortcuts for the search and comment
       if ($("#help-box").length && !["search-box","comment_body"].includes(e.target.id)  && !e.ctrlKey && !e.metaKey) {
         var shortcutFunction = (!e.shiftKey ? shortcuts : shiftShortcuts)[e.which] ;
         if (shortcutFunction) { shortcutFunction(e) }

--- a/app/assets/javascripts/search_suggestion.js
+++ b/app/assets/javascripts/search_suggestion.js
@@ -48,7 +48,7 @@ SearchSuggestion = {
     var searchSuggestionFound = false;
     timestampIndex.openCursor(null, 'prev').onsuccess = function(event) {
       var cursor = event.target.result;
-      // if there is still another cursor to go, keep runing this code
+      // if there is still another cursor to go, keep running this code
       if (cursor) {
         searchSuggestionFound = true;
         // create a list item to put each data item inside when displaying it

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 class User < ApplicationRecord
-  attr_encrypted :access_token, key: Octobox.config.attr_encyrption_key
-  attr_encrypted :personal_access_token, key: Octobox.config.attr_encyrption_key
-  attr_encrypted :app_token, key: Octobox.config.attr_encyrption_key
+  attr_encrypted :access_token, key: Octobox.config.attr_encryption_key
+  attr_encrypted :personal_access_token, key: Octobox.config.attr_encryption_key
+  attr_encrypted :app_token, key: Octobox.config.attr_encryption_key
 
   has_secure_token :api_token
   has_many :notifications, dependent: :delete_all

--- a/app/views/pages/terms.html.erb
+++ b/app/views/pages/terms.html.erb
@@ -91,7 +91,7 @@
 
   <h4 id='support'>Support</h4>
   <p>
-    Octobox.io is a small community of people supporting the service. We do not offer formal support processes. If you require mroe formal support arrangements please <a href='mailto:support@octobox.io'>email us</a> otherwise you can try:
+    Octobox.io is a small community of people supporting the service. We do not offer formal support processes. If you require more formal support arrangements please <a href='mailto:support@octobox.io'>email us</a> otherwise you can try:
   </p>
   <ul>
     <li>Filing an issue in our <a href='https://github.com/octobox/octobox/issues/new'>bug tracker</a> following the template provided.</li>

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -424,9 +424,9 @@ Then start the rails app and visit <https://github.com/apps/my-octobox/installat
 
 n.b. you will be required to log into the oauth app (to allow access to the notifications scope), followed by the github app (to allow access to installed app data).
 
-To process events recieved from the webhook, ensure you have a sidekiq worker running as well as the rails server: `$ bundle exec sidekiq -C config/sidekiq.yml`
+To process events received from the webhook, ensure you have a sidekiq worker running as well as the rails server: `$ bundle exec sidekiq -C config/sidekiq.yml`
 
-If you wish to run the GitHub app locally and still recieve webhook events, use a service like <https://ngrok.com> to create a public url (`https://my-octobx.ngrok.com`) and use instead of http://localhost:3000 for all oauth and GitHub app config urls.
+If you wish to run the GitHub app locally and still receive webhook events, use a service like <https://ngrok.com> to create a public url (`https://my-octobx.ngrok.com`) and use instead of http://localhost:3000 for all oauth and GitHub app config urls.
 
 ## Open links in the same tab
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -54,4 +54,4 @@ See the comment thread right from within the Octobox interface, either in a thre
 
 ## Private discussions
 
-GitHub used to have this years and years ago. The additonal context and social engagement is often useful for projects of globally distributed, disparate contributors. This might be implemented alongside 'reply on GitHub' functions as part of the above.
+GitHub used to have this years and years ago. The additional context and social engagement is often useful for projects of globally distributed, disparate contributors. This might be implemented alongside 'reply on GitHub' functions as part of the above.

--- a/lib/octobox/configurator.rb
+++ b/lib/octobox/configurator.rb
@@ -1,6 +1,6 @@
 module Octobox
   class Configurator
-    def attr_encyrption_key
+    def attr_encryption_key
       @key ||= begin
         key = ENV['OCTOBOX_ATTRIBUTE_ENCRYPTION_KEY']
 

--- a/test/helpers/emoji_helper_test.rb
+++ b/test/helpers/emoji_helper_test.rb
@@ -6,7 +6,7 @@ class EmojiHelperTest < ActionView::TestCase
     assert_dom_equal %{<img alt="+1" src="/images/emoji/unicode/1f44d.png" style="vertical-align:middle" class="emoji"/>}, emojify(':+1:')
     assert_dom_equal %{bug <img alt="beetle" src="/images/emoji/unicode/1f41e.png" style="vertical-align:middle" class="emoji"/>}, emojify('bug :beetle:')
     assert_dom_equal %{Priority 0 <img alt="fire" src="/images/emoji/unicode/1f525.png" style="vertical-align:middle" class="emoji"/>}, emojify('Priority 0 :fire:')
-    assert_dom_equal %{<img alt="fire" src="/images/emoji/unicode/1f525.png" style="vertical-align:middle" class="emoji"/> Everthing is fine. <img alt="fire" src="/images/emoji/unicode/1f525.png" style="vertical-align:middle" class="emoji"/>}, emojify(':fire: Everthing is fine. :fire:')
+    assert_dom_equal %{<img alt="fire" src="/images/emoji/unicode/1f525.png" style="vertical-align:middle" class="emoji"/> Everything is fine. <img alt="fire" src="/images/emoji/unicode/1f525.png" style="vertical-align:middle" class="emoji"/>}, emojify(':fire: Everything is fine. :fire:')
     assert_dom_equal %{<img alt="octocat" src="/images/emoji/octocat.png" style="vertical-align:middle" class="emoji"/> &amp; <img alt="squirrel" src="/images/emoji/shipit.png" style="vertical-align:middle" class="emoji"/>}, emojify(':octocat: & :squirrel:')
   end
 end


### PR DESCRIPTION
:writing_hand: **Fix typos across octobox repo**

**Files that have typos**

```
octobox/.env.example:1:18: "seperated" is a misspelling of "separated"
octobox/app/assets/javascripts/octobox.js:129:35: "seach" is a misspelling of "search"
octobox/app/assets/javascripts/search_suggestion.js:51:54: "runing" is a misspelling of "running"
octobox/app/models/user.rb:3:57: "encyrption" is a misspelling of "encryption"
octobox/app/models/user.rb:4:66: "encyrption" is a misspelling of "encryption"
octobox/app/models/user.rb:5:54: "encyrption" is a misspelling of "encryption"
octobox/app/views/pages/terms.html.erb:94:127: "mroe" is a misspelling of "more"
octobox/docs/INSTALLATION.md:427:18: "recieved" is a misspelling of "received"
octobox/docs/INSTALLATION.md:429:52: "recieve" is a misspelling of "receive"
octobox/docs/ROADMAP.md:57:50: "additonal" is a misspelling of "additional"
octobox/lib/octobox/configurator.rb:3:13: "encyrption" is a misspelling of "encryption"
octobox/test/helpers/emoji_helper_test.rb:9:123: "Everthing" is a misspelling of "Everything"
octobox/test/helpers/emoji_helper_test.rb:9:260: "Everthing" is a misspelling of "Everything"
```

**PS:** I use [**client9/misspell**](https://github.com/client9/misspell) to scan typos :heart: 

Making the world a better place :innocent: