### PR TITLE
Mark as "done" on Github when archiving

### DIFF
--- a/app/workers/archive_worker.rb
+++ b/app/workers/archive_worker.rb
@@ -1,0 +1,9 @@
+class ArchiveWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: :user, lock: :until_and_while_executing
+
+  def perform(user_id, notification_ids)
+    user = User.find_by_id(user_id)
+    Notification.archive_on_github(user, notification_ids) if user
+  end
+end

--- a/test/controllers/api/notifications_controller_test.rb
+++ b/test/controllers/api/notifications_controller_test.rb
@@ -60,7 +60,7 @@ class ApiNotificationsControllerTest < ActionDispatch::IntegrationTest
     notification2 = create(:notification, user: @user, archived: false)
     notification3 = create(:notification, user: @user, archived: false)
 
-    stub_request(:patch, /https:\/\/api.github.com\/notifications\/threads/)
+    stub_request(:delete, /https:\/\/api.github.com\/notifications\/threads/)
 
     post '/api/notifications/archive_selected', params: { id: [notification1.id, notification2.id], value: true }, xhr: true, headers: { 'Authorization' => "Bearer #{@user.api_token}" }
 
@@ -76,7 +76,7 @@ class ApiNotificationsControllerTest < ActionDispatch::IntegrationTest
     notification2 = create(:notification, user: @user, archived: false)
     notification3 = create(:notification, user: @user, archived: false)
 
-    stub_request(:patch, /https:\/\/api.github.com\/notifications\/threads/)
+    stub_request(:delete, /https:\/\/api.github.com\/notifications\/threads/)
 
     post '/api/notifications/archive_selected', params: { id: ['all'], value: true }, xhr: true, headers: { 'Authorization' => "Bearer #{@user.api_token}" }
 
@@ -651,7 +651,7 @@ class ApiNotificationsControllerTest < ActionDispatch::IntegrationTest
   test 'archives false Unarchives the notifications' do
     notification1 = create(:notification, user: @user, archived: true)
     create(:notification, user: @user, archived: true)
-    stub_request(:patch, /https:\/\/api.github.com\/notifications\/threads/)
+    # stub_request(:patch, /https:\/\/api.github.com\/notifications\/threads/)
 
     post '/api/notifications/archive_selected', params: { id: [notification1.id], value: false }, xhr: true, headers: { 'Authorization' => "Bearer #{@user.api_token}" }
 

--- a/test/controllers/api/notifications_controller_test.rb
+++ b/test/controllers/api/notifications_controller_test.rb
@@ -60,7 +60,7 @@ class ApiNotificationsControllerTest < ActionDispatch::IntegrationTest
     notification2 = create(:notification, user: @user, archived: false)
     notification3 = create(:notification, user: @user, archived: false)
 
-    stub_request(:delete, /https:\/\/api.github.com\/notifications\/threads/)
+    stub_request(:delete, /https:\/\/api\.github\.com\/notifications\/threads/)
 
     post '/api/notifications/archive_selected', params: { id: [notification1.id, notification2.id], value: true }, xhr: true, headers: { 'Authorization' => "Bearer #{@user.api_token}" }
 
@@ -76,7 +76,7 @@ class ApiNotificationsControllerTest < ActionDispatch::IntegrationTest
     notification2 = create(:notification, user: @user, archived: false)
     notification3 = create(:notification, user: @user, archived: false)
 
-    stub_request(:delete, /https:\/\/api.github.com\/notifications\/threads/)
+    stub_request(:delete, /https:\/\/api\.github\.com\/notifications\/threads/)
 
     post '/api/notifications/archive_selected', params: { id: ['all'], value: true }, xhr: true, headers: { 'Authorization' => "Bearer #{@user.api_token}" }
 
@@ -651,7 +651,7 @@ class ApiNotificationsControllerTest < ActionDispatch::IntegrationTest
   test 'archives false Unarchives the notifications' do
     notification1 = create(:notification, user: @user, archived: true)
     create(:notification, user: @user, archived: true)
-    # stub_request(:patch, /https:\/\/api.github.com\/notifications\/threads/)
+    # stub_request(:patch, /https:\/\/api\.github\.com\/notifications\/threads/)
 
     post '/api/notifications/archive_selected', params: { id: [notification1.id], value: false }, xhr: true, headers: { 'Authorization' => "Bearer #{@user.api_token}" }
 

--- a/test/controllers/notifications_controller_test.rb
+++ b/test/controllers/notifications_controller_test.rb
@@ -171,7 +171,7 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
     notification2 = create(:notification, user: @user, archived: false)
     notification3 = create(:notification, user: @user, archived: false)
 
-    stub_request(:delete, /https:\/\/api.github.com\/notifications\/threads/)
+    stub_request(:delete, /https:\/\/api\.github\.com\/notifications\/threads/)
 
     post '/notifications/archive_selected', params: { id: [notification1.id, notification2.id], value: true }, xhr: true
 
@@ -188,7 +188,7 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
     notification2 = create(:notification, user: @user, archived: false)
     notification3 = create(:notification, user: @user, archived: false)
 
-    stub_request(:delete, /https:\/\/api.github.com\/notifications\/threads/)
+    stub_request(:delete, /https:\/\/api\.github\.com\/notifications\/threads/)
 
     post '/notifications/archive_selected', params: { id: ['all'], value: true }, xhr: true
 

--- a/test/controllers/notifications_controller_test.rb
+++ b/test/controllers/notifications_controller_test.rb
@@ -171,7 +171,7 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
     notification2 = create(:notification, user: @user, archived: false)
     notification3 = create(:notification, user: @user, archived: false)
 
-    stub_request(:patch, /https:\/\/api.github.com\/notifications\/threads/)
+    stub_request(:delete, /https:\/\/api.github.com\/notifications\/threads/)
 
     post '/notifications/archive_selected', params: { id: [notification1.id, notification2.id], value: true }, xhr: true
 
@@ -188,7 +188,7 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
     notification2 = create(:notification, user: @user, archived: false)
     notification3 = create(:notification, user: @user, archived: false)
 
-    stub_request(:patch, /https:\/\/api.github.com\/notifications\/threads/)
+    stub_request(:delete, /https:\/\/api.github.com\/notifications\/threads/)
 
     post '/notifications/archive_selected', params: { id: ['all'], value: true }, xhr: true
 
@@ -896,7 +896,7 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
 
     notification1 = create(:notification, user: @user, archived: true)
     create(:notification, user: @user, archived: true)
-    stub_request(:patch, /https:\/\/api.github.com\/notifications\/threads/)
+    
 
     post '/notifications/archive_selected', params: { id: [notification1.id], value: false }, xhr: true
 

--- a/test/support/stub_helper.rb
+++ b/test/support/stub_helper.rb
@@ -104,7 +104,7 @@ module StubHelper
     stub_comments_requests
     headers  = { 'Content-Type' => 'application/json' }.merge(extra_headers)
 
-    stub_request(:get, /https:\/\/api.github.com\/repos\/octobox\/octobox\z/)
+    stub_request(:get, /https:\/\/api\.github\.com\/repos\/octobox\/octobox\z/)
       .to_return({ status: 200, body: file_fixture('repository.json'), headers: headers })
   end
 


### PR DESCRIPTION
Fixes #3036 

Uses the new REST API Endpoint to mark a notification thread as "Done": https://docs.github.com/en/rest/activity/notifications?apiVersion=2022-11-28#mark-a-thread-as-done 

