### PR TITLE
Show the original issue age in notification previews

### DIFF
--- a/app/views/notifications/_thread_subject.html.erb
+++ b/app/views/notifications/_thread_subject.html.erb
@@ -9,6 +9,7 @@
 <% end %>
 
 <% subject_visible = notification.subject && notification.display? %>
+<% subject_created_at = notification.subject.created_at if subject_visible && %w[Issue PullRequest].include?(notification.subject_type) %>
 <% if subject_visible %>
   <%= notification_status(notification.subject.status) %>
   <%= link_to notification.subject.author, root_path(filtered_params(author: notification.subject.author)), class: 'text-muted', target: '_blank' %> opened this <%= notification.subject_type.underscore.humanize.downcase %>
@@ -16,7 +17,7 @@
 
 on <%= link_to notification.repository_full_name, notification.repo_url, class: 'text-muted', target: '_blank' %>
 
-<%= time_ago_in_words(subject_visible ? notification.subject.created_at : notification.updated_at) %> ago
+<%= time_ago_in_words(subject_created_at || notification.updated_at) %> ago
 
 <div class='d-flex justify-content-between mt-2'>
   <div class='labels'>

--- a/app/views/notifications/_thread_subject.html.erb
+++ b/app/views/notifications/_thread_subject.html.erb
@@ -8,14 +8,15 @@
   <%= notification_button_title(notification) %>
 <% end %>
 
-<% if notification.subject && notification.display? %>
+<% subject_visible = notification.subject && notification.display? %>
+<% if subject_visible %>
   <%= notification_status(notification.subject.status) %>
   <%= link_to notification.subject.author, root_path(filtered_params(author: notification.subject.author)), class: 'text-muted', target: '_blank' %> opened this <%= notification.subject_type.underscore.humanize.downcase %>
 <% end %>
 
 on <%= link_to notification.repository_full_name, notification.repo_url, class: 'text-muted', target: '_blank' %>
 
-<%= time_ago_in_words(notification.updated_at) %> ago
+<%= time_ago_in_words(subject_visible ? notification.subject.created_at : notification.updated_at) %> ago
 
 <div class='d-flex justify-content-between mt-2'>
   <div class='labels'>

--- a/test/controllers/notifications_controller_test.rb
+++ b/test/controllers/notifications_controller_test.rb
@@ -1166,18 +1166,58 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
     assert_select 'a[href=?]', pricing_path
   end
 
-  test 'thread subject hides author and labels when display? is false' do
-    sign_in_as(@user)
-    notification = create(:notification, user: @user)
-    subject = create(:subject, url: notification.subject_url, author: 'secretauthor')
-    create(:label, subject: subject, name: 'secretlabel')
+  test 'thread subject shows when the issue was opened' do
+    travel_to Time.zone.parse('2026-09-05 12:00:00 UTC') do
+      sign_in_as(@user)
+      subject = create(:subject, author: 'aspiers', created_at: 8.months.ago)
+      notification = create(
+        :notification,
+        user: @user,
+        subject: subject,
+        repository_full_name: 'EpicenterHQ/epicenter',
+        updated_at: 1.day.ago
+      )
 
-    Notification.any_instance.stubs(:display?).returns(false)
+      get notification_path(notification)
 
-    get notification_path(notification)
-    assert_response :success
-    refute_includes response.body, 'secretauthor'
-    refute_includes response.body, 'secretlabel'
+      assert_response :success
+      page_text = Nokogiri::HTML(response.body).text.squish
+      assert_includes page_text, 'aspiers opened this issue on EpicenterHQ/epicenter 8 months ago'
+      refute_includes page_text, 'aspiers opened this issue on EpicenterHQ/epicenter 1 day ago'
+    end
+  end
+
+  test 'thread subject shows the notification age when subject data is unavailable' do
+    travel_to Time.zone.parse('2026-09-05 12:00:00 UTC') do
+      sign_in_as(@user)
+      notification = create(:notification, user: @user, updated_at: 1.day.ago)
+
+      get notification_path(notification)
+
+      assert_response :success
+      page_text = Nokogiri::HTML(response.body).text.squish
+      assert_includes page_text, 'on octobox/octobox 1 day ago'
+    end
+  end
+
+  test 'thread subject hides author, labels, and creation time when display? is false' do
+    travel_to Time.zone.parse('2026-09-05 12:00:00 UTC') do
+      sign_in_as(@user)
+      notification = create(:notification, user: @user, updated_at: 1.day.ago)
+      subject = create(:subject, url: notification.subject_url, author: 'secretauthor', created_at: 8.months.ago)
+      create(:label, subject: subject, name: 'secretlabel')
+
+      Notification.any_instance.stubs(:display?).returns(false)
+
+      get notification_path(notification)
+
+      assert_response :success
+      page_text = Nokogiri::HTML(response.body).text.squish
+      refute_includes page_text, 'secretauthor'
+      refute_includes page_text, 'secretlabel'
+      assert_includes page_text, 'on octobox/octobox 1 day ago'
+      refute_includes page_text, 'on octobox/octobox 8 months ago'
+    end
   end
 
   test 'show with a label filter does not raise on pluck' do

--- a/test/controllers/notifications_controller_test.rb
+++ b/test/controllers/notifications_controller_test.rb
@@ -1187,6 +1187,27 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test 'thread subject shows the notification age for commits' do
+    travel_to Time.zone.parse('2026-09-05 12:00:00 UTC') do
+      sign_in_as(@user)
+      subject = create(:subject, author: 'aspiers', created_at: 8.months.ago)
+      notification = create(
+        :notification,
+        user: @user,
+        subject: subject,
+        subject_type: 'Commit',
+        updated_at: 1.day.ago
+      )
+
+      get notification_path(notification)
+
+      assert_response :success
+      page_text = Nokogiri::HTML(response.body).text.squish
+      assert_includes page_text, 'on octobox/octobox 1 day ago'
+      refute_includes page_text, 'on octobox/octobox 8 months ago'
+    end
+  end
+
   test 'thread subject shows the notification age when subject data is unavailable' do
     travel_to Time.zone.parse('2026-09-05 12:00:00 UTC') do
       sign_in_as(@user)


### PR DESCRIPTION
## Summary

Notification previews say that an author “opened this issue,” but the displayed age currently comes from the notification’s latest update. An old issue resurfacing in notifications can therefore appear to have been opened recently.

Use the synced subject creation time for visible issues and pull requests. Keep the notification timestamp when subject details are unavailable or hidden, and for commits because GitHub’s commit response has no equivalent top-level creation timestamp.

## Testing

- `rails test test/controllers/notifications_controller_test.rb`
- 112 runs, 250 assertions, 0 failures, 0 errors, 5 skips
