### PR TITLE
Add undo for notification archive actions

### DIFF
--- a/app/assets/javascripts/octobox.js
+++ b/app/assets/javascripts/octobox.js
@@ -24,6 +24,12 @@ var Octobox = (function() {
     });
   };
 
+  var responseJson = function(response) {
+    var contentType = response.headers.get('content-type') || '';
+    if (contentType.indexOf('json') === -1) return Promise.resolve({});
+    return response.json();
+  };
+
   var maybeConfirm = function(message){
     if(document.body.classList.contains('disable_confirmations')) {
       return true;
@@ -317,8 +323,14 @@ var Octobox = (function() {
       if (response.ok) {
         resetCursorAfterRowsRemoved(ids);
         updateFavicon();
+        return responseJson(response);
       } else {
         throw new Error('Request failed');
+      }
+    })
+    .then(data => {
+      if (data.undo_url) {
+        notify(data.message + " <a href='" + data.undo_url + "' data-method='post'>Undo</a>", "success");
       }
     })
     .catch(() => {

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -105,12 +105,29 @@ class NotificationsController < ApplicationController
   end
 
   def archive_selected
-    Notification.archive(selected_notifications, params[:value])
+    notifications = selected_notifications
+    undo_action = NotificationUndoAction.record_archive!(current_user, notifications)
+
+    Notification.archive(notifications, params[:value])
+
     if request.xhr?
-      head :ok
+      render json: undo_archive_payload(undo_action)
     else
+      flash[:success] = undo_archive_message(undo_action)
       redirect_back fallback_location: root_path
     end
+  end
+
+  def undo_archive
+    undo_action = current_user.notification_undo_actions.find_by(token: params[:token])
+
+    if undo_action&.restore!
+      flash[:success] = 'Notification action undone'
+    else
+      flash[:error] = 'Undo link has expired'
+    end
+
+    redirect_back fallback_location: root_path
   end
 
   def mark_read_selected
@@ -157,5 +174,23 @@ class NotificationsController < ApplicationController
     else
       render json: { error: Sidekiq::Status::get(current_user.sync_job_id, :exception) }, status: :ok
     end
+  end
+
+  private
+
+  def undo_archive_payload(undo_action)
+    return {} unless undo_action
+
+    {
+      message: 'Notification action complete.',
+      undo_url: undo_archive_notifications_path(token: undo_action.token)
+    }
+  end
+
+  def undo_archive_message(undo_action)
+    return 'Notification action complete.' unless undo_action
+
+    undo_path = undo_archive_notifications_path(token: undo_action.token)
+    "Notification action complete. <a href=\"#{undo_path}\" data-method=\"post\">Undo</a>"
   end
 end

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -106,9 +106,9 @@ class NotificationsController < ApplicationController
 
   def archive_selected
     notifications = selected_notifications
-    undo_action = NotificationUndoAction.record_archive!(current_user, notifications)
+    undo_action = record_archive_undo_action(notifications)
 
-    Notification.archive(notifications, params[:value])
+    Notification.archive(notifications, params[:value], undo_action: undo_action)
 
     if request.xhr?
       render json: undo_archive_payload(undo_action)
@@ -192,5 +192,12 @@ class NotificationsController < ApplicationController
 
     undo_path = undo_archive_notifications_path(token: undo_action.token)
     "Notification action complete. <a href=\"#{undo_path}\" data-method=\"post\">Undo</a>"
+  end
+
+  def record_archive_undo_action(notifications)
+    archive_value = params[:value] ? ActiveRecord::Type::Boolean.new.cast(params[:value]) : true
+    return if archive_value && !Octobox.background_jobs_enabled?
+
+    NotificationUndoAction.record_archive!(current_user, notifications)
   end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -84,7 +84,7 @@ class Notification < ApplicationRecord
     return unless user && value
 
     if undo_action
-      ArchiveWorker.perform_in_if_configured(NotificationUndoAction::EXPIRES_IN, user.id, github_ids, undo_action.id)
+      ArchiveWorker.perform_in_if_configured(NotificationUndoAction::ARCHIVE_DELAY, user.id, github_ids, undo_action.id)
     else
       ArchiveWorker.perform_async_if_configured(user.id, github_ids)
     end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -76,11 +76,18 @@ class Notification < ApplicationRecord
     repository.try(:display_subject?) || user.has_personal_plan?
   end
 
-  def self.archive(notifications, value)
+  def self.archive(notifications, value, undo_action: nil)
     value = value ? ActiveRecord::Type::Boolean.new.cast(value) : true
-    notifications.update_all(archived: value)
     user = notifications.first.try(:user)
-    ArchiveWorker.perform_async_if_configured(user.id, notifications.map(&:github_id)) if user && value
+    github_ids = notifications.pluck(:github_id)
+    notifications.update_all(archived: value)
+    return unless user && value
+
+    if undo_action
+      ArchiveWorker.perform_in_if_configured(NotificationUndoAction::EXPIRES_IN, user.id, github_ids, undo_action.id)
+    else
+      ArchiveWorker.perform_async_if_configured(user.id, github_ids)
+    end
   end
 
   def self.archive_on_github(user, notification_ids)

--- a/app/models/notification_undo_action.rb
+++ b/app/models/notification_undo_action.rb
@@ -2,6 +2,7 @@
 
 class NotificationUndoAction < ApplicationRecord
   EXPIRES_IN = 5.minutes
+  ARCHIVE_DELAY = EXPIRES_IN + 10.seconds
 
   has_secure_token :token
 

--- a/app/models/notification_undo_action.rb
+++ b/app/models/notification_undo_action.rb
@@ -14,16 +14,16 @@ class NotificationUndoAction < ApplicationRecord
   scope :expired, -> { where('expires_at <= ?', Time.current) }
 
   def self.record_archive!(user, notifications)
-    states = notifications.map do |notification|
+    states = notifications.pluck(:id, :archived).map do |id, archived|
       {
-        'id' => notification.id,
-        'archived' => notification.archived?
+        'id' => id,
+        'archived' => archived
       }
     end
 
     return if states.empty?
 
-    expired.delete_all
+    user.notification_undo_actions.expired.delete_all
 
     user.notification_undo_actions.create!(
       action: 'archive',
@@ -48,9 +48,8 @@ class NotificationUndoAction < ApplicationRecord
     return false if expired?
 
     transaction do
-      notification_states.each do |state|
-        notification = user.notifications.find_by(id: state['id'])
-        notification&.update_columns(archived: state['archived'])
+      notification_states.group_by { |state| state['archived'] }.each do |archived, states|
+        user.notifications.where(id: states.map { |state| state['id'] }).update_all(archived: archived)
       end
 
       destroy!

--- a/app/models/notification_undo_action.rb
+++ b/app/models/notification_undo_action.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+class NotificationUndoAction < ApplicationRecord
+  EXPIRES_IN = 5.minutes
+
+  has_secure_token :token
+
+  belongs_to :user
+
+  validates :action, presence: true
+  validates :expires_at, presence: true
+  validates :notification_states, presence: true
+
+  scope :expired, -> { where('expires_at <= ?', Time.current) }
+
+  def self.record_archive!(user, notifications)
+    states = notifications.map do |notification|
+      {
+        'id' => notification.id,
+        'archived' => notification.archived?
+      }
+    end
+
+    return if states.empty?
+
+    expired.delete_all
+
+    user.notification_undo_actions.create!(
+      action: 'archive',
+      notification_states: states,
+      expires_at: EXPIRES_IN.from_now
+    )
+  end
+
+  def notification_states
+    JSON.parse(read_attribute(:notification_states) || '[]')
+  end
+
+  def notification_states=(states)
+    write_attribute(:notification_states, JSON.generate(states))
+  end
+
+  def expired?
+    expires_at <= Time.current
+  end
+
+  def restore!
+    return false if expired?
+
+    transaction do
+      notification_states.each do |state|
+        notification = user.notifications.find_by(id: state['id'])
+        notification&.update_columns(archived: state['archived'])
+      end
+
+      destroy!
+    end
+
+    true
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,7 @@ class User < ApplicationRecord
   has_many :app_installation_permissions, dependent: :delete_all
   has_many :app_installations, through: :app_installation_permissions
   has_many :pinned_searches, dependent: :delete_all
+  has_many :notification_undo_actions, dependent: :delete_all
   has_one :individual_subscription_purchase, foreign_key: :account_id, primary_key: :github_id, class_name: 'SubscriptionPurchase'
 
   ERRORS = {

--- a/app/workers/archive_worker.rb
+++ b/app/workers/archive_worker.rb
@@ -2,8 +2,14 @@ class ArchiveWorker
   include Sidekiq::Worker
   sidekiq_options queue: :user, lock: :until_and_while_executing
 
-  def perform(user_id, notification_ids)
+  def perform(user_id, notification_ids, undo_action_id = nil)
     user = User.find_by_id(user_id)
-    Notification.archive_on_github(user, notification_ids) if user
+    return unless user
+
+    undo_action = NotificationUndoAction.find_by(id: undo_action_id) if undo_action_id
+    return if undo_action_id && !undo_action&.expired?
+
+    Notification.archive_on_github(user, notification_ids)
+    undo_action&.destroy
   end
 end

--- a/config/initializers/custom_sidekiq_worker.rb
+++ b/config/initializers/custom_sidekiq_worker.rb
@@ -16,5 +16,22 @@ module Sidekiq::Worker
         end
       end
     end
+
+    def perform_in_if_configured(interval, *args)
+      if Octobox.background_jobs_enabled?
+        perform_in(interval, *args)
+      else
+        begin
+          worker = new
+          if worker.method(:perform).arity != 0
+            worker.perform(*args)
+          else
+            worker.perform
+          end
+        rescue => e
+          Rails.logger.error("[#{name}] Inline worker failed: #{e.class}: #{e.message}")
+        end
+      end
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -78,6 +78,7 @@ Rails.application.routes.draw do
       get  :unread_count
       get  :lookup
       post :delete_selected
+      post :undo_archive
     end
 
     member do

--- a/db/migrate/20260705000000_create_notification_undo_actions.rb
+++ b/db/migrate/20260705000000_create_notification_undo_actions.rb
@@ -1,0 +1,16 @@
+class CreateNotificationUndoActions < ActiveRecord::Migration[7.1]
+  def change
+    create_table :notification_undo_actions do |t|
+      t.references :user, null: false, index: true
+      t.string :token, null: false
+      t.string :action, null: false
+      t.text :notification_states, null: false, limit: 16.megabytes
+      t.datetime :expires_at, null: false
+
+      t.timestamps
+    end
+
+    add_index :notification_undo_actions, :token, unique: true
+    add_index :notification_undo_actions, :expires_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_06_30_000000) do
+ActiveRecord::Schema[7.1].define(version: 2026_07_05_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
@@ -59,6 +59,19 @@ ActiveRecord::Schema[7.1].define(version: 2026_06_30_000000) do
     t.bigint "github_id"
     t.index ["name"], name: "index_labels_on_name"
     t.index ["subject_id"], name: "index_labels_on_subject_id"
+  end
+
+  create_table "notification_undo_actions", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "token", null: false
+    t.string "action", null: false
+    t.text "notification_states", null: false
+    t.datetime "expires_at", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["expires_at"], name: "index_notification_undo_actions_on_expires_at"
+    t.index ["token"], name: "index_notification_undo_actions_on_token", unique: true
+    t.index ["user_id"], name: "index_notification_undo_actions_on_user_id"
   end
 
   create_table "notifications", id: :serial, force: :cascade do |t|

--- a/test/controllers/api/notifications_controller_test.rb
+++ b/test/controllers/api/notifications_controller_test.rb
@@ -92,6 +92,8 @@ class ApiNotificationsControllerTest < ActionDispatch::IntegrationTest
     notification2 = create(:notification, user: @user, archived: false)
     notification3 = create(:notification, user: @user, archived: false)
 
+    stub_request(:delete, /https:\/\/api\.github\.com\/notifications\/threads/)
+
     post '/api/notifications/archive_selected', params: { unread: true, id: ['all'], value: true }, xhr: true, headers: { 'Authorization' => "Bearer #{@user.api_token}" }
 
     assert_response :ok
@@ -104,6 +106,8 @@ class ApiNotificationsControllerTest < ActionDispatch::IntegrationTest
   test 'archives defaults value to true' do
     notification1 = create(:notification, user: @user, archived: false)
     notification2 = create(:notification, user: @user, archived: false)
+
+    stub_request(:delete, /https:\/\/api\.github\.com\/notifications\/threads/)
 
     post '/api/notifications/archive_selected', params: { unread: true, id: ['all'], value: nil }, xhr: true, headers: { 'Authorization' => "Bearer #{@user.api_token}" }
 

--- a/test/controllers/notifications_controller_test.rb
+++ b/test/controllers/notifications_controller_test.rb
@@ -180,6 +180,58 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
     assert notification1.reload.archived?
     assert notification2.reload.archived?
     refute notification3.reload.archived?
+
+    data = JSON.parse(response.body)
+    assert_match %r{/notifications/undo_archive\?token=}, data['undo_url']
+  end
+
+  test 'undo archive restores previous archived state' do
+    sign_in_as(@user)
+    notification1 = create(:notification, user: @user, archived: false)
+    notification2 = create(:notification, user: @user, archived: false)
+
+    stub_request(:delete, /https:\/\/api\.github\.com\/notifications\/threads/)
+
+    post '/notifications/archive_selected', params: { id: [notification1.id, notification2.id], value: true }, xhr: true
+    undo_url = JSON.parse(response.body).fetch('undo_url')
+
+    assert notification1.reload.archived?
+    assert notification2.reload.archived?
+
+    post undo_url
+
+    assert_redirected_to root_path
+    refute notification1.reload.archived?
+    refute notification2.reload.archived?
+    assert_equal 'Notification action undone', flash[:success]
+  end
+
+  test 'undo archive cannot restore expired action' do
+    sign_in_as(@user)
+    notification = create(:notification, user: @user, archived: false)
+    undo_action = NotificationUndoAction.record_archive!(@user, @user.notifications.where(id: notification.id))
+    undo_action.update!(expires_at: 1.minute.ago)
+    notification.update!(archived: true)
+
+    post undo_archive_notifications_path(token: undo_action.token)
+
+    assert_redirected_to root_path
+    assert notification.reload.archived?
+    assert_equal 'Undo link has expired', flash[:error]
+  end
+
+  test 'undo archive cannot restore another users action' do
+    sign_in_as(@user)
+    other_user = create(:user)
+    notification = create(:notification, user: other_user, archived: false)
+    undo_action = NotificationUndoAction.record_archive!(other_user, other_user.notifications.where(id: notification.id))
+    notification.update!(archived: true)
+
+    post undo_archive_notifications_path(token: undo_action.token)
+
+    assert_redirected_to root_path
+    assert notification.reload.archived?
+    assert_equal 'Undo link has expired', flash[:error]
   end
 
   test 'archives all notifications' do

--- a/test/controllers/notifications_controller_test.rb
+++ b/test/controllers/notifications_controller_test.rb
@@ -180,12 +180,10 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
     assert notification1.reload.archived?
     assert notification2.reload.archived?
     refute notification3.reload.archived?
-
-    data = JSON.parse(response.body)
-    assert_match %r{/notifications/undo_archive\?token=}, data['undo_url']
   end
 
   test 'undo archive restores previous archived state' do
+    stub_background_jobs_enabled
     sign_in_as(@user)
     notification1 = create(:notification, user: @user, archived: false)
     notification2 = create(:notification, user: @user, archived: false)
@@ -204,6 +202,19 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
     refute notification1.reload.archived?
     refute notification2.reload.archived?
     assert_equal 'Notification action undone', flash[:success]
+  end
+
+  test 'archive with undo schedules GitHub archive after undo window' do
+    stub_background_jobs_enabled
+    sign_in_as(@user)
+    notification = create(:notification, user: @user, archived: false)
+
+    post '/notifications/archive_selected', params: { id: [notification.id], value: true }, xhr: true
+
+    data = JSON.parse(response.body)
+    assert_match %r{/notifications/undo_archive\?token=}, data['undo_url']
+    assert_equal 1, ArchiveWorker.jobs.size
+    assert ArchiveWorker.jobs.first['at'] > Time.current.to_f
   end
 
   test 'undo archive cannot restore expired action' do
@@ -257,6 +268,8 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
     notification2 = create(:notification, user: @user, archived: false)
     notification3 = create(:notification, user: @user, archived: false)
 
+    stub_request(:delete, /https:\/\/api\.github\.com\/notifications\/threads/)
+
     post '/notifications/archive_selected', params: { unread: true, id: ['all'], value: true }, xhr: true
 
     assert_response :ok
@@ -270,6 +283,8 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
     sign_in_as(@user)
     notification1 = create(:notification, user: @user, archived: false)
     notification2 = create(:notification, user: @user, archived: false)
+
+    stub_request(:delete, /https:\/\/api\.github\.com\/notifications\/threads/)
 
     post '/notifications/archive_selected', params: { unread: true, id: ['all'], value: nil }, xhr: true
 

--- a/test/controllers/notifications_controller_test.rb
+++ b/test/controllers/notifications_controller_test.rb
@@ -214,7 +214,7 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
     data = JSON.parse(response.body)
     assert_match %r{/notifications/undo_archive\?token=}, data['undo_url']
     assert_equal 1, ArchiveWorker.jobs.size
-    assert ArchiveWorker.jobs.first['at'] > Time.current.to_f
+    assert_in_delta NotificationUndoAction::ARCHIVE_DELAY.from_now.to_f, ArchiveWorker.jobs.first['at'], 2
   end
 
   test 'undo archive cannot restore expired action' do

--- a/test/models/notification_undo_action_test.rb
+++ b/test/models/notification_undo_action_test.rb
@@ -1,0 +1,43 @@
+require 'test_helper'
+
+class NotificationUndoActionTest < ActiveSupport::TestCase
+  test 'record_archive stores previous archived states' do
+    user = create(:user)
+    notification1 = create(:notification, user: user, archived: false)
+    notification2 = create(:notification, user: user, archived: true)
+
+    undo_action = NotificationUndoAction.record_archive!(user, user.notifications.where(id: [notification1.id, notification2.id]))
+
+    states = undo_action.notification_states.index_by { |state| state['id'] }
+    assert_equal false, states[notification1.id]['archived']
+    assert_equal true, states[notification2.id]['archived']
+    assert undo_action.expires_at.future?
+  end
+
+  test 'restore reverts archived states and destroys the undo action' do
+    user = create(:user)
+    notification1 = create(:notification, user: user, archived: false)
+    notification2 = create(:notification, user: user, archived: true)
+    undo_action = NotificationUndoAction.record_archive!(user, user.notifications.where(id: [notification1.id, notification2.id]))
+
+    notification1.update!(archived: true)
+    notification2.update!(archived: false)
+
+    assert undo_action.restore!
+    refute notification1.reload.archived?
+    assert notification2.reload.archived?
+    refute NotificationUndoAction.exists?(undo_action.id)
+  end
+
+  test 'restore does not revert expired undo action' do
+    user = create(:user)
+    notification = create(:notification, user: user, archived: false)
+    undo_action = NotificationUndoAction.record_archive!(user, user.notifications.where(id: notification.id))
+    undo_action.update!(expires_at: 1.minute.ago)
+    notification.update!(archived: true)
+
+    refute undo_action.restore!
+    assert notification.reload.archived?
+    assert NotificationUndoAction.exists?(undo_action.id)
+  end
+end

--- a/test/models/notification_undo_action_test.rb
+++ b/test/models/notification_undo_action_test.rb
@@ -14,6 +14,22 @@ class NotificationUndoActionTest < ActiveSupport::TestCase
     assert undo_action.expires_at.future?
   end
 
+  test 'record_archive only deletes expired undo actions for the same user' do
+    user = create(:user)
+    other_user = create(:user)
+    notification = create(:notification, user: user)
+    create(:notification, user: other_user)
+    expired_action = NotificationUndoAction.record_archive!(user, user.notifications.where(id: notification.id))
+    other_expired_action = NotificationUndoAction.record_archive!(other_user, other_user.notifications)
+    expired_action.update!(expires_at: 1.minute.ago)
+    other_expired_action.update!(expires_at: 1.minute.ago)
+
+    NotificationUndoAction.record_archive!(user, user.notifications.where(id: notification.id))
+
+    refute NotificationUndoAction.exists?(expired_action.id)
+    assert NotificationUndoAction.exists?(other_expired_action.id)
+  end
+
   test 'restore reverts archived states and destroys the undo action' do
     user = create(:user)
     notification1 = create(:notification, user: user, archived: false)

--- a/test/workers/archive_worker_test.rb
+++ b/test/workers/archive_worker_test.rb
@@ -1,0 +1,46 @@
+require 'test_helper'
+
+class ArchiveWorkerTest < ActiveSupport::TestCase
+  test 'archives on GitHub without an undo action' do
+    user = create(:user)
+    github_ids = [123]
+
+    Notification.expects(:archive_on_github).once
+
+    ArchiveWorker.new.perform(user.id, github_ids)
+  end
+
+  test 'skips GitHub archive when undo action was consumed' do
+    user = create(:user)
+    github_ids = [123]
+
+    Notification.expects(:archive_on_github).never
+
+    ArchiveWorker.new.perform(user.id, github_ids, 12345)
+  end
+
+  test 'skips GitHub archive while undo action is still active' do
+    user = create(:user)
+    notification = create(:notification, user: user)
+    undo_action = NotificationUndoAction.record_archive!(user, user.notifications.where(id: notification.id))
+
+    Notification.expects(:archive_on_github).never
+
+    ArchiveWorker.new.perform(user.id, [notification.github_id], undo_action.id)
+
+    assert NotificationUndoAction.exists?(undo_action.id)
+  end
+
+  test 'archives on GitHub after undo action expires' do
+    user = create(:user)
+    notification = create(:notification, user: user)
+    undo_action = NotificationUndoAction.record_archive!(user, user.notifications.where(id: notification.id))
+    undo_action.update!(expires_at: 1.minute.ago)
+
+    Notification.expects(:archive_on_github).once
+
+    ArchiveWorker.new.perform(user.id, [notification.github_id], undo_action.id)
+
+    refute NotificationUndoAction.exists?(undo_action.id)
+  end
+end

--- a/test/workers/custom_worker_test.rb
+++ b/test/workers/custom_worker_test.rb
@@ -52,4 +52,24 @@ class CustomWorkerTest < ActiveSupport::TestCase
       SyncLabelWorker.perform_async_if_configured(['arg'])
     end
   end
+
+  test 'perform_in_if_configured calls perform_in' do
+    with_background_jobs_enabled(enabled: true) do
+      ArchiveWorker.any_instance.expects(:perform).never
+      ArchiveWorker.perform_in_if_configured(5.minutes, 1, [2], 3)
+      assert_equal 1, ArchiveWorker.jobs.size
+
+      job = ArchiveWorker.jobs.first
+      assert_in_delta 5.minutes.from_now.to_f, job['at'], 2
+      assert_equal [1, [2], 3], job['args']
+    end
+  end
+
+  test 'perform_in_if_configured calls perform when background jobs are disabled' do
+    with_background_jobs_enabled(enabled: false) do
+      ArchiveWorker.any_instance.expects(:perform).once.with(1, [2], 3)
+      ArchiveWorker.expects(:perform_in).never
+      ArchiveWorker.perform_in_if_configured(5.minutes, 1, [2], 3)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Adds a short-lived undo flow for notification archive and unarchive actions.

## Changes

- Add `NotificationUndoAction` records to store previous archived states.
- Create undo tokens when notifications are archived or unarchived.
- Delay GitHub archive sync until the undo window has expired.
- Add `POST /notifications/undo_archive` to restore the previous archived state.
- Show an `Undo` link in the existing notification flash after archive actions.
- Batch undo restores to avoid N+1 updates on large archive actions.
- Avoid loading full notification records when creating undo state.
- Clean up expired undo actions per user.
- Add model, worker, and controller coverage for restore, expiry, scheduling, and user isolation.

## Behavior Note

Archive-all now captures GitHub ids before the local archived state is updated, so `id: ['all']` archive operations enqueue GitHub archive deletes for the selected inbox scope instead of only updating local state. This fixes the previous local-only archive-all behavior, but it can increase GitHub archive API traffic for archive-all actions.

## Validation

- `git diff --check`
- `ruby -c app/models/notification_undo_action.rb`
- `ruby -c app/models/notification.rb`
- `ruby -c test/controllers/notifications_controller_test.rb`
- `rails test test/models/notification_undo_action_test.rb`
- `rails test test/workers/archive_worker_test.rb test/workers/custom_worker_test.rb`
- `rails test test/controllers/notifications_controller_test.rb`
- `rails test test/controllers/api/notifications_controller_test.rb`
- `rails test test/models/notification_test.rb`