### PR TITLE
Allowlist import fields and gate thread view behind display?

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -170,10 +170,13 @@ class User < ApplicationRecord
     pinned_searches.create(query: "type:pull_request author:#{github_login} inbox:true", name: 'My PRs')
   end
 
+  IMPORTABLE_NOTIFICATION_FIELDS = %w[archived starred unread muted_at last_read_at].freeze
+
   def import_notifications(data)
     data.each do |new_notification|
-      n = self.notifications.find_or_initialize_by(github_id: new_notification['github_id'])
-      n.attributes = new_notification.except('id', 'user_id')
+      n = self.notifications.find_by(github_id: new_notification['github_id'])
+      next unless n
+      n.attributes = new_notification.slice(*IMPORTABLE_NOTIFICATION_FIELDS)
       n.save(touch: false) if n.changed?
     end
   end

--- a/app/views/notifications/_thread.html.erb
+++ b/app/views/notifications/_thread.html.erb
@@ -30,7 +30,7 @@
       <%= render 'thread_subject', notification: @notification %>
     </div>
 
-    <% if @notification.subject %>
+    <% if @notification.subject && @notification.display? %>
       <div class='discussion-thread'>
         <% if @notification.subject.body %>
           <div class="card-comment card mt-3">
@@ -76,6 +76,12 @@
       <% if current_user.can_comment?(@notification.subject)%>
         <%= render partial: 'reply', locals: {notification: @notification} %>
       <% end %>
+    <% elsif @notification.subject %>
+      <div class='card mt-3'>
+        <div class='card-body'>
+          <%= render 'notifications/private_repos' %>
+        </div>
+      </div>
     <% end %>
   </div>
 </div>

--- a/app/views/notifications/_thread_subject.html.erb
+++ b/app/views/notifications/_thread_subject.html.erb
@@ -8,7 +8,7 @@
   <%= notification_button_title(notification) %>
 <% end %>
 
-<% if notification.subject %>
+<% if notification.subject && notification.display? %>
   <%= notification_status(notification.subject.status) %>
   <%= link_to notification.subject.author, root_path(filtered_params(author: notification.subject.author)), class: 'text-muted', target: '_blank' %> opened this <%= notification.subject_type.underscore.humanize.downcase %>
 <% end %>
@@ -20,13 +20,13 @@ on <%= link_to notification.repository_full_name, notification.repo_url, class: 
 <div class='d-flex justify-content-between mt-2'>
   <div class='labels'>
     <%= link_to notification.reason.humanize, root_path(filtered_params(reason: notification.reason)), class: "badge badge-#{reason_label(notification.reason)}" %>
-    <% if notification.subject %>
+    <% if notification.subject && notification.display? %>
       <% notification.subject.labels.each do |label| %>
         <%= link_to emojify(label.name), root_path(filtered_params(label: label.name)), class: "badge", style: "background-color: ##{label.color}; color: #{label.text_color}" %>
       <% end %>
     <% end %>
   </div>
-  <% if notification.subject %>
+  <% if notification.subject && notification.display? %>
     <div>
       <%= link_to pluralize(notification.subject.comment_count,'comment'), expand_comments_notification_url(notification),  class: 'text-muted'%>
     </div>

--- a/test/controllers/notifications_controller_test.rb
+++ b/test/controllers/notifications_controller_test.rb
@@ -1126,4 +1126,57 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
     get '/?page=0'
     assert_response :success
   end
+
+  test 'thread view hides subject body when display? is false' do
+    sign_in_as(@user)
+    notification = create(:notification, user: @user)
+    create(:subject, url: notification.subject_url, body: 'secret private content')
+
+    Notification.any_instance.stubs(:display?).returns(false)
+
+    get notification_path(notification)
+    assert_response :success
+    refute_includes response.body, 'secret private content'
+    assert_select '.discussion-thread', false
+  end
+
+  test 'thread view shows subject body when display? is true' do
+    sign_in_as(@user)
+    notification = create(:notification, user: @user)
+    create(:subject, url: notification.subject_url, body: 'visible content')
+
+    Notification.any_instance.stubs(:display?).returns(true)
+
+    get notification_path(notification)
+    assert_response :success
+    assert_includes response.body, 'visible content'
+  end
+
+  test 'thread view shows upgrade prompt when display? is false and subject exists' do
+    Octobox.stubs(:io?).returns(true)
+    sign_in_as(@user)
+    notification = create(:notification, user: @user)
+    create(:subject, url: notification.subject_url, body: 'paywalled content')
+
+    Notification.any_instance.stubs(:display?).returns(false)
+
+    get notification_path(notification)
+    assert_response :success
+    refute_includes response.body, 'paywalled content'
+    assert_select 'a[href=?]', pricing_path
+  end
+
+  test 'thread subject hides author and labels when display? is false' do
+    sign_in_as(@user)
+    notification = create(:notification, user: @user)
+    subject = create(:subject, url: notification.subject_url, author: 'secretauthor')
+    create(:label, subject: subject, name: 'secretlabel')
+
+    Notification.any_instance.stubs(:display?).returns(false)
+
+    get notification_path(notification)
+    assert_response :success
+    refute_includes response.body, 'secretauthor'
+    refute_includes response.body, 'secretlabel'
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -237,4 +237,78 @@ class UserTest < ActiveSupport::TestCase
     assert_equal @app_user.comment_client(comment).access_token, @app_user.app_token
   end
 
+  test '#import_notifications updates allowed fields on existing notifications' do
+    notification = create(:notification, user: @user, archived: false, starred: false, unread: true)
+
+    @user.import_notifications([{
+      'github_id' => notification.github_id,
+      'archived' => true,
+      'starred' => true,
+      'unread' => false,
+      'muted_at' => '2026-01-01T00:00:00Z',
+      'last_read_at' => '2026-01-01T00:00:00Z'
+    }])
+
+    notification.reload
+    assert notification.archived
+    assert notification.starred
+    refute notification.unread
+    refute_nil notification.muted_at
+  end
+
+  test '#import_notifications ignores subject_url' do
+    notification = create(:notification, user: @user)
+    original_subject_url = notification.subject_url
+
+    @user.import_notifications([{
+      'github_id' => notification.github_id,
+      'subject_url' => 'https://api.github.com/repos/victim-org/private-repo/issues/1',
+      'archived' => true
+    }])
+
+    notification.reload
+    assert_equal original_subject_url, notification.subject_url
+    assert notification.archived
+  end
+
+  test '#import_notifications ignores repository_full_name' do
+    notification = create(:notification, user: @user)
+    original_repo = notification.repository_full_name
+
+    @user.import_notifications([{
+      'github_id' => notification.github_id,
+      'repository_full_name' => 'victim-org/private-repo'
+    }])
+
+    notification.reload
+    assert_equal original_repo, notification.repository_full_name
+  end
+
+  test '#import_notifications does not create records for unknown github_ids' do
+    assert_no_difference 'Notification.count' do
+      @user.import_notifications([{
+        'github_id' => 999999999,
+        'subject_url' => 'https://api.github.com/repos/victim-org/private-repo/issues/1',
+        'archived' => true
+      }])
+    end
+  end
+
+  test '#import_notifications cannot link to another users subject' do
+    victim = create(:user)
+    victim_subject = create(:subject, url: 'https://api.github.com/repos/victim-org/secret/issues/42', body: 'private issue body')
+    create(:notification, user: victim, subject_url: victim_subject.url)
+
+    attacker_notification = create(:notification, user: @user, subject_url: 'https://api.github.com/repos/attacker/repo/issues/1')
+
+    @user.import_notifications([{
+      'github_id' => attacker_notification.github_id,
+      'subject_url' => victim_subject.url
+    }])
+
+    attacker_notification.reload
+    assert_equal 'https://api.github.com/repos/attacker/repo/issues/1', attacker_notification.subject_url
+    assert_nil attacker_notification.subject
+  end
+
 end


### PR DESCRIPTION
Two related fixes for subject content access.

`User#import_notifications` did `n.attributes = new_notification.except('id', 'user_id')`, allowing the caller to set `subject_url`. Since `Notification belongs_to :subject, foreign_key: :subject_url` and Subject records are global, an attacker could link their own notification to any existing Subject including private repo issues synced by other users. The import button was already hidden on octobox.io (`unless Octobox.io?` in the settings view) but the route had no gate. Now `find_by` instead of `find_or_initialize_by`, and `slice` an allowlist of `archived starred unread muted_at last_read_at`. Import becomes "restore my flags onto already-synced notifications" rather than "create arbitrary records". GitHub-sourced metadata comes from sync, not the import file.

The thread view rendered `subject.body`, author, labels, and comments without checking `notification.display?`, the paywall check that the list view enforces at `_notification.html.erb:26`. A free-tier user on octobox.io with private-repo notifications could open `/notifications/<id>` directly and read content the list view hid. This was also the render sink for the import attack above. Now every `if notification.subject` block in the thread views also checks `display?`, with the existing `_private_repos` upgrade prompt shown when gated. Title and repo name still render since those live on the Notification record, not the global Subject.

The semantic change to import: notifications past GitHub's API window can no longer be restored from a backup file. Sync first, then import to restore state.