### PR TITLE
Overrides sidebar hover color in dark theme

### DIFF
--- a/app/assets/stylesheets/themes/darkly/_variables.scss
+++ b/app/assets/stylesheets/themes/darkly/_variables.scss
@@ -146,7 +146,7 @@ $progress-bg:                       $gray-700 !default;
 // List group
 
 $list-group-bg:                     $card-bg !default;
-$list-group-hover-bg:               darken($blue, 15%) !default;
+$list-group-hover-bg:               darken($primary, 15%) !default;
 $list-group-border-color:           lighten($body-bg, 15%) !default;
 $list-group-action-active-bg:				lighten($body-bg, 20%) !default;
 $list-group-active-border-color:    $white !default;

--- a/app/assets/stylesheets/themes/darkly/_variables.scss
+++ b/app/assets/stylesheets/themes/darkly/_variables.scss
@@ -146,6 +146,7 @@ $progress-bg:                       $gray-700 !default;
 // List group
 
 $list-group-bg:                     $card-bg !default;
+$list-group-hover-bg:               darken($blue, 15%) !default;
 $list-group-border-color:           lighten($body-bg, 15%) !default;
 $list-group-action-active-bg:				lighten($body-bg, 20%) !default;
 $list-group-active-border-color:    $white !default;


### PR DESCRIPTION
### Current `main`

![image](https://github.com/user-attachments/assets/3da9f93a-c84e-45d1-9a7c-cead5c0d361e)

### Proposed change

![image](https://github.com/user-attachments/assets/7ca81375-be18-4d9b-8be5-c4717dae674a)



