### PR TITLE
Store label github_id in bigint

### DIFF
--- a/db/migrate/20200619095214_label_github_id_bigint.rb
+++ b/db/migrate/20200619095214_label_github_id_bigint.rb
@@ -1,0 +1,5 @@
+class LabelGithubIdBigint < ActiveRecord::Migration[6.0]
+  def change
+    change_column :labels, :github_id, :bigint
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_10_092010) do
+ActiveRecord::Schema.define(version: 2020_06_19_095214) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -57,7 +57,7 @@ ActiveRecord::Schema.define(version: 2019_06_10_092010) do
     t.bigint "subject_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "github_id"
+    t.bigint "github_id"
     t.index ["name"], name: "index_labels_on_name"
     t.index ["subject_id"], name: "index_labels_on_subject_id"
   end

--- a/test/fixtures/files/label.json
+++ b/test/fixtures/files/label.json
@@ -1,7 +1,7 @@
 {
   "action": "edited",
   "label": {
-    "id": 1023072455,
+    "id": 2147484814,
     "node_id": "MDU6TGFiZWwxMDIzMDcyNDU1",
     "url": "https://api.github.com/repos/andrew/no-rabbits/labels/%F0%9F%A5%95%F0%9F%A5%95:carrot:",
     "name": ":carrot: :carrot:",

--- a/test/fixtures/github_webhooks/label.json
+++ b/test/fixtures/github_webhooks/label.json
@@ -1,7 +1,7 @@
 {
   "action": "edited",
   "label": {
-    "id": 1023072455,
+    "id": 2147484814,
     "node_id": "MDU6TGFiZWwxMDIzMDcyNDU1",
     "url": "https://api.github.com/repos/andrew/no-rabbits/labels/%F0%9F%A5%95%F0%9F%A5%95:carrot:",
     "name": ":carrot: :carrot:",

--- a/test/models/subject_test.rb
+++ b/test/models/subject_test.rb
@@ -16,7 +16,7 @@ class SubjectTest < ActiveSupport::TestCase
 
     label = subject.labels.first
     assert_equal true, label.present?
-    assert_equal 1023072455, label.github_id
+    assert_equal 2147484814, label.github_id
     assert_equal "080bcc", label.color
     assert_equal ":carrot: :carrot:", label.name
     assert_equal 1, subject.labels.count
@@ -24,7 +24,7 @@ class SubjectTest < ActiveSupport::TestCase
 
   test 'update_labels updates labels' do
     subject = create(:subject)
-    create(:label, subject: subject, github_id: "1023072455")
+    create(:label, subject: subject, github_id: "2147484814")
     labels = [load_fixture("label.json")["label"]]
     assert_equal 1, subject.labels.count
 
@@ -32,7 +32,7 @@ class SubjectTest < ActiveSupport::TestCase
 
     label = subject.labels.first.reload
     assert_equal true, label.present?
-    assert_equal 1023072455, label.github_id
+    assert_equal 2147484814, label.github_id
     assert_equal "080bcc", label.color
     assert_equal ":carrot: :carrot:", label.name
     assert_equal 1, subject.labels.count
@@ -343,7 +343,7 @@ class SubjectTest < ActiveSupport::TestCase
     create(:notification, subject_url:remote_subject['url'], user: user)
     create(:subject, url: remote_subject['url'])
 
-    Subject.sync_comments(remote_subject)    
+    Subject.sync_comments(remote_subject)
 
     assert_equal 1, Comment.where(review_state: "CHANGES_REQUESTED").count
 


### PR DESCRIPTION
The ids of github labels recently ticked over the 4 byte limit, causing syncing errors, this should fix that up.