### PR TITLE
Include muted_at in notification json response

### DIFF
--- a/app/views/notifications/_notification.json.jbuilder
+++ b/app/views/notifications/_notification.json.jbuilder
@@ -11,6 +11,7 @@ json.(
   :last_read_at,
   :created_at,
   :updated_at,
+  :muted_at
 )
 
 json.subject do


### PR DESCRIPTION
Allows toggling of Mute/Subscribe button in the [browser extension](https://github.com/octobox/extension)