### PR TITLE
Login page for browser extension

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,6 +8,10 @@ class UsersController < ApplicationController
     render 'api/users/profile'
   end
 
+  def extension
+    @return_to = params[:return_to].presence || Octobox.config.github_domain
+  end
+
   def edit
     repo_counts = current_user.notifications.group(:repository_full_name).count
     @total = repo_counts.sum(&:last)

--- a/app/views/users/extension.html.erb
+++ b/app/views/users/extension.html.erb
@@ -2,33 +2,67 @@
   <div class="w-100 d-flex justify-content-between">
     <h1 class="pt-3">Octobox Browser Extension</h1>
   </div>
+  <p>Integrate Octobox directly into your GitHub workflow with this browser extension.</p>
+
+  <p>Directly manage and triage through your Octobox inbox from your GitHub issues and pull requests. You can star, archive and mute notifications without needing to leave the page and quickly jump to the next and previous notifications in your inbox with a single click.</p>
   <hr>
 
-  <div class="card mb-3" id='login-extension'>
-    <h5 class="card-header">
-      Enable extension access
-    </h5>
-    <div class="card-body">
-      <p>Login into the browser extension to give it access to your Octobox account</p>
+  <% if true || Octobox.io? %>
+    <div class="card mb-3 d-none" id='login-extension'>
+      <h5 class="card-header">
+        Enable extension access
+      </h5>
+      <div class="card-body">
+        <p>Login into the browser extension to give it access to your Octobox account</p>
 
-      <%= link_to '#', class: 'btn btn-primary', onclick: "document.dispatchEvent(new CustomEvent('octobox:enable', {detail: {api_token:'#{current_user.api_token}', return_to: '#{@return_to}'}}))" do %>
-        <span class='mr-1'>Enable extension</span>
-        <%= octicon 'plug', height: 22 %>
-      <% end %>
+        <%= link_to '#', class: 'btn btn-primary', onclick: "document.dispatchEvent(new CustomEvent('octobox:enable', {detail: {api_token:'#{current_user.api_token}', return_to: '#{@return_to}'}}))" do %>
+          <span class='mr-1'>Enable extension</span>
+          <%= octicon 'plug', height: 22 %>
+        <% end %>
+      </div>
     </div>
-  </div>
-  <!-- TODO toggle enable/install depending on if you have the extension installed -->
-  <!-- TODO handle case where you have the extension installed and enabled -->
-  <!-- TODO this only works on octobox.io at the moment -->
-  <div class="card mb-3" id='install-extension'>
-    <h5 class="card-header">
-      Install Extension
-    </h5>
-    <div class="card-body">
-      <p>Install the browser extension</p>
-      <p>chrome store link</p>
-      <p>firefox store link</p>
-      <p>github link</p>
+
+    <div class="card mb-3 d-none" id='installed-extension'>
+      <h5 class="card-header">
+        Extension installed and authorized
+      </h5>
+      <div class="card-body">
+        <p>You're all installed and ready to go!</p>
+
+        <%= link_to @return_to, class:'btn btn-primary' do %>
+        <span class='mr-1'>Go to GitHub</span>
+        <%= octicon 'mark-github', height: 22 %>
+        <% end %>
+      </div>
     </div>
-  </div>
+
+    <div class="card mb-3" id='install-extension'>
+      <h5 class="card-header">
+        Install Extension
+      </h5>
+      <div class="card-body">
+        <p>Install the Octobox Browser Extension from:</p>
+        <ul>
+          <li>
+            <%= link_to 'The Google Chrome Extension Store', 'https://chrome.google.com/webstore/detail/octobox/dpbajpnhgagfneijghelgldegjblinkc' %>
+          </li>
+          <li>
+            <%= link_to 'The Firefox Extension Store', 'https://addons.mozilla.org/addon/octobox/' %>
+          </li>
+        </ul>
+        or manually build it from source on GitHub: <%= link_to 'github.com/octobox/extension','https://github.com/octobox/extension' %>
+      </div>
+    </div>
+  <% else %>
+    <div class="card mb-3">
+      <h5 class="card-header">
+        It's not quite ready yet
+      </h5>
+      <div class="card-body">
+        <p>The browser extension currently only works on Octobox.io and GitHub.com</p>
+
+        <p>Subscribe and comment this issue on GitHub for support of other octobox instances: <%= link_to 'github.com/octobox/extension/issues/2', 'https://github.com/octobox/extension/issues/2' %> </p>
+      </div>
+    </div>
+  <% end %>
 </div>

--- a/app/views/users/extension.html.erb
+++ b/app/views/users/extension.html.erb
@@ -1,0 +1,34 @@
+<div class="container user-settings">
+  <div class="w-100 d-flex justify-content-between">
+    <h1 class="pt-3">Octobox Browser Extension</h1>
+  </div>
+  <hr>
+
+  <div class="card mb-3" id='login-extension'>
+    <h5 class="card-header">
+      Enable extension access
+    </h5>
+    <div class="card-body">
+      <p>Login into the browser extension to give it access to your Octobox account</p>
+
+      <%= link_to '#', class: 'btn btn-primary', onclick: "document.dispatchEvent(new CustomEvent('octobox:enable', {detail: {api_token:'#{current_user.api_token}', return_to: '#{@return_to}'}}))" do %>
+        <span class='mr-1'>Enable extension</span>
+        <%= octicon 'plug', height: 22 %>
+      <% end %>
+    </div>
+  </div>
+  <!-- TODO toggle enable/install depending on if you have the extension installed -->
+  <!-- TODO handle case where you have the extension installed and enabled -->
+  <!-- TODO this only works on octobox.io at the moment -->
+  <div class="card mb-3" id='install-extension'>
+    <h5 class="card-header">
+      Install Extension
+    </h5>
+    <div class="card-body">
+      <p>Install the browser extension</p>
+      <p>chrome store link</p>
+      <p>firefox store link</p>
+      <p>github link</p>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -101,6 +101,7 @@ Rails.application.routes.draw do
   resources :pinned_searches
 
   get '/settings', to: 'users#edit'
+  get '/extension', to: 'users#extension'
   get '/export', to: 'users#export'
   post '/import', to: 'users#import'
   resources :users, only: [:update, :destroy] do


### PR DESCRIPTION
To enable chrome users to log into the browser extension we need a new login flow that passes the users api token to the extension to make api requests. 

This new page offers that up if the extension is present or prompts to install it otherwise from one of the extension stores.

Related to https://github.com/octobox/extension/pull/13

todos:
- [x] toggle enable/install depending on if you have the extension installed
- [x] handle case where you have the extension installed and enabled
- [x] this only works on octobox.io at the moment, add message for other instances