### PR TITLE
Use Turbolinks for notification list navigation

### DIFF
--- a/app/assets/javascripts/octobox.js
+++ b/app/assets/javascripts/octobox.js
@@ -390,7 +390,7 @@ var Octobox = (function() {
 
       if(syncLink) {
         setTimeout(() => {
-          window.location.href = syncLink.getAttribute("href");
+          Turbolinks.visit(syncLink.getAttribute("href"));
         }, 10);
       }
     }
@@ -844,12 +844,12 @@ var Octobox = (function() {
 
   var nextPage = function() {
     var nextBtn = document.querySelector(".page-item:last-child .page-link[rel=next]");
-    if (nextBtn) window.location.href = nextBtn.getAttribute('href');
+    if (nextBtn) Turbolinks.visit(nextBtn.getAttribute('href'));
   }
 
   var prevPage = function() {
     var prevBtn = document.querySelector(".page-item:first-child .page-link[rel=prev]");
-    if (prevBtn) window.location.href = prevBtn.getAttribute('href');
+    if (prevBtn) Turbolinks.visit(prevBtn.getAttribute('href'));
   }
 
   var markCurrent = function() {

--- a/app/assets/javascripts/octobox.js
+++ b/app/assets/javascripts/octobox.js
@@ -843,12 +843,12 @@ var Octobox = (function() {
   };
 
   var nextPage = function() {
-    var nextBtn = document.querySelector(".page-item:last-child .page-link[rel=next]");
+    var nextBtn = document.querySelector(".page-item.next .page-link");
     if (nextBtn) Turbolinks.visit(nextBtn.getAttribute('href'));
   }
 
   var prevPage = function() {
-    var prevBtn = document.querySelector(".page-item:first-child .page-link[rel=prev]");
+    var prevBtn = document.querySelector(".page-item.prev .page-link");
     if (prevBtn) Turbolinks.visit(prevBtn.getAttribute('href'));
   }
 

--- a/test/system/keyboard_shortcuts_test.rb
+++ b/test/system/keyboard_shortcuts_test.rb
@@ -86,29 +86,30 @@ class KeyboardShortcutsTest < ApplicationSystemTestCase
   test 'n and p route pagination through Turbolinks' do
     create_list(:notification, 50, user: @user)
     visit '/'
-    next_url = page.evaluate_script(<<~JS)
-      (function() {
-        var link = document.querySelector('.page-item:last-child .page-link');
-        link.rel = 'next';
-        return link.href;
-      })()
-    JS
+    next_url = find('.page-item.next .page-link')[:href]
     capture_turbolinks_visits
 
     send_keys 'n'
     assert_equal next_url, page.evaluate_script('window.lastTurbolinksVisit')
 
     visit '/?page=2'
-    previous_url = page.evaluate_script(<<~JS)
-      (function() {
-        var link = document.querySelector('.page-item:first-child .page-link');
-        link.rel = 'prev';
-        return link.href;
-      })()
-    JS
+    previous_url = find('.page-item.prev .page-link')[:href]
     capture_turbolinks_visits
+
     send_keys 'p'
     assert_equal previous_url, page.evaluate_script('window.lastTurbolinksVisit')
+  end
+
+  test 'r routes foreground sync through Turbolinks' do
+    stub_background_jobs_enabled(value: false)
+    visit '/'
+    sync_url = find('a.js-sync')[:href]
+    capture_turbolinks_visits
+
+    send_keys 'r'
+    sleep 0.1
+
+    assert_equal sync_url, page.evaluate_script('window.lastTurbolinksVisit')
   end
 
   def capture_turbolinks_visits

--- a/test/system/keyboard_shortcuts_test.rb
+++ b/test/system/keyboard_shortcuts_test.rb
@@ -83,6 +83,42 @@ class KeyboardShortcutsTest < ApplicationSystemTestCase
     assert_includes star[:class], 'star-active'
   end
 
+  test 'n and p route pagination through Turbolinks' do
+    create_list(:notification, 50, user: @user)
+    visit '/'
+    next_url = page.evaluate_script(<<~JS)
+      (function() {
+        var link = document.querySelector('.page-item:last-child .page-link');
+        link.rel = 'next';
+        return link.href;
+      })()
+    JS
+    capture_turbolinks_visits
+
+    send_keys 'n'
+    assert_equal next_url, page.evaluate_script('window.lastTurbolinksVisit')
+
+    visit '/?page=2'
+    previous_url = page.evaluate_script(<<~JS)
+      (function() {
+        var link = document.querySelector('.page-item:first-child .page-link');
+        link.rel = 'prev';
+        return link.href;
+      })()
+    JS
+    capture_turbolinks_visits
+    send_keys 'p'
+    assert_equal previous_url, page.evaluate_script('window.lastTurbolinksVisit')
+  end
+
+  def capture_turbolinks_visits
+    page.execute_script(<<~JS)
+      Turbolinks.visit = function(url) {
+        window.lastTurbolinksVisit = new URL(url, window.location.href).href;
+      };
+    JS
+  end
+
   def send_keys(*keys)
     find('body').send_keys(*keys)
   end


### PR DESCRIPTION
## Summary

Foreground sync refreshes and the `n`/`p` pagination shortcuts currently assign `window.location`, forcing a full-page reload instead of using Octobox’s existing Turbolinks navigation lifecycle.

Route those same-app transitions through `Turbolinks.visit`. Select Pagy’s rendered `.page-item.next` and `.page-item.prev` links rather than `rel` attributes that are absent from current markup.

## Testing

- `node --check app/assets/javascripts/octobox.js`
- Test assets precompiled successfully
- Targeted pagination and foreground-sync system tests: 2 browser runs, 5 assertions, 0 failures, 0 errors
