### PR TITLE
Use the notification client when syncing preview comments

### DIFF
--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -44,7 +44,8 @@ class Subject < ApplicationRecord
     involved_user_ids.each { |user_id| SyncNotificationsWorker.perform_in(1.minutes, user_id) }
   end
 
-  def sync(remote_subject)
+  def sync(remote_subject, github_client: nil)
+    @preferred_github_client = github_client
     update({
       repository_full_name: extract_full_name_from_remote_subject(remote_subject),
       github_id: remote_subject['id'],
@@ -68,11 +69,13 @@ class Subject < ApplicationRecord
     update_comments if Octobox.include_comments? && (has_comments? || pull_request?)
     update_status
     sync_involved_users if (saved_changes.keys & notifiable_fields).any?
+  ensure
+    @preferred_github_client = nil
   end
 
-  def self.sync(remote_subject)
+  def self.sync(remote_subject, github_client: nil)
     subject = Subject.find_or_create_by(url: remote_subject['url'])
-    subject.sync(remote_subject)
+    subject.sync(remote_subject, github_client: github_client)
   end
 
   def self.sync_status(sha, repository_full_name)
@@ -230,6 +233,8 @@ class Subject < ApplicationRecord
   end
 
   def github_client
+    return @preferred_github_client if @preferred_github_client
+
     if app_installation.present?
       app_installation.github_client
     else

--- a/lib/octobox/notifications/sync_subject.rb
+++ b/lib/octobox/notifications/sync_subject.rb
@@ -19,10 +19,11 @@ module Octobox
         # skip syncing if the notification was updated around the same time as subject
         return if !force && subject != nil && updated_at - subject.updated_at < 2.seconds
 
-        remote_subject = download_subject
+        client = github_client
+        remote_subject = download_subject(client)
         return unless remote_subject.present?
 
-        Subject.sync(remote_subject.to_h.as_json)
+        Subject.sync(remote_subject.to_h.as_json, github_client: client)
       end
 
       def github_client
@@ -50,8 +51,8 @@ module Octobox
 
       private
 
-      def download_subject
-        github_client.get(subject_url)
+      def download_subject(client = github_client)
+        client.get(subject_url)
 
       # If permissions changed and the user hasn't accepted, we get a 401
       # We may receive a 403 Forbidden or a 403 Not Available

--- a/test/models/subject_test.rb
+++ b/test/models/subject_test.rb
@@ -322,6 +322,24 @@ class SubjectTest < ActiveSupport::TestCase
     assert subject.persisted?
   end
 
+  test 'notification sync downloads comments when the user only has a personal access token' do
+    stub_personal_access_tokens_enabled
+    remote_subject = load_fixture('subject_56.json')
+    stub_request(:get, remote_subject['url'])
+      .to_return(status: 200, body: file_fixture('subject_56.json'), headers: { 'Content-Type' => 'application/json' })
+    stub_request(:get, remote_subject['url'] + '/comments?since')
+      .to_return(status: 200, body: file_fixture('subject_58_comments.json'), headers: { 'Content-Type' => 'application/json' })
+
+    user = build(:user, access_token: nil, personal_access_token: 'FAKE_PERSONAL_ACCESS_TOKEN')
+    stub_user_request(user: user)
+    user.save!
+    notification = create(:notification, subject_url: remote_subject['url'], user: user)
+
+    notification.update_subject_in_foreground(true)
+
+    assert_equal 13, notification.subject.comments.count
+  end
+
   test 'sync updates reviews and review comemnts when the subject is a pull request' do
     remote_subject = load_fixture('subject_58.json')
     stub_review_requests


### PR DESCRIPTION
## Summary

Notification sync can successfully fetch subject metadata with a personal access token, but `Subject` currently discards that working client before downloading comments, reviews, and status. PAT-only users therefore receive incomplete notification previews.

Pass the successful notification client through subject synchronization and prefer it for the remaining subject requests. Clear the temporary client in `ensure` so a reused model instance cannot retain viewer-specific authentication.

## Testing

- `rails test test/models/subject_test.rb`
- 46 runs, 79 assertions, 0 failures, 0 errors
- Coverage verifies that a user with only a personal access token downloads all preview comments
