### PR TITLE
Handle 423 Locked sync polling

### DIFF
--- a/app/assets/javascripts/octobox.js
+++ b/app/assets/javascripts/octobox.js
@@ -331,8 +331,17 @@ var Octobox = (function() {
     }
 
     fetch("/notifications/syncing.json")
-    .then(response => response.json())
+    .then(response => {
+      if (response.status === 423) {
+        setTimeout(refreshOnSync, 2000);
+        return null;
+      }
+
+      return response.json();
+    })
     .then(data => {
+      if (data == null) return;
+
       if (data["error"] != null) {
         var icon = document.querySelector(".sync .octicon");
         if (icon) icon.classList.remove("spinning");


### PR DESCRIPTION
Treat the `423 Locked` response from `/notifications/syncing.json` as a pending sync state instead of a completed sync.

The previous client code always parsed the response body and then reloaded the page when no error was present.  While a background sync was still working, the server returned `423 Locked` with an empty JSON body, which made the UI reload immediately and enter a visible refresh loop.

Poll again after a short delay while the sync is still locked, and only reload the page once the endpoint returns an ordinary completion response.