### PR TITLE
Support for subjects without a notification record from GitHub

### DIFF
--- a/db/migrate/20211104170313_add_title_to_subjects.rb
+++ b/db/migrate/20211104170313_add_title_to_subjects.rb
@@ -1,0 +1,5 @@
+class AddTitleToSubjects < ActiveRecord::Migration[6.1]
+  def change
+    add_column :subjects, :title, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_08_073701) do
+ActiveRecord::Schema.define(version: 2021_11_04_170313) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -127,6 +127,7 @@ ActiveRecord::Schema.define(version: 2021_07_08_073701) do
     t.text "body"
     t.integer "comment_count"
     t.boolean "draft", default: false
+    t.string "title"
     t.index ["repository_full_name"], name: "index_subjects_on_repository_full_name"
     t.index ["url"], name: "index_subjects_on_url"
   end

--- a/test/factories/subject.rb
+++ b/test/factories/subject.rb
@@ -7,5 +7,6 @@ FactoryBot.define do
     author { 'andrew' }
     repository_full_name { 'octobox/octobox' }
     comment_count { 0 }
+    sequence(:title) { |n| "issue number #{n}" }
   end
 end

--- a/test/models/notification_test.rb
+++ b/test/models/notification_test.rb
@@ -432,4 +432,9 @@ class NotificationTest < ActiveSupport::TestCase
     notification.destroy
     refute Subject.where(id: subject.id).empty?
   end
+
+  test 'notification can be missing their github_id' do
+    notification = create(:notification, github_id: nil)
+    assert notification.valid?
+  end
 end


### PR DESCRIPTION
Working on making octobox able to create notifications for subjects (issues, prs etc) that don't have a remote notification record on GitHub (i.e. where `github_id` is null)

Some example use cases:

- user stars a subject without an existing notification
  - download subject and create a starred notification with null github_id 

- user subscribes to a subject without an existing notification (can only be done in extension atm)
  - download subject and create a starred notification with null github_id 

- user imports subjects created by themselves
  - download subject and create a notification with null github_id 

Things to carefully check for:

- [ ] ensure notification functions that use github_id can handle nulls
- [ ] ensure notifications without github_id get properly merged/updated/replaced when a real notification for a subject is generated by GitHub
- [ ] Users may need more oauth scopes to enable full access to all issues and pull requests

Related issues:
- https://github.com/octobox/octobox/issues/2821
- https://github.com/octobox/octobox/issues/2456
- https://github.com/octobox/octobox/issues/2310
- https://github.com/octobox/octobox/issues/2302

Current todo list:

- [x] subject's need to record or infer their `subject_type`
- [x] subject's should record their `title`
- [ ] Mute button should be disabled if `github_id` is `nil`
- [ ] `Notification.mute` should ignore internal notifications
- [ ] `Notification.mark_read` should ignore internal notifications
- [ ] When syncing a user, download and create internal notifications for subjects they created that don't existing notifications (skip inbox)