### PR TITLE
Only sync subjects for users who've been active within the past month

### DIFF
--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -256,8 +256,8 @@ class Subject < ApplicationRecord
   end
 
   def involved_user_ids
-    involved_users = users.with_access_token.not_recently_synced
-    involved_users += repository.users.with_access_token.not_recently_synced if repository.present?
+    involved_users = users.with_access_token.not_recently_synced.active
+    involved_users += repository.users.with_access_token.not_recently_synced.active if repository.present?
     involved_users.uniq.reject(&:syncing?).map(&:id)
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,8 +27,9 @@ class User < ApplicationRecord
   }
   validates_with PersonalAccessTokenValidator
 
-  scope :not_recently_synced, -> { where('last_synced_at < ?', 5.minutes.ago) }
+  scope :not_recently_synced, -> { where('users.last_synced_at < ?', 5.minutes.ago) }
   scope :with_access_token, -> { where.not(encrypted_access_token: nil) }
+  scope :active, -> { where('users.updated_at > ?', 1.month.ago) }
 
   after_create :create_default_pinned_searches
 


### PR DESCRIPTION
Reduce the amount of background jobs being queued for inactive users, save on server resources plus faster syncing for active users 👍 