### PR TITLE
Build search suggestion DOM safely instead of via innerHTML

### DIFF
--- a/app/assets/javascripts/search_suggestion.js
+++ b/app/assets/javascripts/search_suggestion.js
@@ -70,10 +70,10 @@ SearchSuggestion = {
 
     var divtem = document.createElement('div');
     divtem.setAttribute('aria-label', suggestion);
-    divtem.innerHTML = suggestion;
+    divtem.textContent = suggestion;
 
     listItem.appendChild(divtem);
-    listItem.innerHTML += SearchSuggestion.createDeleteButtonElement(suggestion);
+    listItem.appendChild(SearchSuggestion.createDeleteButtonElement(suggestion));
 
     return listItem;
   },
@@ -81,7 +81,11 @@ SearchSuggestion = {
   // create a delete button inside each list item, giving it an event handler
   // so that it runs the deleteButton()  when clicked
   createDeleteButtonElement: function(suggestion) {
-    return "<div class='badge badge-light search-remove-btn btn' data-suggestion='"+suggestion+"'><svg height='16' class='octicon octicon-x' data-suggestion='"+suggestion+"' viewBox='0 0 12 16' version='1.1' width='12' aria-hidden='true'><path data-suggestion='"+suggestion+"' fill-rule='evenodd' d='M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z'></path></svg></div>";
+    var btn = document.createElement('div');
+    btn.className = 'badge badge-light search-remove-btn btn';
+    btn.setAttribute('data-suggestion', suggestion);
+    btn.innerHTML = "<svg height='16' class='octicon octicon-x' viewBox='0 0 12 16' version='1.1' width='12' aria-hidden='true'><path fill-rule='evenodd' d='M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z'></path></svg>";
+    return btn;
   },
 
   addToSearchBox: function(event) {

--- a/test/system/search_suggestion_test.rb
+++ b/test/system/search_suggestion_test.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'application_system_test_case'
+
+class SearchSuggestionTest < ApplicationSystemTestCase
+  setup do
+    @user = create(:user)
+    create(:notification, user: @user)
+    sign_in_as(@user)
+  end
+
+  test 'createSuggestionListElement renders payload as text not html' do
+    payload = '<img src=x onerror=window.xss_fired=true>'
+
+    page.execute_script(<<~JS)
+      var list = document.getElementById('search-sugguestion-list');
+      list.appendChild(SearchSuggestion.createSuggestionListElement(#{payload.to_json}));
+      list.classList.add('d-flex');
+    JS
+
+    li = find('#search-sugguestion-list li', visible: :all)
+    assert_equal payload, li.find('div', match: :first, visible: :all).text(:all)
+    assert_no_selector '#search-sugguestion-list img', visible: :all
+    refute page.evaluate_script('window.xss_fired'), 'onerror handler executed'
+  end
+
+  test 'createDeleteButtonElement does not break out of data-suggestion attribute' do
+    payload = "foo' onclick='window.xss_fired=true"
+
+    page.execute_script(<<~JS)
+      var list = document.getElementById('search-sugguestion-list');
+      list.appendChild(SearchSuggestion.createDeleteButtonElement(#{payload.to_json}));
+      list.classList.add('d-flex');
+    JS
+
+    btn = find('#search-sugguestion-list .search-remove-btn', visible: :all)
+    assert_equal payload, btn['data-suggestion']
+    assert_nil btn['onclick']
+    refute page.evaluate_script('window.xss_fired')
+  end
+
+  test 'suggestion list round-trips through delete handler' do
+    # Verify the data-suggestion attribute still feeds deleteSearchString correctly
+    # after switching from string concat to setAttribute.
+    page.execute_script(<<~JS)
+      var list = document.getElementById('search-sugguestion-list');
+      list.appendChild(SearchSuggestion.createSuggestionListElement('repo:octobox/octobox'));
+      list.classList.add('d-flex');
+    JS
+
+    btn = find('#search-sugguestion-list .search-remove-btn', visible: :all)
+    assert_equal 'repo:octobox/octobox', btn['data-suggestion']
+  end
+end


### PR DESCRIPTION
Search queries stored in IndexedDB were rendered back into the suggestion dropdown via `innerHTML` and string concatenation into a single-quoted attribute. The query reaches IndexedDB through the form submit listener which reads `#search-box.value`, and the server populates that value from `params[:q]`. The browser decodes the HTML-escaped attribute before `.value` returns it, so raw markup is what gets stored. A `?q=<img src=x onerror=...>` link, if the victim submits the search, would persist across sessions and re-execute on every search box click.

Three changes in `createSuggestionListElement` and `createDeleteButtonElement`:

- `textContent` instead of `innerHTML` for the suggestion text
- `appendChild` instead of `innerHTML +=` for the delete button
- `setAttribute('data-suggestion', ...)` instead of string concatenation into the attribute

The remaining `innerHTML` is a static SVG with no user data. The duplicated `data-suggestion` on the inner svg/path was dropped since the click handler at `application.js:31` only matches `.search-remove-btn` on `event.target` directly, so it was already unreachable.

Existing poisoned IndexedDB entries render harmlessly as text after this lands, no cleanup needed.

System tests verified to fail against the original code.