### PR TITLE
Validate return_to and remove inline onclick on extension page

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -47,6 +47,18 @@ document.addEventListener('click', function(e) {
 
 document.addEventListener('mouseup', SearchSuggestion.unblur);
 
+document.addEventListener('click', function(e) {
+  var link = e.target.closest('.js-enable-extension');
+  if (!link) return;
+  e.preventDefault();
+  document.dispatchEvent(new CustomEvent('octobox:enable', {
+    detail: {
+      api_token: link.dataset.apiToken,
+      return_to: link.dataset.returnTo
+    }
+  }));
+});
+
 // Checkbox handling is now done in initShiftClickCheckboxes
 
 document.addEventListener('change', function(e) {

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,7 +9,13 @@ class UsersController < ApplicationController
   end
 
   def extension
-    @return_to = params[:return_to].presence || Octobox.config.github_domain
+    @return_to = safe_return_to(params[:return_to])
+  end
+
+  def safe_return_to(url)
+    domain = Octobox.config.github_domain
+    return domain unless url.present? && url.start_with?("#{domain}/")
+    url
   end
 
   def edit

--- a/app/views/users/extension.html.erb
+++ b/app/views/users/extension.html.erb
@@ -7,7 +7,7 @@
   <p>Directly manage and triage through your Octobox inbox from your GitHub issues and pull requests. You can star, archive and mute notifications without needing to leave the page and quickly jump to the next and previous notifications in your inbox with a single click.</p>
   <hr>
 
-  <% if true || Octobox.io? %>
+  <% if Octobox.io? %>
     <div class="card mb-3 d-none" id='login-extension'>
       <h5 class="card-header">
         Enable extension access
@@ -15,7 +15,7 @@
       <div class="card-body">
         <p>Login into the browser extension to give it access to your Octobox account</p>
 
-        <%= link_to '#', class: 'btn btn-primary', onclick: "document.dispatchEvent(new CustomEvent('octobox:enable', {detail: {api_token:'#{current_user.api_token}', return_to: '#{@return_to}'}}))" do %>
+        <%= link_to '#', class: 'btn btn-primary js-enable-extension', data: { api_token: current_user.api_token, return_to: @return_to } do %>
           <span class='mr-1'>Enable extension</span>
           <%= octicon 'plug', height: 22 %>
         <% end %>

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -51,6 +51,57 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test 'extension page allows return_to on the configured github domain' do
+    Octobox.stubs(:io?).returns(true)
+    sign_in_as(@user)
+    get '/extension', params: { return_to: 'https://github.com/octobox/octobox/issues/1' }
+    assert_response :success
+    assert_equal 'https://github.com/octobox/octobox/issues/1', assigns(:return_to)
+  end
+
+  test 'extension page rejects javascript: return_to' do
+    Octobox.stubs(:io?).returns(true)
+    sign_in_as(@user)
+    get '/extension', params: { return_to: 'javascript:alert(1)' }
+    assert_response :success
+    assert_equal Octobox.config.github_domain, assigns(:return_to)
+  end
+
+  test 'extension page rejects lookalike domain in return_to' do
+    Octobox.stubs(:io?).returns(true)
+    sign_in_as(@user)
+    get '/extension', params: { return_to: 'https://github.com.evil.com/foo' }
+    assert_response :success
+    assert_equal Octobox.config.github_domain, assigns(:return_to)
+  end
+
+  test 'extension page falls back to github domain when return_to is blank' do
+    Octobox.stubs(:io?).returns(true)
+    sign_in_as(@user)
+    get '/extension'
+    assert_response :success
+    assert_equal Octobox.config.github_domain, assigns(:return_to)
+  end
+
+  test 'extension page does not render inline onclick' do
+    Octobox.stubs(:io?).returns(true)
+    sign_in_as(@user)
+    get '/extension', params: { return_to: 'https://github.com/octobox/octobox' }
+    assert_response :success
+    refute_includes response.body, 'onclick'
+    assert_select 'a.js-enable-extension[data-api-token=?]', @user.api_token
+    assert_select 'a.js-enable-extension[data-return-to=?]', 'https://github.com/octobox/octobox'
+  end
+
+  test 'extension page go-to-github link uses validated return_to' do
+    Octobox.stubs(:io?).returns(true)
+    sign_in_as(@user)
+    get '/extension', params: { return_to: 'javascript:alert(1)' }
+    assert_response :success
+    assert_select '#installed-extension a.btn-primary[href=?]', Octobox.config.github_domain
+    assert_select 'a[href^="javascript:"]', false
+  end
+
   test 'updates api_token' do
     sign_in_as(@user)
     token = @user.api_token


### PR DESCRIPTION
Two fixes for `/extension`:

`params[:return_to]` was used unvalidated as the href of the "Go to GitHub" link, allowing `?return_to=javascript:...` payloads. Now constrained to URLs that start with the configured GitHub domain followed by `/`, which also blocks lookalike domains like `https://github.com.evil.com`.

The "Enable extension" button interpolated `@return_to` and `current_user.api_token` into an inline `onclick` via Ruby `#{}`. Rails HTML-escapes attribute values, but browsers decode entities before passing event handler attributes to the JS engine, so the escaping was insufficient. Moved both values to `data-*` attributes with a delegated click handler in `application.js`. The dispatched `octobox:enable` event has the same shape so no extension-side changes are needed.

Also removed the `true ||` debug override on line 10 so the enable/install cards are gated to octobox.io as originally intended.