### PR TITLE
Make GITHUB_WEBHOOK_SECRET requirement clearer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,13 @@ GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=
 BUGSNAG_API_KEY=
 BUGSNAG_JS_API_KEY=
+
+# Only needed when running as a GitHub App (see docs/INSTALLATION.md).
+# GITHUB_WEBHOOK_SECRET is required for any publicly reachable deployment;
+# without it, /hooks/github accepts unsigned requests.
+GITHUB_APP_ID=
+GITHUB_APP_SLUG=
+GITHUB_APP_CLIENT_ID=
+GITHUB_APP_CLIENT_SECRET=
+GITHUB_APP_JWT=
+GITHUB_WEBHOOK_SECRET=

--- a/config/initializers/webhook_secret_check.rb
+++ b/config/initializers/webhook_secret_check.rb
@@ -1,0 +1,5 @@
+Rails.application.config.after_initialize do
+  if Octobox.github_app? && Octobox.config.github_webhook_secret.blank? && !Rails.env.test?
+    Rails.logger.warn "[octobox] GITHUB_WEBHOOK_SECRET is not set. The /hooks/github endpoint will accept unsigned requests. Set a webhook secret on your GitHub App and in this environment before exposing this instance publicly. See docs/INSTALLATION.md."
+  end
+end

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -412,8 +412,8 @@ Then add the following ENV variables to `.env` (or `heroku config:add` if you're
 - `GITHUB_APP_CLIENT_ID` - From the GitHub App "OAuth credentials" section labelled `Client ID`
 - `GITHUB_APP_CLIENT_SECRET` - From the GitHub App "OAuth credentials" section labelled `Client secret`
 - `GITHUB_APP_ID` - From the GitHub App "About" section labelled `ID`
-- `GITHUB_APP_SLUG`-  - From the GitHub App "About" section labelled `Public link`, the last section of the url, i.e https://github.com/apps/my-octobox -> `my-octobox`
-- `GITHUB_APP_JWT`- - In the GitHub App "Private keys" section, generate a private key, which will cause a `.pem` file to be downloaded to your computer. This environment variable must contain the contents of the `.pem` file with newlines preserved.
+- `GITHUB_APP_SLUG` - From the GitHub App "About" section labelled `Public link`, the last section of the url, i.e https://github.com/apps/my-octobox -> `my-octobox`
+- `GITHUB_APP_JWT` - In the GitHub App "Private keys" section, generate a private key, which will cause a `.pem` file to be downloaded to your computer. This environment variable must contain the contents of the `.pem` file with newlines preserved.
 - `GITHUB_WEBHOOK_SECRET` - The webhook secret you generated above. Required for production deployments; Octobox will log a warning at boot if GitHub App mode is enabled without it.
 
 Then start the rails app and visit <https://github.com/apps/my-octobox/installations/new> to install it on the orgs/repos you wish, it should log you into Octobox on completion of the install.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -397,7 +397,7 @@ Then create a new GitHub App, <https://github.com/settings/apps/new>, with the f
 - Setup URL: The domain plus `/auth/githubapp`, i.e. http://myoctoboxdomain.com/auth/githubapp
 - Redirect on update: ✔
 - Webhook URL: The domain plus `/hooks/github`, i.e. http://myoctoboxdomain.com/hooks/github
-- Webhook secret: generate a password and paste it in here and save for later
+- Webhook secret: generate a strong random secret, paste it here, and save it for the `GITHUB_WEBHOOK_SECRET` env var below. This is required for any deployment reachable from the public internet; without it, anyone can post forged events to `/hooks/github`.
 - Permissions:
   - Organization members: Read-only (only needed if your organization has private members)
   - Repository metadata: Read-only
@@ -414,7 +414,7 @@ Then add the following ENV variables to `.env` (or `heroku config:add` if you're
 - `GITHUB_APP_ID` - From the GitHub App "About" section labelled `ID`
 - `GITHUB_APP_SLUG`-  - From the GitHub App "About" section labelled `Public link`, the last section of the url, i.e https://github.com/apps/my-octobox -> `my-octobox`
 - `GITHUB_APP_JWT`- - In the GitHub App "Private keys" section, generate a private key, which will cause a `.pem` file to be downloaded to your computer. This environment variable must contain the contents of the `.pem` file with newlines preserved.
-- `GITHUB_WEBHOOK_SECRET` - The Webhook secret if you generated one earlier
+- `GITHUB_WEBHOOK_SECRET` - The webhook secret you generated above. Required for production deployments; Octobox will log a warning at boot if GitHub App mode is enabled without it.
 
 Then start the rails app and visit <https://github.com/apps/my-octobox/installations/new> to install it on the orgs/repos you wish, it should log you into Octobox on completion of the install.
 


### PR DESCRIPTION
The GitHub App setup docs described the webhook secret as optional ("if you generated one earlier"), and `.env.example` didn't list any of the GitHub App env vars. Without a secret set, `/hooks/github` accepts unsigned requests, so a publicly reachable instance running in App mode could receive forged events.

This tightens the wording in `INSTALLATION.md`, adds the GitHub App vars to `.env.example` with a note about the secret, and logs a warning at boot when GitHub App mode is enabled without `GITHUB_WEBHOOK_SECRET` configured. The endpoint behaviour is unchanged so existing self-hosters running behind a private network aren't broken.