### PR TITLE
bold unread message subjects

### DIFF
--- a/app/assets/stylesheets/_notifications.scss
+++ b/app/assets/stylesheets/_notifications.scss
@@ -10,7 +10,7 @@ $notification-items: (
 );
 
 .table-notifications {
-  td{
+  td {
     padding: 0.6rem;
     &.notification-archived, .notification-repo{
       padding: 0;
@@ -20,6 +20,11 @@ $notification-items: (
     }
   }
   tr {
+    &.active {
+      .thread-link {
+        font-weight: bold;
+      }
+    }
     &:not(.active) {
       background-color: mix($list-group-action-active-bg, $body-bg, 50%);
       .notification-subject .link {


### PR DESCRIPTION
I've found the unread notification state a little hard to differentiate from ones I've already read. This helps a little by bolding the unread title, similar to how many email clients handle it.

![image](https://user-images.githubusercontent.com/154479/118632003-05812e80-b79e-11eb-8425-e223566bc615.png)
