### PR TITLE
Nicer notification view styling

### DIFF
--- a/app/assets/stylesheets/_badges.scss
+++ b/app/assets/stylesheets/_badges.scss
@@ -32,19 +32,10 @@
 }
 
 .badge-pr {
+  background-color: transparent;
   &.success {
-    background-color: transparent;
     .octicon {
       fill: $notification-open;
-    }
-  }
-  &.failure, &.pending, &.error {
-    background-color: $list-group-bg;
-    .active & {
-      background-color: $list-group-action-active-bg;
-    }
-    .notification:hover & {
-      background-color: transparent;
     }
   }
   &.pending .octicon {

--- a/app/assets/stylesheets/_notifications.scss
+++ b/app/assets/stylesheets/_notifications.scss
@@ -19,10 +19,6 @@ $notification-items: (
       }
     }
   }
-  .active {
-    font-weight: bold;
-    background-color: mix($list-group-action-active-bg, $body-bg, 50%);
-  }
 }
 
 .table > tbody > tr:first-child > td {
@@ -164,7 +160,6 @@ $notification-items: (
       width:100%
     }
     &.table > tbody > tr {
-      // Be less "eye-catching" when inactive.
       &:not(.active) {
         background-color: mix($list-group-action-active-bg, $body-bg, 50%);
         .notification-subject .link {
@@ -193,6 +188,7 @@ $notification-items: (
       }
       @media (hover: hover) {
         &:hover, &:focus{
+          box-shadow: 0 1px 5px rgba(27, 31, 35, .15);
           .notification-date{
             small, .badge{
               display: inline;

--- a/app/assets/stylesheets/_notifications.scss
+++ b/app/assets/stylesheets/_notifications.scss
@@ -266,4 +266,7 @@ $notification-items: (
 
 a span.notification-number {
   font-weight: normal;
+  // Looks more tabular, while allowing overflow.
+  display: inline-block;
+  min-width: 3rem;
 }

--- a/app/assets/stylesheets/_notifications.scss
+++ b/app/assets/stylesheets/_notifications.scss
@@ -163,8 +163,14 @@ $notification-items: (
     tbody{
       width:100%
     }
-    &.table > tbody > tr.active {
-      background: $list-group-action-active-bg;
+    &.table > tbody > tr {
+      // Be less "eye-catching" when inactive.
+      &:not(.active) {
+        background-color: mix($list-group-action-active-bg, $body-bg, 50%);
+        .notification-subject .link {
+          color: $text-muted;
+        }
+      }
       &:hover {
         background: $list-group-action-active-bg;
       }

--- a/app/assets/stylesheets/_notifications.scss
+++ b/app/assets/stylesheets/_notifications.scss
@@ -19,6 +19,20 @@ $notification-items: (
       }
     }
   }
+  tr {
+    &:not(.active) {
+      background-color: mix($list-group-action-active-bg, $body-bg, 50%);
+      .notification-subject .link {
+        color: $text-muted;
+      }
+    }
+    @media (hover: hover) {
+      &:hover, &:focus {
+        box-shadow: 0 1px 5px rgba(27, 31, 35, .15);
+        background: $list-group-action-active-bg;
+      }
+    }
+  }
 }
 
 .table > tbody > tr:first-child > td {
@@ -159,18 +173,6 @@ $notification-items: (
     tbody{
       width:100%
     }
-    &.table > tbody > tr {
-      &:not(.active) {
-        background-color: mix($list-group-action-active-bg, $body-bg, 50%);
-        .notification-subject .link {
-          color: $text-muted;
-        }
-      }
-      &:hover {
-        background: $list-group-action-active-bg;
-      }
-
-    }
     &.table > tbody > tr > td {
       border: none;
       padding: 0;
@@ -188,7 +190,6 @@ $notification-items: (
       }
       @media (hover: hover) {
         &:hover, &:focus{
-          box-shadow: 0 1px 5px rgba(27, 31, 35, .15);
           .notification-date{
             small, .badge{
               display: inline;


### PR DESCRIPTION
- Use muted colors for inactive notifications
- Drop the background from all badge-pr (not just success)
- Add a min-width to issue/notification numbers, to make things feel more tabular while allowing overflow.

I've been using these styles for months now and I should've contributed these upstream a while back!

---

(screenshots)

After:

![Screenshot from 2020-05-15 18-15-34](https://user-images.githubusercontent.com/3275593/82052749-c9724400-96d9-11ea-849c-7543db52c9fc.png)


Before:

![Screenshot from 2020-05-15 18-24-24](https://user-images.githubusercontent.com/3275593/82052822-e4dd4f00-96d9-11ea-9378-545ee73e5ea1.png)
