### PR TITLE
Support large GitHub account IDs

### DIFF
--- a/db/migrate/20260630000000_change_github_account_ids_to_bigint.rb
+++ b/db/migrate/20260630000000_change_github_account_ids_to_bigint.rb
@@ -1,0 +1,17 @@
+class ChangeGithubAccountIdsToBigint < ActiveRecord::Migration[7.1]
+  def up
+    change_column :app_installations, :app_id, :bigint
+    change_column :app_installations, :account_id, :bigint
+    change_column :app_installations, :target_id, :bigint
+    change_column :subscription_plans, :github_id, :bigint
+    change_column :subscription_purchases, :account_id, :bigint
+  end
+
+  def down
+    change_column :app_installations, :app_id, :integer
+    change_column :app_installations, :account_id, :integer
+    change_column :app_installations, :target_id, :integer
+    change_column :subscription_plans, :github_id, :integer
+    change_column :subscription_purchases, :account_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_21_191013) do
+ActiveRecord::Schema[7.1].define(version: 2026_06_30_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
@@ -24,12 +24,12 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_21_191013) do
 
   create_table "app_installations", force: :cascade do |t|
     t.bigint "github_id"
-    t.integer "app_id"
+    t.bigint "app_id"
     t.string "account_login"
-    t.integer "account_id"
+    t.bigint "account_id"
     t.string "account_type"
     t.string "target_type"
-    t.integer "target_id"
+    t.bigint "target_id"
     t.string "permission_pull_requests"
     t.string "permission_issues"
     t.datetime "created_at", precision: nil, null: false
@@ -131,7 +131,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_21_191013) do
   end
 
   create_table "subscription_plans", force: :cascade do |t|
-    t.integer "github_id"
+    t.bigint "github_id"
     t.string "name"
     t.string "description"
     t.integer "monthly_price_in_cents"
@@ -146,7 +146,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_21_191013) do
 
   create_table "subscription_purchases", force: :cascade do |t|
     t.integer "subscription_plan_id"
-    t.integer "account_id"
+    t.bigint "account_id"
     t.string "billing_cycle"
     t.integer "unit_count"
     t.boolean "on_free_trial"

--- a/test/models/app_installation_test.rb
+++ b/test/models/app_installation_test.rb
@@ -25,4 +25,18 @@ class AppInstallationTest < ActiveSupport::TestCase
     @app_installation.account_id = nil
     refute @app_installation.valid?
   end
+
+  test 'supports large GitHub account ids' do
+    large_github_id = 2_147_483_648
+    app_installation = create(
+      :app_installation,
+      app_id: large_github_id,
+      account_id: large_github_id,
+      target_id: large_github_id
+    )
+
+    assert_equal large_github_id, app_installation.app_id
+    assert_equal large_github_id, app_installation.account_id
+    assert_equal large_github_id, app_installation.target_id
+  end
 end


### PR DESCRIPTION
There are existing accounts with bigint IDs, and Octobox cannot handle notifications containing them.