### PR TITLE
Make the webhook sync throttle configurable

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,7 +27,7 @@ class User < ApplicationRecord
   }
   validates_with PersonalAccessTokenValidator
 
-  scope :not_recently_synced, -> { where('users.last_synced_at < ?', 5.minutes.ago) }
+  scope :not_recently_synced, -> { where('users.last_synced_at < ?', Octobox.config.webhook_sync_throttle.seconds.ago) }
   scope :with_access_token, -> { where.not(encrypted_access_token: nil) }
   scope :active, -> { where('users.updated_at > ?', 1.month.ago) }
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -234,6 +234,27 @@ You may allow users to set an auto-refresh interval that will cause a periodic s
 
 When enabled, user settings pages will have an 'Notification Refresh Interval' option.  This can be set to any value above `MINIMUM_REFRESH_INTERVAL`.
 
+## Webhook sync throttle
+
+When running as a GitHub App, an incoming webhook schedules a notification sync
+for each user involved in the subject that changed.  To stop a busy repository
+from scheduling a sync for every subscribed user on every event, a user who
+synced within the last 5 minutes is skipped.
+
+On a busy shared instance that throttle is worth having.  On a single-user
+instance it mostly discards webhooks: if a scheduled sync keeps `last_synced_at`
+fresh, webhooks arriving inside the window are dropped, and the update waits for
+the next poll instead.
+
+Set `WEBHOOK_SYNC_THROTTLE_SECONDS` to change the window.  It defaults to 300
+(5 minutes); lower it to let webhooks drive syncs promptly.  Overlapping syncs
+are already prevented by `SyncNotificationsWorker`'s `until_executed` lock, so a
+low value does not allow syncs to pile up.
+
+```
+WEBHOOK_SYNC_THROTTLE_SECONDS=30
+```
+
 ## Scheduling server-side notification syncs
 
 **Note**: This is *not* enabled on the hosted version (octobox.io).

--- a/lib/octobox/configurator.rb
+++ b/lib/octobox/configurator.rb
@@ -67,6 +67,16 @@ module Octobox
     end
     attr_writer :max_notifications_to_sync
 
+    # How recently a user must have synced before a webhook stops scheduling
+    # another sync for them. Guards shared instances against sync storms when a
+    # busy repository fires many events; a single-user instance can safely set
+    # it low, since SyncNotificationsWorker's until_executed lock already
+    # prevents overlapping syncs.
+    def webhook_sync_throttle
+      @webhook_sync_throttle || env_integer('WEBHOOK_SYNC_THROTTLE_SECONDS', 5.minutes.to_i)
+    end
+    attr_writer :webhook_sync_throttle
+
     def max_concurrency
       @max_concurrency || env_integer('MAX_CONCURRENCY', 10)
     end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -311,4 +311,20 @@ class UserTest < ActiveSupport::TestCase
     assert_nil attacker_notification.subject
   end
 
+  test 'not_recently_synced excludes a user synced inside the default window' do
+    stub_webhook_sync_throttle
+    user = create(:user, last_synced_at: 1.minute.ago)
+
+    assert_not_includes User.not_recently_synced, user
+  end
+
+  test 'not_recently_synced includes that user when the window is shortened' do
+    stub_webhook_sync_throttle(value: 30)
+    user = create(:user, last_synced_at: 1.minute.ago)
+
+    assert_includes User.not_recently_synced, user,
+                    'a shorter throttle must let a webhook schedule a sync ' \
+                    'that the default window would have dropped'
+  end
+
 end

--- a/test/support/stub_helper.rb
+++ b/test/support/stub_helper.rb
@@ -136,6 +136,10 @@ module StubHelper
     stub_request(:get, transactions_url).to_return(response)
   end
 
+  def stub_webhook_sync_throttle(value: 5.minutes.to_i)
+    Octobox.config.stubs(:webhook_sync_throttle).returns(value)
+  end
+
   def stub_personal_access_tokens_enabled(value: true)
     Octobox.config.stubs(:personal_access_tokens_enabled).returns(value)
   end


### PR DESCRIPTION
When running as a GitHub App, an incoming webhook calls `Subject#sync_involved_users`, which schedules a notification sync for each involved user. Those users are filtered through `User.not_recently_synced`:

```ruby
scope :not_recently_synced, -> { where('users.last_synced_at < ?', 5.minutes.ago) }
```

A user who synced less than five minutes ago is excluded, and nothing is scheduled — the webhook is silently discarded.

On an instance that also runs the scheduled sync (`OCTOBOX_SIDEKIQ_SCHEDULE_ENABLED`, every 10 minutes), `last_synced_at` is under five minutes old for roughly half of each cycle. So about half of all webhooks are dropped, and the instance ends up polling for information it had already been sent.

### Why not just remove the throttle

It earns its place on a shared instance: one busy repository could otherwise schedule a sync for every subscribed user on every event.

It has much less value on a single-user instance, where `SyncNotificationsWorker` already declares `lock: :until_executed`, so a second sync cannot be enqueued while one is pending. Pile-ups are prevented by the lock; the five-minute floor is a second, blunter guard on top of a working one.

### This change

Reads the window from `WEBHOOK_SYNC_THROTTLE_SECONDS`, defaulting to `5.minutes` so existing deployments behave exactly as before. Operators who want webhook-speed updates can lower it.

Documented in `docs/INSTALLATION.md`, since the interaction between the throttle, the scheduled sync and the worker lock is not obvious from the code alone.

### Effect

For repositories with the App installed, updates arrive within the existing one-minute debounce in `sync_involved_users` rather than waiting for the next poll. Total API calls go **down**, not up: a webhook-triggered sync only runs when something actually changed, whereas the scheduled poll runs regardless.