### PR TITLE
hacky way to disable confirming mute

### DIFF
--- a/app/assets/javascripts/octobox.js
+++ b/app/assets/javascripts/octobox.js
@@ -159,7 +159,7 @@ var Octobox = (function() {
   };
 
   var mute = function(ids){
-    var result = confirm("Are you sure you want to mute?");
+    var result = localStorage.noConfirmMute || confirm("Are you sure you want to mute?");
     if (result) {
       $.post( "/notifications/mute_selected" + location.search, { "id[]": ids})
       .done(function() {


### PR DESCRIPTION
I work on a very noisy repository (electron/electron), and muting threads is something I do a lot. The extra `confirm()` is quite irritating 😅 

I'd love to have a setting in the preferences for this, but this is an easy way and would work well enough for me!