### PR TITLE
fix: validate file presence and JSON parsing in notifications import

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -67,7 +67,18 @@ class UsersController < ApplicationController
   end
 
   def import
-    data = JSON.parse(params[:file].read)
+    unless params[:file].present?
+      flash[:error] = "Please choose a file to import"
+      redirect_to :settings and return
+    end
+
+    begin
+      data = JSON.parse(params[:file].read)
+    rescue JSON::ParserError
+      flash[:error] = "Could not import file: invalid JSON"
+      redirect_to :settings and return
+    end
+
     current_user.import_notifications(data)
     flash[:success] = "Import complete"
     redirect_to root_path

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -248,4 +248,34 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_nil @user.refresh_interval
     assert_response :unprocessable_content
   end
+
+  test 'imports notifications from a valid file' do
+    sign_in_as(@user)
+    notification = create(:notification, user: @user)
+    file = fixture_file_upload_json([notification.attributes.slice('github_id').merge('unread' => false)])
+    post '/import', params: {file: file}
+    assert_redirected_to root_path
+    assert_equal 'Import complete', flash[:success]
+  end
+
+  test 'rejects import without a file' do
+    sign_in_as(@user)
+    post '/import'
+    assert_redirected_to '/settings'
+    assert_equal 'Please choose a file to import', flash[:error]
+  end
+
+  test 'rejects import with invalid JSON' do
+    sign_in_as(@user)
+    file = Rack::Test::UploadedFile.new(StringIO.new('not valid json'), 'application/json', original_filename: 'octobox.json')
+    post '/import', params: {file: file}
+    assert_redirected_to '/settings'
+    assert_equal 'Could not import file: invalid JSON', flash[:error]
+  end
+
+  private
+
+  def fixture_file_upload_json(data)
+    Rack::Test::UploadedFile.new(StringIO.new(data.to_json), 'application/json', original_filename: 'octobox.json')
+  end
 end


### PR DESCRIPTION
## Summary
Fixes #4582.

`UsersController#import` called `JSON.parse(params[:file].read)` without checking that `params[:file]` was present, and without rescuing `JSON::ParserError`. A request without a file raised `NoMethodError`, and an invalid/empty JSON file raised `JSON::ParserError` — both resulting in a 500 response instead of a controlled redirect with a helpful flash message.

- Added a presence check for `params[:file]` before reading it.
- Rescue `JSON::ParserError` around the parse call.
- Both failure paths redirect to `:settings` with `flash[:error]`, matching the existing error-handling pattern already used in this controller (see `update` action).

## Test plan
- [x] Added `imports notifications from a valid file` — covers the happy path still works.
- [x] Added `rejects import without a file` — covers the missing-file case.
- [x] Added `rejects import with invalid JSON` — covers the malformed-JSON case.
- [x] Ran `bundle exec rails test test/controllers/users_controller_test.rb` — 31 runs, 0 failures, 0 errors.

Note: this PR was prepared with the assistance of Claude Code; the diff is small and every line has been reviewed and tested against the actual Rails test suite (Ruby 4.0.5, Postgres 11, Redis) before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)