### PR TITLE
Rewrite search parser to avoid potential ReDoS attack

### DIFF
--- a/lib/search_parser.rb
+++ b/lib/search_parser.rb
@@ -16,14 +16,10 @@ class SearchParser
         value = group[2].strip
         @operators[key] ||= []
 
+        # if last group, split last item in group and add extras to free text
         if i == groups.length - 1
-          # if last group, split last item in group and add extras to free text
-          if value[0] == "'"
-            parts = value.split("'")
-            value = parts[1]
-            @freetext = parts[2].to_s.strip
-          elsif value[0] == '"'
-            parts = value.split('"')
+          if ["'", '"'].include?(value[0])
+            parts = value.split(value[0])
             value = parts[1]
             @freetext = parts[2].to_s.strip
           else


### PR DESCRIPTION
The regex from https://github.com/marcelocf/searrrch that was used to parse the `repo:foo/bar` search text options had the potential for someone to perform a [ReDoS](https://owasp.org/www-community/attacks/Regular_expression_Denial_of_Service_-_ReDoS) on an Octobox instance, so I've rewritten the search parser with a simpler method that should close that possible attack vector.