### PR TITLE
Feature: filter by issue/pull-request number

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -337,7 +337,7 @@ class NotificationsController < ApplicationController
   end
 
   def current_notifications(scope = notifications_for_presentation)
-    [:repo, :reason, :type, :unread, :owner, :state, :author, :is_private, :status, :draft].each do |sub_scope|
+    [:repo, :reason, :type, :unread, :owner, :state, :number, :author, :is_private, :status, :draft, :subject].each do |sub_scope|
       next unless params[sub_scope].present?
       # This cast is required due to a bug in type casting
       # TODO: Rails 5.2 was supposed to fix this:

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -337,7 +337,7 @@ class NotificationsController < ApplicationController
   end
 
   def current_notifications(scope = notifications_for_presentation)
-    [:repo, :reason, :type, :unread, :owner, :state, :number, :author, :is_private, :status, :draft, :subject].each do |sub_scope|
+    [:repo, :reason, :type, :unread, :owner, :state, :number, :author, :is_private, :status, :draft].each do |sub_scope|
       next unless params[sub_scope].present?
       # This cast is required due to a bug in type casting
       # TODO: Rails 5.2 was supposed to fix this:

--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -56,6 +56,7 @@ module NotificationsHelper
       reason:          params[:reason],
       unread:          params[:unread],
       repo:            params[:repo],
+      number:          params[:number],
       type:            params[:type],
       archive:         params[:archive],
       starred:         params[:starred],

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -31,6 +31,8 @@ class Search
     res = res.exclude_state(exclude_state) if exclude_state.present?
     res = res.author(author) if author.present?
     res = res.exclude_author(exclude_author) if exclude_author.present?
+    res = res.number(number) if number.present?
+    res = res.exclude_number(exclude_number) if exclude_number.present?
     res = res.assigned(assignee) if assignee.present?
     res = res.exclude_assigned(exclude_assignee) if exclude_assignee.present?
     res = res.status(status) if status.present?
@@ -80,7 +82,7 @@ class Search
       @parsed_query[filter] = Array(params[filter]).map(&:underscore)
     end
 
-    [:repo, :owner, :author].each do |filter|
+    [:repo, :owner, :author, :number].each do |filter|
       next if params[filter].blank?
       @parsed_query[filter] = Array(params[filter])
     end
@@ -163,6 +165,14 @@ class Search
 
   def exclude_author
     parsed_query[:'-author']
+  end
+
+  def number
+    parsed_query[:number]
+  end
+
+  def exclude_number
+    parsed_query[:'-number']
   end
 
   def unread

--- a/app/views/notifications/_filter-list.html.erb
+++ b/app/views/notifications/_filter-list.html.erb
@@ -51,6 +51,10 @@
         Author: <%= params[:author] %>
       <% end %>
 
+      <%= filter_option :number do %>
+        Number: <%= params[:number] %>
+      <% end %>
+
       <%= filter_option :assigned do %>
         Assigned: <%= params[:assigned] %>
       <% end %>

--- a/app/views/shared/_search_prefixes.html.erb
+++ b/app/views/shared/_search_prefixes.html.erb
@@ -27,6 +27,12 @@
     </tr>
     <tr>
       <td>
+        <code>number:123</code>
+      </td>
+      <td>Filter by notifications from issues and/or pull requests with the number '123'.</td>
+    </tr>
+    <tr>
+      <td>
         <code>reason:mention</code>
       </td>
       <td>

--- a/lib/octobox/notifications/exclusive_scope.rb
+++ b/lib/octobox/notifications/exclusive_scope.rb
@@ -32,6 +32,12 @@ module Octobox
           )
         }
 
+        scope :exclude_number, ->(subject_numbers)  {
+          joins(:subject).where.not(
+            subject_numbers.map { |subject_number| arel_table[:subject_url].matches("%/#{subject_number}") }.reduce(:or)
+          )
+        }
+
         scope :exclude_state, ->(states)  {
           states = [states] if states.is_a?(String)
           joins(:subject).where.not(

--- a/lib/octobox/notifications/inclusive_scope.rb
+++ b/lib/octobox/notifications/inclusive_scope.rb
@@ -51,6 +51,12 @@ module Octobox
           )
         }
 
+        scope :number, ->(subject_numbers)  {
+          joins(:subject).where(
+            subject_numbers.map { |subject_number| arel_table[:subject_url].matches("%/#{subject_number}") }.reduce(:or)
+          )
+        }
+
         scope :state, ->(states)  {
           states = [states] if states.is_a?(String)
           joins(:subject).where(

--- a/test/controllers/notifications_controller_test.rb
+++ b/test/controllers/notifications_controller_test.rb
@@ -635,6 +635,27 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
     assert_equal assigns(:notifications).length, 1
   end
 
+  test 'search results can filter by number' do
+    sign_in_as(@user)
+    notification1 = create(:notification, user: @user, subject_type: 'Issue')
+    notification2 = create(:notification, user: @user, subject_type: 'PullRequest')
+    subject1 = create(:subject, notifications: [notification1])
+    subject2 = create(:subject, notifications: [notification2])
+    get '/?q=number%3A' + subject1.url.scan(/\d+$/).first
+    assert_equal assigns(:notifications).length, 1
+    assert_equal assigns(:notifications).first.subject_url, subject1.url
+  end
+
+  test 'search results can filter by multiple numbers' do
+    sign_in_as(@user)
+    notification1 = create(:notification, user: @user, subject_type: 'Issue')
+    notification2 = create(:notification, user: @user, subject_type: 'PullRequest')
+    subject1 = create(:subject, notifications: [notification1])
+    subject2 = create(:subject, notifications: [notification2])
+    get '/?q=number%3A' + subject1.url.scan(/\d+$/).first + '%2C' + subject2.url.scan(/\d+$/).first
+    assert_equal assigns(:notifications).length, 2
+  end
+
   test 'search results can filter by draft' do
     sign_in_as(@user)
     notification1 = create(:notification, user: @user, subject_type: 'PullRequest')

--- a/test/models/search_test.rb
+++ b/test/models/search_test.rb
@@ -50,4 +50,9 @@ class SearchTest < ActiveSupport::TestCase
     search = Search.new(query: 'inbox:true', scope: Notification.all, params: {draft: 'true'})
     assert_equal search.to_query, 'inbox:true draft:true'
   end
+
+  test 'converts number params to number prefix without changing it' do
+    search = Search.new(query: 'inbox:true', scope: Notification.all, params: {number: '123'})
+    assert_equal search.to_query, 'inbox:true number:123'
+  end
 end


### PR DESCRIPTION
This PR adds the possibility to filter issues and pull-requests according to their **reference number**.

Closes #2144

<p align="center">
<img width="700" alt="filters" src="https://user-images.githubusercontent.com/32459935/108487697-d42cbb80-729f-11eb-867d-c1f495aed956.png" />
</p>

If the type of the notification is not specified we will search in both issues and pull-requests.

Here is the new filtering demo:

<p align="center">
<img src="https://user-images.githubusercontent.com/32459935/108488048-37b6e900-72a0-11eb-9b12-92a641f87ee5.gif" width="700" />
</p>

**NOTE:** I'm still not sure about the wording `number`, I'd like to get your opinion on it.   
I wanted something that was short enough to write and at the same time relevant in the context of an issue or a pull-request.