### PR TITLE
Invalidate a GitHub App token that GitHub has rejected

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -150,6 +150,17 @@ class User < ApplicationRecord
     app_installation_ids = app_installations.map(&:id)
     removed_permissions = app_installation_permissions.reject{|ep| app_installation_ids.include?(ep.app_installation_id) }
     removed_permissions.each(&:destroy)
+  rescue Octokit::Unauthorized
+    # GitHub rejected the token, so the authorization is gone even though no
+    # github_app_authorization webhook told us. Discard it, matching what
+    # SyncGithubAppAuthorizationWorker does on an observed revocation: leaving
+    # it set would keep github_app_authorized? true, which hides the re-login
+    # button that is the only way for the user to recover.
+    revoke_app_token!
+  end
+
+  def revoke_app_token!
+    update(app_token: nil)
   end
 
   def has_app_installed?(subject)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -142,6 +142,7 @@ class User < ApplicationRecord
 
   def sync_app_installation_access
     return unless github_app_authorized?
+    rejected_encrypted_app_token = encrypted_app_token
     remote_installs = app_installation_client.find_user_installations
     app_installations = AppInstallation.where(github_id: remote_installs[:installations].map(&:id))
     app_installations.each do |app_installation|
@@ -156,11 +157,15 @@ class User < ApplicationRecord
     # SyncGithubAppAuthorizationWorker does on an observed revocation: leaving
     # it set would keep github_app_authorized? true, which hides the re-login
     # button that is the only way for the user to recover.
-    revoke_app_token!
+    revoke_app_token!(expected_encrypted_app_token: rejected_encrypted_app_token)
   end
 
-  def revoke_app_token!
-    update(app_token: nil)
+  def revoke_app_token!(expected_encrypted_app_token: nil)
+    with_lock do
+      return false if expected_encrypted_app_token && encrypted_app_token != expected_encrypted_app_token
+
+      update_column(:encrypted_app_token, nil)
+    end
   end
 
   def has_app_installed?(subject)

--- a/app/workers/sync_github_app_authorization_worker.rb
+++ b/app/workers/sync_github_app_authorization_worker.rb
@@ -5,7 +5,6 @@ class SyncGithubAppAuthorizationWorker
   sidekiq_options queue: :marketplace, lock: :until_and_while_executing
 
   def perform(github_id)
-    user = User.find_by_github_id(github_id)
-    user.update(app_token: nil) if user.present?
+    User.find_by_github_id(github_id).try(:revoke_app_token!)
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -311,4 +311,37 @@ class UserTest < ActiveSupport::TestCase
     assert_nil attacker_notification.subject
   end
 
+  test 'sync_app_installation_access discards an app token GitHub has rejected' do
+    user = create(:user, app_token: SecureRandom.hex(20))
+    stub_request(:get, /https:\/\/api\.github\.com\/user\/installations/)
+      .to_return(status: 401, body: '{"message":"Bad credentials"}',
+                 headers: { 'Content-Type' => 'application/json' })
+
+    user.sync_app_installation_access
+
+    assert_nil user.reload.app_token
+    refute user.github_app_authorized?,
+           'a rejected token must not keep reporting the user as authorized, ' \
+           'or the re-login button stays hidden'
+  end
+
+  test 'sync_app_installation_access keeps a working app token' do
+    user = create(:user, app_token: SecureRandom.hex(20))
+    stub_request(:get, /https:\/\/api\.github\.com\/user\/installations/)
+      .to_return(status: 200, body: '{"total_count":0,"installations":[]}',
+                 headers: { 'Content-Type' => 'application/json' })
+
+    user.sync_app_installation_access
+
+    assert_not_nil user.reload.app_token
+  end
+
+  test 'revoke_app_token! clears the stored app token' do
+    user = create(:user, app_token: SecureRandom.hex(20))
+
+    user.revoke_app_token!
+
+    assert_nil user.reload.app_token
+  end
+
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -336,6 +336,31 @@ class UserTest < ActiveSupport::TestCase
     assert_not_nil user.reload.app_token
   end
 
+  test 'sync_app_installation_access does not discard a replacement app token' do
+    user = create(:user, app_token: SecureRandom.hex(20))
+    replacement_token = SecureRandom.hex(20)
+    client = Object.new
+    client.define_singleton_method(:find_user_installations) do
+      User.find(user.id).update!(app_token: replacement_token)
+      raise Octokit::Unauthorized
+    end
+    user.stubs(:app_installation_client).returns(client)
+
+    user.sync_app_installation_access
+
+    assert_equal replacement_token, user.reload.app_token
+  end
+
+  test 'revoke_app_token! clears the token despite unrelated validation errors' do
+    user = create(:user, app_token: SecureRandom.hex(20))
+    user.stubs(:valid?).returns(false)
+    refute user.valid?
+
+    user.revoke_app_token!
+
+    assert_nil user.reload.app_token
+  end
+
   test 'revoke_app_token! clears the stored app token' do
     user = create(:user, app_token: SecureRandom.hex(20))
 


### PR DESCRIPTION
## Summary

Once `app_token` is stored, `User#github_app_authorized?` remains true until the token is explicitly cleared. If GitHub rejects that token while the authorization webhook is unavailable, permission sync retries with `401 Bad credentials` while the settings page hides the re-login route behind the stale authorization state.

Clear the token when `GET /user/installations` proves it invalid, and have `SyncGithubAppAuthorizationWorker` reuse the same revocation method. The rejection path locks and reloads the user, clears without unrelated model validations, and only removes the encrypted token that made the failed request, so concurrent reauthorization cannot lose a replacement token.

## Testing

- `rails test test/models/user_test.rb`
- 43 runs, 64 assertions, 0 failures, 0 errors
- Coverage includes rejected and working tokens, concurrent replacement, validation-independent revocation, and direct webhook-style revocation
