### PR TITLE
Check response.ok on remaining fetch calls

### DIFF
--- a/app/assets/javascripts/octobox.js
+++ b/app/assets/javascripts/octobox.js
@@ -75,7 +75,9 @@ var Octobox = (function() {
         return response.json();
       })
       .then(data => setFavicon(data.count))
-      .catch(() => {});
+      .catch(() => {
+        // favicon is cosmetic; keep the current count/title on error
+      });
   };
 
   var setFavicon = function(count) {

--- a/app/assets/javascripts/octobox.js
+++ b/app/assets/javascripts/octobox.js
@@ -40,7 +40,10 @@ var Octobox = (function() {
 
   var updatePinnedSearchCounts = function(pinned_search) {
     fetch(pinned_search.dataset.url)
-      .then(response => response.json())
+      .then(response => {
+        if (!response.ok) throw new Error('Request failed');
+        return response.json();
+      })
       .then(data => {
         pinned_search.innerHTML = data.count;
       })
@@ -67,8 +70,12 @@ var Octobox = (function() {
 
   var updateFavicon = function () {
     fetch("/notifications/unread_count")
-      .then(response => response.json())
-      .then(data => setFavicon(data.count));
+      .then(response => {
+        if (!response.ok) throw new Error('Request failed');
+        return response.json();
+      })
+      .then(data => setFavicon(data.count))
+      .catch(() => {});
   };
 
   var setFavicon = function(count) {
@@ -528,6 +535,9 @@ var Octobox = (function() {
         'X-Requested-With': 'XMLHttpRequest',
         'X-CSRF-Token': getCsrfToken()
       }
+    })
+    .then(response => {
+      if (!response.ok) throw new Error('Request failed');
     })
     .catch(() => {
       // Revert to original state on failure


### PR DESCRIPTION
Follow-up to #4569 and #4572. Audited the remaining `fetch()` calls in `octobox.js` for places that still relied on jQuery's reject-on-HTTP-error behaviour after 81344b1e.

Three spots:

- `star` — the optimistic icon toggle was only reverted in `.catch()`, so a 4xx/5xx from the server left the star showing the wrong state. The original `$.post().fail()` reverted on any HTTP error.
- `updatePinnedSearchCounts` — a JSON error response would set the badge text to `undefined` instead of removing it like the original `.fail()` did.
- `updateFavicon` — passed `undefined` to `setFavicon` on an error response and had no catch, so a non-JSON body surfaced as an unhandled rejection.

The `postRequest` callers (mute/archive/markRead/delete) already check `response.ok` and throw, so they were fine. The thread/comment loaders inject whatever HTML comes back on error, which isn't ideal but isn't a regression from the jQuery version, so left alone.