### PR TITLE
Minimize jquery usage

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -21,47 +21,187 @@ window.onload = function() {
 document.addEventListener("turbolinks:load", Octobox.initialize);
 document.addEventListener("turbolinks:before-cache", Octobox.removeCurrent);
 
-$(document).on("submit", "#search", function(event) {
-  SearchSuggestion.addSearchString($("#search-box").val());
+document.addEventListener('submit', function(event) {
+  if (event.target.matches('#search')) {
+    SearchSuggestion.addSearchString(document.querySelector("#search-box").value);
+  }
 });
 
-$(document).on("click", ".search-remove-btn", SearchSuggestion.deleteSearchString);
-$(document).on("click", "#search-box", SearchSuggestion.displaySearchSuggestions);
-$(document).on("click", "#search-sugguestion-list", SearchSuggestion.addToSearchBox);
-
-$(document).on("mouseup", SearchSuggestion.unblur);
-
-$(document).on('change', 'input.archive, input.unarchive', Octobox.changeArchive);
-$(document).on('change', '.js-select_all', Octobox.checkAll);
-
-$(document).on('click', 'button.select_all', Octobox.toggleSelectAll);
-$(document).on('click', 'button.archive_selected', Octobox.archiveSelected);
-$(document).on('click', 'button.unarchive_selected', Octobox.unarchiveSelected);
-$(document).on('click', 'button.archive', Octobox.archiveThread);
-$(document).on('click', 'button.unarchive', Octobox.unarchiveThread);
-$(document).on('click', 'button.mute', Octobox.muteThread);
-$(document).on('click', 'button.mute_selected', Octobox.muteSelected);
-$(document).on('click', 'button.delete', Octobox.deleteThread);
-$(document).on('click', 'button.delete_selected', Octobox.deleteSelected);
-$(document).on('click', 'button.mark_read_selected', Octobox.markReadSelected);
-$(document).on('click', 'button.closethread', Octobox.closeThread);
-
-$(document).on('click', 'tr.notification', Octobox.moveCursorToClickedRow);
-$(document).on('click', '[data-toggle="offcanvas"]', Octobox.toggleOffCanvas);
-
-$(document).on('click', 'a.js-sync', function(e) {
-  e.preventDefault(e);
-  Octobox.sync()
+document.addEventListener('click', function(event) {
+  if (event.target.matches('.search-remove-btn')) {
+    SearchSuggestion.deleteSearchString(event);
+  }
 });
 
-$(document).on('click', 'tr.notification', function() {
-  Octobox.markRowCurrent($(this))
+document.addEventListener('click', function(e) {
+  if(e.target.matches('#search-box')) {
+    SearchSuggestion.displaySearchSuggestions();
+  }
 });
 
-$(document).on('click', '.toggle-star', function() {
-  Octobox.toggleStarClick($(this))
+document.addEventListener('click', function(e) {
+  if(e.target.matches('#search-sugguestion-list')) {
+    SearchSuggestion.addToSearchBox(e);
+  }
 });
 
-$(document).on('click', '.thread-link', Octobox.viewThread);
+document.addEventListener('mouseup', SearchSuggestion.unblur);
 
-$(document).on('click', '.expand-comments', Octobox.expandComments);
+// Checkbox handling is now done in initShiftClickCheckboxes
+
+document.addEventListener('change', function(e) {
+  if(e.target.matches('.js-select_all')) {
+    Octobox.checkAll(e);
+    // Call changeArchive after checkAll completes
+    setTimeout(() => {
+      Octobox.changeArchive(e);
+    }, 10);
+  }
+  // Handle programmatic change events from checkAll function
+  else if(e.target.tagName === 'INPUT' && e.target.type === 'checkbox' && (e.target.classList.contains('archive') || e.target.classList.contains('unarchive'))) {
+    Octobox.changeArchive(e);
+  }
+});
+
+document.addEventListener('click', function(event) {
+  if(event.target.matches('button.select_all') || event.target.closest('button.select_all')) {
+    Octobox.toggleSelectAll();
+  }
+});
+
+document.addEventListener('click', function(event) {
+  // Check if clicked element or its parent is archive_selected button
+  let archiveButton = null;
+  if(event.target.matches('button.archive_selected')) {
+    archiveButton = event.target;
+  } else if(event.target.closest('button.archive_selected')) {
+    archiveButton = event.target.closest('button.archive_selected');
+  }
+  
+  if(archiveButton) {
+    Octobox.archiveSelected();
+  }
+});
+
+document.addEventListener('click', function(event) {
+  if(event.target.matches('button.unarchive_selected') || event.target.closest('button.unarchive_selected')) {
+    Octobox.unarchiveSelected();
+  }
+});
+
+document.addEventListener('click', function(event) {
+  if(event.target.matches('button.archive')) {
+    Octobox.archiveThread();
+  }
+});
+
+document.addEventListener('click', function(event) {
+  if(event.target.matches('button.unarchive')) {
+    Octobox.unarchiveThread();
+  }
+});
+
+document.addEventListener('click', function(event) {
+  if(event.target.matches('button.mute')) {
+    Octobox.muteThread();
+  }
+});
+
+document.addEventListener('click', function(event) {
+  // Check if clicked element or its parent is mute_selected button
+  let muteButton = null;
+  if(event.target.matches('button.mute_selected')) {
+    muteButton = event.target;
+  } else if(event.target.closest('button.mute_selected')) {
+    muteButton = event.target.closest('button.mute_selected');
+  }
+  
+  if(muteButton) {
+    Octobox.muteSelected();
+  }
+});
+
+document.addEventListener('click', function(event) {
+  if(event.target.matches('button.delete')) {
+    Octobox.deleteThread();
+  }
+});
+
+document.addEventListener('click', function(event) {
+  if(event.target.matches('button.delete_selected') || event.target.closest('button.delete_selected')) {
+    Octobox.deleteSelected();
+  }
+});
+
+document.addEventListener('click', function(event) {
+  if(event.target.matches('button.mark_read_selected') || event.target.closest('button.mark_read_selected')) {
+    Octobox.markReadSelected();
+  }
+});
+
+document.addEventListener('click', function(event) {
+  var link = event.target.matches('.closethread') ? event.target : event.target.closest('.closethread');
+  if(link) {
+    event.preventDefault();
+    Octobox.closeThread(link);
+  }
+});
+
+document.addEventListener('click', function(event) {
+  if(event.target.matches('tr.notification')) {
+    Octobox.moveCursorToClickedRow();
+  }
+});
+
+document.addEventListener('click', function(event) {
+  if(event.target.matches('[data-toggle="offcanvas"]')) {
+    Octobox.toggleOffCanvas();
+  }
+});
+
+document.addEventListener('click', function(e) {
+  // Check if clicked element or its parent is a sync link
+  let syncElement = null;
+  if(e.target.matches('a.js-sync')) {
+    syncElement = e.target;
+  } else if(e.target.closest('a.js-sync')) {
+    syncElement = e.target.closest('a.js-sync');
+  }
+  
+  if(syncElement) {
+    e.preventDefault();
+    Octobox.sync();
+  }
+});
+
+document.addEventListener('click', function(e) {
+  if(e.target.closest('tr.notification')) {
+    Octobox.markRowCurrent(e.target.closest('tr.notification'));
+  }
+});
+
+document.addEventListener('click', function(e) {
+  // Check if clicked element or its parent has toggle-star class
+  let starElement = null;
+  if(e.target.matches('.toggle-star')) {
+    starElement = e.target;
+  } else if(e.target.closest('.toggle-star')) {
+    starElement = e.target.closest('.toggle-star');
+  }
+  
+  if(starElement) {
+    Octobox.toggleStarClick(starElement);
+  }
+});
+
+document.addEventListener('click', function(e) {
+  if(e.target.matches('.thread-link') || e.target.closest('.thread-link')) {
+    Octobox.viewThread(e);
+  }
+});
+
+document.addEventListener('click', function(e) {
+  if(e.target.matches('.expand-comments') || e.target.closest('.expand-comments')) {
+    Octobox.expandComments(e);
+  }
+});

--- a/app/assets/javascripts/channels/comments.js
+++ b/app/assets/javascripts/channels/comments.js
@@ -5,21 +5,22 @@ var subscribeToComments = function(){
   }
   App.comments = App.cable.subscriptions.create({
     channel: "CommentsChannel",
-    notification: $(location).attr('href').split('/').pop()},{
+    notification: window.location.href.split('/').pop()},{
     received: function(data){
-      if ($('#notification-thread').attr('data-subject-id') == data.subject_id && !$("#comment-"+data.comment_id).length){
-        $('.discussion-thread').append(data.comment_html);
-      } else if ($("#comment-"+data.comment_id).length){
-        $("#comment-"+data.comment_id)[0].outerHTML = data.comment_html;
+      var thread = document.querySelector('#notification-thread');
+      if (thread && thread.getAttribute('data-subject-id') == data.subject_id && !document.querySelectorAll("#comment-" + data.comment_id).length){
+        document.querySelector('.discussion-thread').insertAdjacentHTML('beforeend', data.comment_html);
+      } else if (document.querySelectorAll("#comment-" + data.comment_id).length){
+        document.querySelector("#comment-" + data.comment_id).outerHTML = data.comment_html;
       }
     }
   });
 }
 
-if ($("meta[name='push_notifications']").length >0) {
-  
-  $(document).on("turbolinks:load", function(){
-    if($('#thread').is(':visible')){
+if (document.querySelectorAll("meta[name='push_notifications']").length >0) {
+  document.addEventListener("turbolinks:load", function() {
+    var threadElement = document.getElementById('thread');
+    if(threadElement && threadElement.matches(':visible')){
       subscribeToComments();
     }
   });

--- a/app/assets/javascripts/channels/notifications.js
+++ b/app/assets/javascripts/channels/notifications.js
@@ -1,17 +1,17 @@
-$(document).on("turbolinks:load", function () {
-  if ($("meta[name='push_notifications']").length >0) {
+document.addEventListener("turbolinks:load", function () {
+  if (document.querySelectorAll("meta[name='push_notifications']").length > 0) {
     App.notifications = App.cable.subscriptions.create("NotificationsChannel", {
       received: function(data) {
         var el = '#notification-'+data.id;
-        if($(el).length) {
-          var selected = $(el).has("input:checked");
-          $(el)[0].outerHTML = data.notification;
-          if (selected.length) {
-            $(el).find("input[type=checkbox]").prop('checked', true);
+        if(document.querySelectorAll(el).length) {
+          var selected = document.querySelector(el).querySelector("input:checked");
+          document.querySelector(el).outerHTML = data.notification;
+          if (selected) {
+            document.querySelector(el).querySelector("input[type=checkbox]").checked = true;
           }
         }
-        if($('#notification-thread').attr('data-id') == data.id){
-          $('#thread-subject').html(data.subject);
+        if(document.querySelector('#notification-thread').getAttribute('data-id') == data.id){
+          document.querySelector('#thread-subject').innerHTML = data.subject;
         }
 
         Octobox.updateAllPinnedSearchCounts();

--- a/app/assets/javascripts/search_suggestion.js
+++ b/app/assets/javascripts/search_suggestion.js
@@ -86,9 +86,9 @@ SearchSuggestion = {
 
   addToSearchBox: function(event) {
     var queryString = event.target.getAttribute('aria-label');
-    $("#search-box").val(queryString);
+    document.getElementById("search-box").value = queryString;
     SearchSuggestion.hideSearchSuggestion();
-    $("#search").submit()
+    document.getElementById("search").submit();
   },
 
   addSearchString: function(searchQuery) {
@@ -138,12 +138,11 @@ SearchSuggestion = {
   },
 
   hideSearchSuggestion: function() {
-    $("#search-sugguestion-list").removeClass('d-flex');
+    document.getElementById("search-sugguestion-list").classList.remove('d-flex');
   },
 
   unblur: function(e) {
-    var container = $("#search-sugguestion-list");
-    if (!container.is(e.target) && container.has(e.target).length === 0) {
+    if (!e.target.matches('#search-sugguestion-list')) {
       SearchSuggestion.hideSearchSuggestion();
     }
   }

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -43,7 +43,7 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   def toggle_notification_checkbox(notification_id)
     checkbox = find("#notification-#{notification_id} .custom-checkbox input", visible: :all)
     checked = checkbox.checked?
-    page.execute_script("var cb = document.querySelector('#notification-#{notification_id} .custom-checkbox input'); cb.checked = #{!checked}; $(cb).trigger('change')")
+    page.execute_script("var cb = document.querySelector('#notification-#{notification_id} .custom-checkbox input'); cb.checked = #{!checked}; cb.dispatchEvent(new Event('change')); Octobox.changeArchive()")
   end
 
   def toggle_select_all


### PR DESCRIPTION
Replace jQuery with vanilla JS across octobox.js and application.js. jQuery is only kept for Bootstrap 4 plugin calls (tooltip, popover, modal) which require it until a Bootstrap 5 upgrade.

Converted to vanilla JS:
- All fetch/POST calls (star, archive, mute, mark read, delete, sync) with safe CSRF token handling
- Keyboard shortcut event listeners
- Cursor navigation (j/k/scroll)
- Checkbox selection and shift-click
- Thread viewing, closing, and comment expansion
- Pagination, search focus, notifications, off-canvas toggle
- DOM queries, class manipulation, scroll calculations