### PR TITLE
Fix exception on boot

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -28,7 +28,7 @@ module Octobox
 
     config.load_defaults '7.1'
 
-    unless File.basename($0) == 'rake' || File.basename($0) == 'rails' || secrets.secret_key_base.length >= 32
+    unless File.basename($0) == 'rake' || File.basename($0) == 'rails' || secret_key_base.length >= 32
       raise "SECRET_KEY_BASE should be a random key of at least 32 chars."
     end
   end


### PR DESCRIPTION
Since the upgrade to Rails 7.2 in 92e77c22ab16b8dd2e5537c4ab5f336ba75cd6b4, Octobox won't boot if you're invoking it with a command other than `rake` or `rails` (e.g. if you're running something like `puma -C path/to/your/config.rb`). This is because Rails removed `Rails::Application#secrets`, which is called as a fallback in `config/application.rb` when other commands are used to run Octobox.

`secret_key_base` is available directly on `Rails::Application` now, so we can drop the call to `secrets` entirely.