### PR TITLE
Preserve the Draft filter during preview navigation

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -16,7 +16,7 @@ class NotificationsController < ApplicationController
 
   def show
     scope = notifications_for_presentation.newest
-    scope = load_and_count_notifications(scope) unless request.xhr?
+    scope = request.xhr? ? current_notifications(scope) : load_and_count_notifications(scope)
 
     ids = scope.pluck(:id)
     position = ids.index(params[:id].to_i)

--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -71,6 +71,7 @@ module NotificationsHelper
       assigned:        params[:assigned],
       is_private:      params[:is_private],
       status:          params[:status],
+      draft:           params[:draft],
     }
   end
 

--- a/app/views/notifications/_filter-list.html.erb
+++ b/app/views/notifications/_filter-list.html.erb
@@ -62,6 +62,10 @@
       <%= filter_option :is_private do %>
         <%= (params[:is_private] === 'true'? 'Private' : 'Public') %>
       <% end %>
+
+      <%= filter_option :draft do %>
+        <%= (params[:draft] === 'true'? 'Draft' : 'Not draft') %>
+      <% end %>
     </span>
   </span>
 <% end %>

--- a/app/views/notifications/_thread.html.erb
+++ b/app/views/notifications/_thread.html.erb
@@ -59,7 +59,7 @@
         <% if @notification.subject.commentable? %>
           <% if @comments_left_to_load > 0 %>
             <div id='more-comments'>
-              <%= link_to expand_comments_notification_url, class: 'btn btn-secondary mt-3 expand_comments' do %>
+              <%= link_to expand_comments_notification_url(filtered_params(id: @notification)), class: 'btn btn-secondary mt-3 expand_comments' do %>
                 <%= octicon('comment', height: 16, class: 'ml-1') %>
                 View <%= @comments_left_to_load %> more comments and reviews
               <% end %>

--- a/app/views/notifications/_thread_subject.html.erb
+++ b/app/views/notifications/_thread_subject.html.erb
@@ -28,7 +28,7 @@ on <%= link_to notification.repository_full_name, notification.repo_url, class: 
   </div>
   <% if notification.subject && notification.display? %>
     <div>
-      <%= link_to pluralize(notification.subject.comment_count,'comment'), expand_comments_notification_url(notification),  class: 'text-muted'%>
+      <%= link_to pluralize(notification.subject.comment_count,'comment'), expand_comments_notification_url(filtered_params(id: notification)),  class: 'text-muted'%>
     </div>
   <% end %>
 </div>

--- a/test/system/notification_list_test.rb
+++ b/test/system/notification_list_test.rb
@@ -46,7 +46,7 @@ class NotificationListTest < ApplicationSystemTestCase
 
   test 'notification navigation preserves the draft sidebar filter' do
     Octobox.stubs(:include_comments?).returns(true)
-    create(:subject, notifications: [@notification], draft: true)
+    create(:subject, notifications: [@notification], draft: true, comment_count: 6)
     create(:subject, notifications: [@unread_notification], draft: true)
     visit '/?draft=true'
 
@@ -59,7 +59,15 @@ class NotificationListTest < ApplicationSystemTestCase
       assert_selector 'a.nav-link.active', text: 'Draft'
     end
 
-    first('a.previous, a.next').click
+    all("a[href*='/expand_comments']", minimum: 2).each do |link|
+      assert_includes link[:href], 'draft=true'
+    end
+
+    click_link 'View 1 more comments and reviews'
+    assert_current_path expand_comments_notification_path(@notification, draft: true)
+    assert_no_selector '#more-comments'
+
+    first('a.previous.btn-outline-dark, a.next.btn-outline-dark').click
     assert_current_path %r{/notifications/\d+\?draft=true}
   end
 

--- a/test/system/notification_list_test.rb
+++ b/test/system/notification_list_test.rb
@@ -44,6 +44,25 @@ class NotificationListTest < ApplicationSystemTestCase
     end
   end
 
+  test 'notification navigation preserves the draft sidebar filter' do
+    Octobox.stubs(:include_comments?).returns(true)
+    create(:subject, notifications: [@notification], draft: true)
+    create(:subject, notifications: [@unread_notification], draft: true)
+    visit '/?draft=true'
+
+    within "#notification-#{@notification.id}" do
+      click_link 'Fix the widget'
+    end
+
+    assert_current_path notification_path(@notification, draft: true)
+    within '.flex-sidebar' do
+      assert_selector 'a.nav-link.active', text: 'Draft'
+    end
+
+    first('a.previous, a.next').click
+    assert_current_path %r{/notifications/\d+\?draft=true}
+  end
+
   test 'sidebar starred link navigates to starred view' do
     starred = create(:notification, user: @user, starred: true, subject_title: 'Starred item')
     within '.flex-sidebar' do

--- a/test/system/notification_list_test.rb
+++ b/test/system/notification_list_test.rb
@@ -58,6 +58,11 @@ class NotificationListTest < ApplicationSystemTestCase
     within '.flex-sidebar' do
       assert_selector 'a.nav-link.active', text: 'Draft'
     end
+    within '.filter-options' do
+      assert_link 'Draft'
+    end
+    neighbor = first('a.previous.btn-outline-dark, a.next.btn-outline-dark')
+    assert_equal notification_path(@unread_notification, draft: true), URI.parse(neighbor[:href]).request_uri
 
     all("a[href*='/expand_comments']", minimum: 2).each do |link|
       assert_includes link[:href], 'draft=true'
@@ -68,7 +73,7 @@ class NotificationListTest < ApplicationSystemTestCase
     assert_no_selector '#more-comments'
 
     first('a.previous.btn-outline-dark, a.next.btn-outline-dark').click
-    assert_current_path %r{/notifications/\d+\?draft=true}
+    assert_current_path notification_path(@unread_notification, draft: true)
   end
 
   test 'sidebar starred link navigates to starred view' do


### PR DESCRIPTION
## Summary

Opening a notification from the Draft view currently drops `draft=true` from preview, adjacent-navigation, and expanded-comment URLs. Navigation can then leave the filtered result set even though the sidebar still represents the user’s Draft workflow.

Carry the Draft filter through the shared filtered parameters and both comment-expansion links. Apply active filters when an XHR builds previous/next preview links, and show Draft as a removable active filter alongside the existing filter chips.

## Testing

- `rails test test/system/notification_list_test.rb:<draft-filter regression>`
- 1 browser run, 12 assertions, 0 failures, 0 errors
- The regression verifies the exact adjacent notification remains inside the Draft result set
