### PR TITLE
Use luminance to determine label foreground color

### DIFF
--- a/app/models/label.rb
+++ b/app/models/label.rb
@@ -4,7 +4,8 @@ class Label < ApplicationRecord
   def text_color
     red, blue, green = RGB::Color.from_rgb_hex("##{color}").to_rgb
     # Magic numbers - see https://stackoverflow.com/a/3943023/2526265
-    if (red*0.299 + green*0.587 + blue*0.114) > 186
+    L = 0.2126 * red/255 + 0.7152 * g/255 + 0.0722 * b/255;
+    if (L + 0.05) / 0.05 > (1.05) / (L + 0.05)
       'black'
     else
       'white'


### PR DESCRIPTION
Use the luminance values from WCAG 2.0 guidelines to determine which foreground colour to use for labels.

The referenced StackOverflow answer was updated to note that the older implementation has suboptimal contrast for some colours and uses a similar computation as well.
