### PR TITLE
Only advance the sync cursor when the batch was fully stored

### DIFF
--- a/app/services/download_service.rb
+++ b/app/services/download_service.rb
@@ -21,11 +21,16 @@ class DownloadService
     latest_comment_url: [:subject, :latest_comment_url]
   }.freeze
 
+  # last_synced_at becomes the next sync's if_modified_since, so advancing it
+  # asserts everything up to `timestamp` was stored. Only make that claim when
+  # the batch really did store: a notification dropped by the RecordNotUnique
+  # rescue below would otherwise sit before the new cursor and never be
+  # offered again, because GitHub correctly reports nothing new since it.
   def download
     timestamp = Time.current
-    fetch_new_notifications
+    complete = fetch_new_notifications
     fetch_all_notifications
-    user.update_column(:last_synced_at, timestamp)
+    user.update_column(:last_synced_at, timestamp) if complete
   end
 
   private
@@ -53,20 +58,27 @@ class DownloadService
     process_unread_state(notifications)
   end
 
+  # Returns true only when every notification in the batch was stored, so the
+  # caller knows whether it may advance the sync cursor past them.
   def process_notifications(notifications)
-    return if notifications.blank?
+    return true if notifications.blank?
     eager_load_relation = Octobox.config.subjects_enabled? ? [:subject, :repository, :app_installation] : nil
     existing_notifications = user.notifications.includes(eager_load_relation).where(github_id: notifications.map(&:id))
+    complete = true
     notifications.each do |notification|
       n = existing_notifications.find{|en| en.github_id == notification.id.to_i}
       n = user.notifications.new(github_id: notification.id, archived: false) if n.nil?
-      next unless n
+      if n.nil?
+        complete = false
+        next
+      end
       begin
         n.update_from_api_response(notification)
       rescue ActiveRecord::RecordNotUnique
-        nil
+        complete = false
       end
     end
+    complete
   end
 
   def process_unread_state(notifications)

--- a/test/services/download_service_test.rb
+++ b/test/services/download_service_test.rb
@@ -96,4 +96,42 @@ class DownloadServiceTest < ActiveSupport::TestCase
     )
     assert_nothing_raised { download_service.download }
   end
+
+  test '#download advances last_synced_at when every notification is stored' do
+    stub_fetch_subject_enabled(value: false)
+    user = create(:user, last_synced_at: nil)
+    stub_notifications_request(
+      url: 'https://api.github.com/notifications?all=true&per_page=100',
+      body: file_fixture('newuser_all_notifications.json')
+    )
+    stub_notifications_request(
+      url: 'https://api.github.com/notifications?per_page=100',
+      body: file_fixture('newuser_notifications.json')
+    )
+
+    DownloadService.new(user).download
+
+    assert_not_nil user.reload.last_synced_at
+  end
+
+  test '#download leaves last_synced_at alone when a notification is dropped' do
+    stub_fetch_subject_enabled(value: false)
+    previous = 2.hours.ago.change(usec: 0)
+    user = create(:user, last_synced_at: previous)
+    stub_notifications_request(
+      url: 'https://api.github.com/notifications?all=true&per_page=100',
+      body: file_fixture('newuser_all_notifications.json')
+    )
+    stub_notifications_request(
+      url: 'https://api.github.com/notifications?per_page=100',
+      body: file_fixture('newuser_notifications.json')
+    )
+    Notification.any_instance.stubs(:update_from_api_response)
+                .raises(ActiveRecord::RecordNotUnique.new('duplicate'))
+
+    DownloadService.new(user).download
+
+    assert_equal previous, user.reload.last_synced_at,
+                 'a dropped notification must not be skipped by the next sync'
+  end
 end


### PR DESCRIPTION
`user.last_synced_at` is sent as `if_modified_since` on the next sync, so advancing it asserts that every notification up to that point has been stored. `DownloadService#download` makes that claim unconditionally:

```ruby
def download
  timestamp = Time.current
  fetch_new_notifications
  fetch_all_notifications
  user.update_column(:last_synced_at, timestamp)
end
```

Meanwhile `process_notifications` silently drops any notification whose update raises `RecordNotUnique`:

```ruby
begin
  n.update_from_api_response(notification)
rescue ActiveRecord::RecordNotUnique
  nil
end
```

A notification dropped there ends up *behind* the newly advanced cursor, so it is never offered again: GitHub correctly reports nothing new since that time, and no later sync can recover it. The loss is silent and permanent rather than retried.

This has `process_notifications` report whether the batch stored cleanly, and holds the cursor when it did not, so the next sync covers the same window again.

### How it showed up

A PR comment stayed missing from a notification for several hours. The comment was being fetched correctly from the API but never stored, and the cursor had already moved past it. Measured directly on the affected account:

```
WITH if_modified_since (cursor): 0 notifications
WITHOUT it:                      500 notifications
```

Recovery required calling `subject.update_comments` by hand; nothing in the normal sync path could repair it.

### Notes on safety

Holding the cursor cannot wedge a user: the next sync re-fetches the same window and succeeds as soon as the underlying cause clears, which is the same behaviour as a user who has never synced. The cost of holding it wrongly is one redundant fetch; the cost of advancing it wrongly is permanent data loss.

The new test was verified to fail without the fix (the cursor jumped forward past the dropped notification) and pass with it.