### PR TITLE
Use secure_compare for webhook signature verification

### DIFF
--- a/app/controllers/hooks_controller.rb
+++ b/app/controllers/hooks_controller.rb
@@ -47,7 +47,7 @@ class HooksController < ApplicationController
     return unless secret.present?
 
     expected_signature = "sha1=#{OpenSSL::HMAC.hexdigest(HMAC_DIGEST, secret, request_body)}"
-    if signature_header != expected_signature
+    unless ActiveSupport::SecurityUtils.secure_compare(signature_header.to_s, expected_signature)
       raise ActiveSupport::MessageVerifier::InvalidSignature
     end
   end

--- a/test/controllers/hooks_controller_test.rb
+++ b/test/controllers/hooks_controller_test.rb
@@ -88,6 +88,40 @@ class HooksControllerTest < ActionController::TestCase
     send_webhook 'repository'
     assert_equal Repository.count, 1
   end
+
+  test 'accepts webhook with valid signature when secret is configured' do
+    Octobox.config.stubs(:github_webhook_secret).returns('mysecret')
+    body = File.read("#{Rails.root}/test/fixtures/github_webhooks/github_app_authorization.json")
+
+    @request.headers['X-Hub-Signature'] = "sha1=#{OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha1'), 'mysecret', body)}"
+    @request.headers['X-GitHub-Event'] = 'github_app_authorization'
+    post :create, body: body
+
+    assert_response :success
+  end
+
+  test 'rejects webhook with invalid signature when secret is configured' do
+    Octobox.config.stubs(:github_webhook_secret).returns('mysecret')
+    body = File.read("#{Rails.root}/test/fixtures/github_webhooks/github_app_authorization.json")
+
+    @request.headers['X-Hub-Signature'] = "sha1=#{'0' * 40}"
+    @request.headers['X-GitHub-Event'] = 'github_app_authorization'
+
+    assert_raises ActiveSupport::MessageVerifier::InvalidSignature do
+      post :create, body: body
+    end
+  end
+
+  test 'rejects webhook with missing signature header when secret is configured' do
+    Octobox.config.stubs(:github_webhook_secret).returns('mysecret')
+    body = File.read("#{Rails.root}/test/fixtures/github_webhooks/github_app_authorization.json")
+
+    @request.headers['X-GitHub-Event'] = 'github_app_authorization'
+
+    assert_raises ActiveSupport::MessageVerifier::InvalidSignature do
+      post :create, body: body
+    end
+  end
 end
 
 def send_webhook(event_type, fixture = nil)


### PR DESCRIPTION
String `!=` short-circuits on the first differing byte. Practically unexploitable over a real network with HTTPS jitter and application noise, but `ActiveSupport::SecurityUtils.secure_compare` is the right primitive here and the swap is one line.

The `.to_s` handles a missing `X-Hub-Signature` header since `secure_compare` would raise on nil.

Added tests for valid signature, invalid signature, and missing header. None of the existing tests configured a webhook secret so this path had no coverage.