### PR TITLE
Fix false Sync failed alert

### DIFF
--- a/app/assets/javascripts/octobox.js
+++ b/app/assets/javascripts/octobox.js
@@ -351,8 +351,13 @@ var Octobox = (function() {
 
     if(asyncSyncLink) {
       fetch("/notifications/sync.json")
-        .then(response => response.json())
-        .then(data => refreshOnSync(data))
+        .then(response => {
+          if (!response.ok) {
+            throw new Error("Request failed");
+          }
+
+          refreshOnSync();
+        })
         .catch(error => {
           console.error('Sync failed:', error);
           notify("Sync failed", "danger");


### PR DESCRIPTION
The sync endpoint starts a notification sync but does not return a JSON payload.  Treat an empty successful response as success, then poll syncing.json for the actual sync result.