### PR TITLE
Fix double quote escaping from login prompt popup

### DIFF
--- a/app/views/notifications/_login_prompt.html.erb
+++ b/app/views/notifications/_login_prompt.html.erb
@@ -2,4 +2,4 @@
   The GitHub App is installed on this repository, authorize it to see state, labels, authors, assignees and CI status on this notification.
 </p>
 
-<%= link_to 'Login to the GitHub App', '/auth/githubapp', class: 'btn btn-primary btn-sm', method: :post %>
+<a class='btn btn-primary btn-sm' rel='nofollow' data-method='post' href='/auth/githubapp'>Login to the GitHub App</a>


### PR DESCRIPTION
Fixes #2831