### PR TITLE
Update pinned search counts after all notification updates

### DIFF
--- a/app/assets/javascripts/channels/notifications.js
+++ b/app/assets/javascripts/channels/notifications.js
@@ -13,6 +13,8 @@ $(document).on("turbolinks:load", function () {
         if($('#notification-thread').attr('data-id') == data.id){
           $('#thread-subject').html(data.subject);
         }
+
+        Octobox.updateAllPinnedSearchCounts();
       }
     });
   }

--- a/app/assets/javascripts/octobox.js
+++ b/app/assets/javascripts/octobox.js
@@ -21,6 +21,12 @@ var Octobox = (function() {
     });
   }
 
+  var updateAllPinnedSearchCounts = function(){
+    $("span.pinned-search-count").each(function() {
+      updatePinnedSearchCounts(this);
+    });
+  }
+
   var moveCursorToClickedRow = function(event) {
     // Don't event.preventDefault(), since we want the
     // normal clicking behavior for links, starring, etc
@@ -407,9 +413,7 @@ var Octobox = (function() {
     }
 
     // Unread counts for pinned searches
-    $("span.pinned-search-count").each(function() {
-      updatePinnedSearchCounts(this);
-    });
+    updateAllPinnedSearchCounts();
 
     // Sync Handling
     if($(".js-is_syncing").length){ refreshOnSync() }
@@ -693,6 +697,7 @@ var Octobox = (function() {
     deleteSelected: deleteSelected,
     deleteThread: deleteThread,
     viewThread: viewThread,
-    expandComments: expandComments
+    expandComments: expandComments,
+    updateAllPinnedSearchCounts: updateAllPinnedSearchCounts
   }
 })();


### PR DESCRIPTION
A small tweak to update the pinned search counts whenever a notification update is recieved via websocket, this should keep the pinned search counts up to date even if you're not refreshing the page very often.