### PR TITLE
Pin redis gem to < 6 for actioncable compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ gem 'rexml'
 gem 'omniauth-rails_csrf_protection'
 gem 'psych'
 gem 'nokogiri'
-gem 'redis'
+gem 'redis', '< 6' # actioncable pins redis to >= 4, < 6 in its subscription adapter
 gem 'rack-cors'
 gem 'benchmark'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -391,8 +391,8 @@ GEM
       prism (>= 1.6.0)
       rbs (>= 4.0.0)
       tsort
-    redis (6.0.0)
-      redis-client (= 0.30.1)
+    redis (5.4.1)
+      redis-client (>= 0.22.0)
     redis-client (0.30.1)
       connection_pool
     regexp_parser (2.12.0)
@@ -539,7 +539,7 @@ DEPENDENCIES
   rails (= 8.1.3.1)
   rails-controller-testing
   rake
-  redis
+  redis (< 6)
   rexml
   rgb
   sassc-rails


### PR DESCRIPTION
actioncable's redis subscription adapter declares `gem "redis", ">= 4", "< 6"` inline in `subscription_adapter/redis.rb` rather than in its gemspec, so bundler happily resolved redis 6.0.0 during the rails 8.1.3.1 update in 1ddd3bd9 but loading the adapter at runtime raises `Gem::LoadError`.

Downgrades redis 6.0.0 → 5.4.1 and adds a `< 6` constraint in the Gemfile so dependabot doesn't bump it again. The pin can be removed once we're on a rails release that relaxes the adapter constraint to `< 7` (already on rails main).