### PR TITLE
Make selection borders more visible

### DIFF
--- a/app/assets/stylesheets/_notifications.scss
+++ b/app/assets/stylesheets/_notifications.scss
@@ -77,19 +77,19 @@ $notification-items: (
 
 @mixin add-borders{
   .table-notifications tr td:first-child {
-    border-left: 1px solid $list-group-bg;
+    border-left: 5px solid $list-group-bg;
   }
   .table-notifications tr.active td:first-child {
-    border-left: 1px solid $list-group-action-active-bg;
+    border-left: 5px solid $list-group-action-active-bg;
   }
   .table-notifications tr:hover td:first-child {
-    border-left: 1px solid $list-group-action-hover-color;
+    border-left: 5px solid $list-group-action-hover-color;
   }
   .table-notifications tr.active:hover td:first-child {
-    border-left: 1px solid $list-group-action-hover-color;
+    border-left: 5px solid $list-group-action-hover-color;
   }
   td.current {
-    border-left: 1px solid $list-group-active-border-color !important;
+    border-left: 5px solid $list-group-active-border-color !important;
   }
 }
 


### PR DESCRIPTION
**PLEASE NOTE: this is untested - just a quick hack based on experiments with the userstyle listed in #3287.**

As per #3287, it's really hard to spot which item is currently selected or focused (e.g. via hover) for potential future selection.

So increase the border width from 1px to 5px.

Fixes #3287.