### PR TITLE
Fall back to root_path for off-host omniauth origins

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -15,7 +15,7 @@ class SessionsController < ApplicationController
     cookies.permanent.signed[:user_id] = {value: user.id, httponly: true}
 
     user.sync_notifications unless initial_sync?
-    redirect_to request.env['omniauth.origin'] || root_path
+    redirect_to url_from(request.env['omniauth.origin']) || root_path
   end
 
   def destroy

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -42,6 +42,36 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to root_path
   end
 
+  test 'POST #create redirects to a relative omniauth origin' do
+    OmniAuth.config.mock_auth[:github].uid = @user.github_id
+    OmniAuth.config.before_callback_phase { |env| env['omniauth.origin'] = '/settings' }
+
+    post '/auth/github/callback'
+    assert_redirected_to '/settings'
+  ensure
+    OmniAuth.config.before_callback_phase = nil
+  end
+
+  test 'POST #create ignores an absolute omniauth origin' do
+    OmniAuth.config.mock_auth[:github].uid = @user.github_id
+    OmniAuth.config.before_callback_phase { |env| env['omniauth.origin'] = 'https://evil.com' }
+
+    post '/auth/github/callback'
+    assert_redirected_to root_path
+  ensure
+    OmniAuth.config.before_callback_phase = nil
+  end
+
+  test 'POST #create ignores a protocol-relative omniauth origin' do
+    OmniAuth.config.mock_auth[:github].uid = @user.github_id
+    OmniAuth.config.before_callback_phase { |env| env['omniauth.origin'] = '//evil.com' }
+
+    post '/auth/github/callback'
+    assert_redirected_to root_path
+  ensure
+    OmniAuth.config.before_callback_phase = nil
+  end
+
   test 'POST #create forces the user to sync their notifications if they have synced before' do
     OmniAuth.config.mock_auth[:github].uid = @user.github_id
 


### PR DESCRIPTION
`redirect_to request.env['omniauth.origin']` is the textbook open-redirect pattern that scanners flag. It wasn't actually exploitable here because `config.load_defaults '7.1'` enables `raise_on_open_redirects`, so an off-host origin produced a 500 rather than a redirect.

Wrapping in `url_from` (returns nil for off-host URLs) makes it fall back to `root_path` instead of raising, and removes the pattern from scans. Relative paths and same-host absolute URLs still work.