### PR TITLE
Stream notification exports in batches

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -63,7 +63,9 @@ class UsersController < ApplicationController
   end
 
   def export
-    send_data current_user.notifications.to_json, :type => 'application/json; header=present', :disposition => "attachment; filename=octobox.json"
+    headers['Content-Type'] = 'application/json; header=present'
+    headers['Content-Disposition'] = 'attachment; filename=octobox.json'
+    self.response_body = NotificationExport.new(current_user.notifications)
   end
 
   def import

--- a/app/services/notification_export.rb
+++ b/app/services/notification_export.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class NotificationExport
+  BATCH_SIZE = 1_000
+
+  def initialize(notifications, batch_size: BATCH_SIZE)
+    @notifications = notifications
+    @batch_size = batch_size
+  end
+
+  def each
+    return enum_for(:each) unless block_given?
+
+    first = true
+
+    yield '['
+    notifications.find_each(batch_size: batch_size) do |notification|
+      yield ',' unless first
+      yield notification.to_json
+      first = false
+    end
+    yield ']'
+  end
+
+  private
+
+  attr_reader :notifications, :batch_size
+end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -185,6 +185,30 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     refute User.exists?(@user.id)
   end
 
+  test 'exports notifications as downloadable json' do
+    sign_in_as(@user, initial_sync: true)
+    notification1 = create(:notification, user: @user)
+    notification2 = create(:notification, user: @user)
+
+    get export_path
+
+    assert_response :success
+    assert_includes response.headers['Content-Type'], 'application/json'
+    assert_equal 'attachment; filename=octobox.json', response.headers['Content-Disposition']
+
+    exported_ids = JSON.parse(response.body).map { |notification| notification['id'] }
+    assert_equal [notification1.id, notification2.id], exported_ids
+  end
+
+  test 'exports an empty notification list' do
+    sign_in_as(@user, initial_sync: true)
+
+    get export_path
+
+    assert_response :success
+    assert_equal [], JSON.parse(response.body)
+  end
+
   test 'cannot delete another user' do
     other_user = create(:user)
     sign_in_as(other_user)

--- a/test/services/notification_export_test.rb
+++ b/test/services/notification_export_test.rb
@@ -1,0 +1,46 @@
+require 'test_helper'
+
+class NotificationExportTest < ActiveSupport::TestCase
+  ExportableNotification = Struct.new(:json) do
+    def to_json(*)
+      json
+    end
+  end
+
+  test 'exports notifications as a json array' do
+    relation = fake_relation([
+      ExportableNotification.new('{"id":1}'),
+      ExportableNotification.new('{"id":2}')
+    ])
+
+    export = NotificationExport.new(relation, batch_size: 2)
+
+    assert_equal '[{"id":1},{"id":2}]', export.each.to_a.join
+    assert_equal 2, relation.batch_size
+  end
+
+  test 'exports an empty json array when there are no notifications' do
+    relation = fake_relation([])
+
+    export = NotificationExport.new(relation)
+
+    assert_equal '[]', export.each.to_a.join
+  end
+
+  private
+
+  def fake_relation(notifications)
+    Class.new do
+      attr_reader :batch_size
+
+      define_method(:initialize) do |items|
+        @items = items
+      end
+
+      define_method(:find_each) do |batch_size:, &block|
+        @batch_size = batch_size
+        @items.each { |item| block.call(item) }
+      end
+    end.new(notifications)
+  end
+end


### PR DESCRIPTION
closes #4583
## Summary

Replaces eager notification export serialization with a batched export body to reduce memory pressure for users with large notification histories.

## Changes

- Add `NotificationExport` to emit the export JSON array incrementally.
- Use `find_each` batching instead of `current_user.notifications.to_json`.
- Preserve the existing `octobox.json` attachment response.
- Add service coverage for JSON shape and batch usage.
- Add controller coverage for populated and empty exports.

## Validation

- `git diff --check`
- `rails test test/services/notification_export_test.rb`
- `rails test test/controllers/users_controller_test.rb`