### PR TITLE
Run CI on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push]
+on: [push, pull_request]
 
 permissions: {}
 


### PR DESCRIPTION
The test workflow only triggered on `push` events, so PRs from forks never ran the test suite (only CodeQL, Docker build, and zizmor ran, since those workflows already include `pull_request`). Noticed while reviewing #4569/#4570/#4572.

Same-repo PRs will now run CI twice (once for the branch push, once for the PR event), which is the trade-off for keeping CI on every branch push.