### PR TITLE
fix: broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,18 +36,23 @@ Octobox adds an extra "archived" state to each notification so you can mark it a
 
 ## Table of Contents
 
-- [Getting Started](#getting-started)
-	- [Install](#install)
-	- [Desktop usage](#desktop-usage)
-	- [Web extension](#web-extension)
-- [Requirements](#requirements)
-- [Keyboard shortcuts](#keyboard-shortcuts)
-- [Contribute](#contribute)
-	- [Vulnerability disclosure](#vulnerability-disclosure)
-	- [Note on Patches/Pull Requests](#note-on-patchespull-requests)
-- [Contribute](#contribute)
-	- [Code of Conduct](#code-of-conduct)
-- [Copyright](#copyright)
+- [Octobox 📮 Untangle your GitHub Notifications.](#octobox--untangle-your-github-notifications)
+	- [Why is this a thing?](#why-is-this-a-thing)
+	- [Table of Contents](#table-of-contents)
+	- [Getting Started](#getting-started)
+		- [Install](#install)
+		- [Desktop usage](#desktop-usage)
+		- [Web extension](#web-extension)
+	- [Requirements](#requirements)
+	- [Viewing comment threads](#viewing-comment-threads)
+	- [Keyboard shortcuts](#keyboard-shortcuts)
+	- [Backers](#backers)
+	- [Sponsors](#sponsors)
+	- [Contribute](#contribute)
+		- [Note on Patches/Pull Requests](#note-on-patchespull-requests)
+		- [Vulnerability disclosure](#vulnerability-disclosure)
+		- [Code of Conduct](#code-of-conduct)
+	- [Copyright](#copyright)
 
 ## Getting Started
 
@@ -69,7 +74,7 @@ This will build a local application (.exe, .app, etc) and put it in your current
 
 ### Web extension
 
-You can also install the cross-browser [Octobox Web Extension](https://github.com/tfrommen/octobox-web-extension). It is available for [Google Chrome](https://chrome.google.com/webstore/detail/octobox-web-extension/efhkcafmbonnomnimilnephjgeccffdn) and [Mozilla Firefox](https://addons.mozilla.org/en-US/firefox/addon/octobox-web-extension/), but you can also use it with other browsers that support web extensions.
+You can also install the cross-browser [Octobox Web Extension](https://github.com/tfrommen/octobox-web-extension). It is available for [Google Chrome](https://chromewebstore.google.com/detail/octobox/dpbajpnhgagfneijghelgldegjblinkc) and [Mozilla Firefox](https://addons.mozilla.org/en-US/firefox/addon/octobox-web-extension/), but you can also use it with other browsers that support web extensions.
 
 ## Requirements
 


### PR DESCRIPTION
The Google Chrome extension link was broken. This PR fixes it. Additionally, the Table of contents has been automatically updated by the markdown linter.