### PR TITLE
docs(install): removes left-over bracket

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -40,7 +40,7 @@ You can host your own instance of Octobox using Heroku.
 [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/octobox/octobox)
 
 Heroku will ask you to provide an OAuth client ID and secret, which you can get by
-[registering a new OAuth application on GitHub](https://github.com/settings/applications/new)]. When creating the OAuth application:
+[registering a new OAuth application on GitHub](https://github.com/settings/applications/new). When creating the OAuth application:
 
 * Make sure you enable the `notifications` scope on it (you will also need the `read:org` scope if you enable restricted access).
 * You can provide Homepage and Authorization URLs by using the Heroku app name you choose. By default, a Heroku app is available at its Heroku domain, which has the form `[name of app].herokuapp.com`.


### PR DESCRIPTION
Nothing big, just a small (syntax) typo adding a redundant `]` after a link.