### PR TITLE
Specify node version in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ services:
   - postgresql
   - redis
 
+before_install:
+  - nvm install 12
+
 before_script:
   - psql -c 'create database "octobox_test";' -U postgres || true
 


### PR DESCRIPTION
Fix for latest version of autoprefix which dropped support for node 8 (default on travis)