### PR TITLE
Pinned searches index json api endpoint

### DIFF
--- a/app/controllers/pinned_searches_controller.rb
+++ b/app/controllers/pinned_searches_controller.rb
@@ -32,7 +32,12 @@ class PinnedSearchesController < ApplicationController
   end
 
   def index
-    redirect_to settings_path
+    respond_to do |format|
+      format.html { redirect_to settings_path }
+      format.json do
+        @pinned_searches = current_user.pinned_searches
+      end
+    end
   end
 
   def show

--- a/app/controllers/pinned_searches_controller.rb
+++ b/app/controllers/pinned_searches_controller.rb
@@ -40,7 +40,6 @@ class PinnedSearchesController < ApplicationController
       format.html { redirect_to settings_path }
       format.json do
         @pinned_search = current_user.pinned_searches.find(params[:id])
-        @search = Search.initialize_for_saved_search(query: @pinned_search.query, user: current_user)
       end
     end
   end

--- a/app/models/pinned_search.rb
+++ b/app/models/pinned_search.rb
@@ -13,4 +13,8 @@ class PinnedSearch < ApplicationRecord
     # ensures consistent formatting by formatting with Search.new
     self.query = Search.new(query: self.query, scope: {}).to_query
   end
+
+  def results(user)
+    Search.initialize_for_saved_search(query: query, user: user).results
+  end
 end

--- a/app/views/pinned_searches/_pinned_search.json.jbuilder
+++ b/app/views/pinned_searches/_pinned_search.json.jbuilder
@@ -1,0 +1,7 @@
+json.id pinned_search.id
+json.user_id pinned_search.user_id
+json.query pinned_search.query
+json.name pinned_search.name
+json.count pinned_search.results(current_user).size
+json.created_at pinned_search.created_at
+json.updated_at pinned_search.updated_at

--- a/app/views/pinned_searches/index.json.jbuilder
+++ b/app/views/pinned_searches/index.json.jbuilder
@@ -1,0 +1,5 @@
+json.pinned_searches do
+  json.array! @pinned_searches do |pinned_search|
+    json.partial! pinned_search
+  end
+end

--- a/app/views/pinned_searches/show.json.jbuilder
+++ b/app/views/pinned_searches/show.json.jbuilder
@@ -1,7 +1,1 @@
-json.id @pinned_search.id
-json.user_id @pinned_search.user_id
-json.query @pinned_search.query
-json.name @pinned_search.name
-json.count @search.results.size
-json.created_at @pinned_search.created_at
-json.updated_at @pinned_search.updated_at
+json.partial! @pinned_search

--- a/test/controllers/pinned_searches_controller_test.rb
+++ b/test/controllers/pinned_searches_controller_test.rb
@@ -104,6 +104,7 @@ class PinnedSearchesControllerTest < ActionDispatch::IntegrationTest
     sign_in_as(@user)
     get "/pinned_searches/#{pinned_search.id}.json"
     assert_response :success
+    assert_template 'pinned_searches/show', file: 'pinned_searches/show.json.jbuilder'
 
     expected_attributes = {
       'id'      => pinned_search.id,

--- a/test/controllers/pinned_searches_controller_test.rb
+++ b/test/controllers/pinned_searches_controller_test.rb
@@ -119,4 +119,16 @@ class PinnedSearchesControllerTest < ActionDispatch::IntegrationTest
         "Expected pinned_search.#{attribute} to be #{value}, but it was #{actual_response[value]}. Full response: #{actual_response}"
     end
   end
+
+  test 'will list pinned_searches as json for json format' do
+    pinned_search = create(:pinned_search, user: @user)
+
+    sign_in_as(@user)
+    get "/pinned_searches.json"
+    assert_response :success
+    assert_template 'pinned_searches/index', file: 'pinned_searches/index.json.jbuilder'
+
+    actual_response = JSON.parse(@response.body)
+    assert_equal actual_response.length, 1
+  end
 end

--- a/test/factories/notification.rb
+++ b/test/factories/notification.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     sequence(:github_id, 1000000) { |n| n }
     repository_id { 930405 }
     repository_full_name { "octobox/octobox" }
-    repository_owner_name { "andrew" }
+    repository_owner_name { "octobox" }
     subject_title { "Test" }
     sequence(:subject_url) { |n| "https://api.github.com/repos/#{repository_full_name}/issues/#{n}" }
     subject_type { "Issue" }

--- a/test/fixtures/files/morty_notifications.json
+++ b/test/fixtures/files/morty_notifications.json
@@ -4,7 +4,7 @@
     "repository": {
       "id": 930405,
       "owner": {
-        "login": "andrew",
+        "login": "octobox",
         "id": 1,
         "avatar_url": "https://avatars3.githubusercontent.com/u/1060",
         "gravatar_id": "",
@@ -47,7 +47,7 @@
     "repository": {
       "id": 930405,
       "owner": {
-        "login": "andrew",
+        "login": "octobox",
         "id": 1,
         "avatar_url": "https://avatars3.githubusercontent.com/u/1060",
         "gravatar_id": "",
@@ -90,7 +90,7 @@
     "repository": {
       "id": 930405,
       "owner": {
-        "login": "andrew",
+        "login": "octobox",
         "id": 1,
         "avatar_url": "https://avatars3.githubusercontent.com/u/1060",
         "gravatar_id": "",

--- a/test/models/notification_test.rb
+++ b/test/models/notification_test.rb
@@ -108,7 +108,7 @@ class NotificationTest < ActiveSupport::TestCase
       url: 'https://api.github.com/notifications/threads/421',
       archived: false,
       starred: false,
-      repository_owner_name: 'andrew',
+      repository_owner_name: 'octobox',
       updated_at: Time.zone.parse('2016-12-19T22:00:00Z')
     }.stringify_keys
     api_response = notifications_from_fixture('morty_notifications.json').second

--- a/test/models/pinned_search_test.rb
+++ b/test/models/pinned_search_test.rb
@@ -30,4 +30,10 @@ class PinnedSearchTest < ActiveSupport::TestCase
     search = PinnedSearch.find(@pinned_search.id)
     assert_equal "inbox:true state:open unread:true reason:team_mention", search.query
   end
+
+  test 'results returns an array of notifications' do
+    @user = create(:user)
+    @notification = create(:notification, user: @user)
+    assert_equal [@notification], @pinned_search.results(@user)
+  end
 end


### PR DESCRIPTION
Another tweak to help with development of the upcoming [Octobox Browser Extension](https://github.com/octobox/extension), this one adds `/pinned_searches.json` which lists all the saved searches for a user.