### PR TITLE
fix: issue #2867

### DIFF
--- a/app/assets/javascripts/octobox.js
+++ b/app/assets/javascripts/octobox.js
@@ -336,12 +336,21 @@ var Octobox = (function() {
 
   var star = function(id){
     $('#notification-thread').data('id') == id ? $('#thread').find('.toggle-star').toggleClass("star-active star-inactive") : null;
-    $("#notification-"+id).find(".toggle-star").toggleClass("star-active star-inactive");
+
+    var fill_star_path = '<path fill-rule="evenodd" d="M8 .25a.75.75 0 01.673.418l1.882 3.815 4.21.612a.75.75 0 01.416 1.279l-3.046 2.97.719 4.192a.75.75 0 01-1.088.791L8 12.347l-3.766 1.98a.75.75 0 01-1.088-.79l.72-4.194L.818 6.374a.75.75 0 01.416-1.28l4.21-.611L7.327.668A.75.75 0 018 .25z"></path>'
+    var empty_star_path = '<path fill-rule="evenodd" d="M8 .25a.75.75 0 01.673.418l1.882 3.815 4.21.612a.75.75 0 01.416 1.279l-3.046 2.97.719 4.192a.75.75 0 01-1.088.791L8 12.347l-3.766 1.98a.75.75 0 01-1.088-.79l.72-4.194L.818 6.374a.75.75 0 01.416-1.28l4.21-.611L7.327.668A.75.75 0 018 .25zm0 2.445L6.615 5.5a.75.75 0 01-.564.41l-3.097.45 2.24 2.184a.75.75 0 01.216.664l-.528 3.084 2.769-1.456a.75.75 0 01.698 0l2.77 1.456-.53-3.084a.75.75 0 01.216-.664l2.24-2.183-3.096-.45a.75.75 0 01-.564-.41L8 2.694v.001z"></path>'
+    var svg = $("#notification-"+id).find(".toggle-star")
+    svg.toggleClass("star-active star-inactive");
+    svg.toggleClass("octicon-star octicon-star-fill")
+    svg.html(svg.hasClass('star-active') ? fill_star_path : empty_star_path)
+
     $.post("/notifications/"+id+"/star")
       .fail(function(){
         $('#notification-thread').data('id') == id ? $('#thread').find('.toggle-star').toggleClass("star-active star-inactive") : null;
-        $("#notification-"+id).find(".toggle-star").toggleClass("star-active star-inactive");
-        notify("Could not toggle star(s)", "danger");
+        svg.toggleClass("star-active star-inactive");
+        svg.toggleClass("octicon-star octicon-star-fill")
+        svg.html(svg.hasClass('star-active') ? fill_star_path : empty_star_path)
+        notify("Could not toggleeeee star(s)", "danger");
       });
   };
 


### PR DESCRIPTION
Fix #2867 

Toggling stars results in incorrect star icon until page refreshes
fixed. It was missing the correct inner <path> tag and toggling another
class. Problem is due because the `<%= octicon ... %>` helper is being
used in the .erb view, and this helper is not available in jQuery.

![image](https://user-images.githubusercontent.com/3003032/186817512-5e74a3e3-24da-4dad-9869-af35fd09e53f.png)

Here you an see on file `app/views/notifications/_notification.html.erb` the `octicon` helper receiving as input `star-active` or `star-inactive` depending whether the notification is starred or not. The same class used as input in the javascript `app/assets/javascripts/octobox.js` the difference is that the helper `octicon` is not only toggling the class `star-active <> star-inactive`, it is doing a lot more!

I would like to retrieve the correct `path`using the octicon helper inside `app/assets/javascripts/octobox.js`, but I'm affraid the helper is out of scope from the javascript. One way to solve it, would be using `ujs` instead of plain jQuery. Using ujs, one can embed ruby code inside the javascript, thus leverage `octicon` helper inside the javascript.

Any feedback to improve this PR would be appreciated.