### PR TITLE
Move label scope dedup into a subquery

### DIFF
--- a/lib/octobox/notifications/inclusive_scope.rb
+++ b/lib/octobox/notifications/inclusive_scope.rb
@@ -67,10 +67,13 @@ module Octobox
         scope :label, ->(label_names) {
           label_names = [label_names] if label_names.is_a?(String)
 
-          # Multiple labels can be matched with one notification so we need to use a distinct query.
-          joins(:labels).where(
-            label_names.map { |label_name| Label.arel_table[:name].matches(label_name) }.reduce(:or)
-          ).distinct
+          # Multiple labels can match one notification. Joining labels on the outer
+          # relation and applying .distinct forces every caller's ORDER BY/SELECT to
+          # include the order columns (PG rejects SELECT DISTINCT ... ORDER BY <col>
+          # when <col> isn't selected). Push the join into an IN subquery instead so
+          # callers can pluck and order freely.
+          condition = label_names.map { |label_name| Label.arel_table[:name].matches(label_name) }.reduce(:or)
+          where(id: reorder(nil).joins(:labels).where(condition).select(:id))
         }
 
         scope :assigned, ->(assignees) {

--- a/test/controllers/notifications_controller_test.rb
+++ b/test/controllers/notifications_controller_test.rb
@@ -1179,4 +1179,24 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
     refute_includes response.body, 'secretauthor'
     refute_includes response.body, 'secretlabel'
   end
+
+  test 'show with a label filter does not raise on pluck' do
+    sign_in_as(@user)
+    notification = create(:notification, user: @user)
+    subject = create(:subject, url: notification.subject_url)
+    create(:label, subject: subject, name: 'bug')
+
+    get notification_path(notification, q: 'label:bug')
+    assert_response :success
+  end
+
+  test 'show with a label filter and subject sort does not raise on pluck' do
+    sign_in_as(@user)
+    notification = create(:notification, user: @user)
+    subject = create(:subject, url: notification.subject_url)
+    create(:label, subject: subject, name: 'bug')
+
+    get notification_path(notification, q: 'label:bug sort:subject')
+    assert_response :success
+  end
 end


### PR DESCRIPTION
Supersedes #4511.

The `label` scope joined labels on the outer relation and applied `.distinct` to dedup notifications that match multiple labels. That constrains every caller: PG rejects `SELECT DISTINCT ... ORDER BY <col>` when `<col>` isn't in the select list, so `notifications#show` and `#expand_comments` raised `PG::InvalidColumnReference` on `pluck(:id)` when filtered by label. Combining `label:` with `sort:subject` failed the same way, which is why patching the two `pluck` call sites (the approach in #4511) wasn't a complete fix.

This pushes the labels join into an `IN` subquery on `notifications.id` so the outer relation has no `.distinct` and callers can pluck and order whatever they like. The subquery is built from the current relation via `reorder(nil)` so it keeps the `user_id` filter rather than scanning the whole table.

Added two controller tests (`q=label:bug` and `q=label:bug sort:subject` against `show`) — both reproduced the PG error before the change. The existing multi-label dedup test still passes.

Thanks @wedamija for tracking down the original error.